### PR TITLE
Add blank and negated + small adjustments

### DIFF
--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -15,7 +15,6 @@ mod time;
 
 #[doc(inline)]
 pub use date::DateDuration;
-use num_traits::Zero;
 #[doc(inline)]
 pub use time::TimeDuration;
 
@@ -865,9 +864,13 @@ impl Duration {
         duration_sign(&self.iter().collect())
     }
 
-    /// Returns whether the current `Duration` is blank.
-    pub fn blank(&self) -> bool {
-        duration_sign(&self.iter().collect()).is_zero()
+    /// Returns whether the current `Duration` is zero.
+    ///
+    /// Equivalant to `Temporal.Duration.blank()`.
+    #[inline]
+    #[must_use]
+    pub fn is_zero(&self) -> bool {
+        duration_sign(&self.iter().collect()) == 0
     }
 
     /// Returns a negated `Duration`

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -15,6 +15,7 @@ mod time;
 
 #[doc(inline)]
 pub use date::DateDuration;
+use num_traits::Zero;
 #[doc(inline)]
 pub use time::TimeDuration;
 
@@ -866,7 +867,7 @@ impl Duration {
 
     /// Returns whether the current `Duration` is blank.
     pub fn blank(&self) -> bool {
-        duration_sign(&self.iter().collect()) == 0
+        duration_sign(&self.iter().collect()).is_zero()
     }
 
     /// Returns a negated `Duration`

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -387,7 +387,7 @@ impl Duration {
 
         // 4. Let sign be ! DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0).
         // 5. Assert: sign ≠ 0.
-        let sign = f64::from(self.duration_sign());
+        let sign = f64::from(self.sign());
 
         // 6. Let oneYear be ! CreateTemporalDuration(sign, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         let one_year = Self::one_year(sign);
@@ -604,7 +604,7 @@ impl Duration {
 
         // 5. Let sign be ! DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0).
         // 6. Assert: sign ≠ 0.
-        let sign = f64::from(self.duration_sign());
+        let sign = f64::from(self.sign());
 
         // 7. Let oneYear be ! CreateTemporalDuration(sign, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         let one_year = Self::one_year(sign);
@@ -857,6 +857,28 @@ impl Duration {
 // ==== Public Duration methods ====
 
 impl Duration {
+    /// Determines the sign for the current self.
+    #[inline]
+    #[must_use]
+    pub fn sign(&self) -> i32 {
+        duration_sign(&self.iter().collect())
+    }
+
+    /// Returns whether the current `Duration` is blank.
+    pub fn blank(&self) -> bool {
+        duration_sign(&self.iter().collect()) == 0
+    }
+
+    /// Returns a negated `Duration`
+    #[inline]
+    #[must_use]
+    pub fn negated(&self) -> Self {
+        Self {
+            date: self.date().negated(),
+            time: self.time().negated(),
+        }
+    }
+
     /// Returns the absolute value of `Duration`.
     #[inline]
     #[must_use]
@@ -865,15 +887,6 @@ impl Duration {
             date: self.date().abs(),
             time: self.time().abs(),
         }
-    }
-
-    /// 7.5.10 `DurationSign ( years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds )`
-    ///
-    /// Determines the sign for the current self.
-    #[inline]
-    #[must_use]
-    pub fn duration_sign(&self) -> i32 {
-        duration_sign(&self.into_iter().collect())
     }
 
     /// 7.5.12 `DefaultTemporalLargestUnit ( years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds )`
@@ -943,6 +956,8 @@ pub(crate) fn is_valid_duration(set: &Vec<f64>) -> bool {
 }
 
 /// Utility function for determining the sign for the current set of `Duration` fields.
+///
+/// Equivalent: 7.5.10 `DurationSign ( years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds )`
 #[inline]
 #[must_use]
 fn duration_sign(set: &Vec<f64>) -> i32 {

--- a/src/components/duration/date.rs
+++ b/src/components/duration/date.rs
@@ -87,6 +87,18 @@ impl DateDuration {
         }
     }
 
+    /// Returns a negated `DateDuration`.
+    #[inline]
+    #[must_use]
+    pub fn negated(&self) -> Self {
+        Self {
+            years: self.years * -1.0,
+            months: self.months * -1.0,
+            weeks: self.weeks * -1.0,
+            days: self.days * -1.0,
+        }
+    }
+
     /// Returns a new `DateDuration` representing the absolute value of the current.
     #[inline]
     #[must_use]

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -332,7 +332,7 @@ impl TimeDuration {
     /// Returns a negated `TimeDuration`.
     #[inline]
     #[must_use]
-    pub fn neg(&self) -> Self {
+    pub fn negated(&self) -> Self {
         Self {
             hours: self.hours * -1f64,
             minutes: self.minutes * -1f64,

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -177,7 +177,7 @@ impl Instant {
     /// Subtracts a `TimeDuration` to `Instant`.
     #[inline]
     pub fn subtract_time_duration(&self, duration: &TimeDuration) -> TemporalResult<Self> {
-        self.add_to_instant(&duration.neg())
+        self.add_to_instant(&duration.negated())
     }
 
     /// Returns a `TimeDuration` representing the duration since provided `Instant`

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -143,7 +143,7 @@ impl Time {
     #[inline]
     #[must_use]
     pub fn subtract_time_duration(&self, duration: &TimeDuration) -> Self {
-        self.add_to_time(&duration.neg())
+        self.add_to_time(&duration.negated())
     }
 
     // TODO (nekevss): optimize and test rounding_increment type (f64 vs. u64).


### PR DESCRIPTION
Related to #11

Primarily implementing `blank` and `negated` functionality onto blank.

Renames: `duration_sign` -> `sign`