### PR TITLE
Implement `Duration` normalization - Part 1

### DIFF
--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -495,8 +495,10 @@ impl<C: CalendarProtocol> CalendarSlot<C> {
             CalendarSlot::Builtin(AnyCalendar::Iso(_)) => {
                 // 8. Let norm be NormalizeTimeDuration(duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]]).
                 // 9. Let balanceResult be BalanceTimeDuration(norm, "day").
-                let (balance_days, _) =
-                    TimeDuration::from_normalized(duration.time().as_norm(), TemporalUnit::Day)?;
+                let (balance_days, _) = TimeDuration::from_normalized(
+                    duration.time().to_normalized(),
+                    TemporalUnit::Day,
+                )?;
                 // 10. Let result be ? AddISODate(date.[[ISOYear]], date.[[ISOMonth]], date.[[ISODay]], duration.[[Years]], duration.[[Months]], duration.[[Weeks]], duration.[[Days]] + balanceResult.[[Days]], overflow).
                 let result = date.iso().add_iso_date(
                     &DateDuration::new_unchecked(

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -366,7 +366,7 @@ impl<C: CalendarProtocol> Date<C> {
             duration.microseconds(),
             duration.nanoseconds(),
         )
-        .balance(duration.days(), TemporalUnit::Day)?;
+        .balance(TemporalUnit::Day)?;
 
         // 5. Let result be ? AddISODate(plainDate.[[ISOYear]], plainDate.[[ISOMonth]], plainDate.[[ISODay]], 0, 0, 0, days, overflow).
         let result = self

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -359,7 +359,7 @@ impl<C: CalendarProtocol> Date<C> {
         // 3. Let overflow be ? ToTemporalOverflow(options).
         // 4. Let days be ? BalanceTimeDuration(duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]], "day").[[Days]].
         let (days, _) =
-            TimeDuration::from_normalized(duration.time().as_norm(), TemporalUnit::Day)?;
+            TimeDuration::from_normalized(duration.time().to_normalized(), TemporalUnit::Day)?;
 
         // 5. Let result be ? AddISODate(plainDate.[[ISOYear]], plainDate.[[ISOMonth]], plainDate.[[ISODay]], 0, 0, 0, days, overflow).
         let result = self

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -358,15 +358,8 @@ impl<C: CalendarProtocol> Date<C> {
 
         // 3. Let overflow be ? ToTemporalOverflow(options).
         // 4. Let days be ? BalanceTimeDuration(duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]], "day").[[Days]].
-        let (days, _) = TimeDuration::new_unchecked(
-            duration.hours(),
-            duration.minutes(),
-            duration.seconds(),
-            duration.milliseconds(),
-            duration.microseconds(),
-            duration.nanoseconds(),
-        )
-        .balance(TemporalUnit::Day)?;
+        let (days, _) =
+            TimeDuration::from_normalized(duration.time().as_norm(), TemporalUnit::Day)?;
 
         // 5. Let result be ? AddISODate(plainDate.[[ISOYear]], plainDate.[[ISOMonth]], plainDate.[[ISODay]], 0, 0, 0, days, overflow).
         let result = self

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -924,7 +924,7 @@ impl Duration {
     /// Calls `TimeDuration`'s balance method on the current `Duration`.
     #[inline]
     pub fn balance_time_duration(&self, unit: TemporalUnit) -> TemporalResult<(f64, TimeDuration)> {
-        TimeDuration::from_normalized(self.time().as_norm(), unit)
+        TimeDuration::from_normalized(self.time().to_normalized(), unit)
     }
 }
 

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -12,6 +12,7 @@ use super::{calendar::CalendarProtocol, tz::TzProtocol};
 
 mod date;
 mod time;
+mod normalized;
 
 #[doc(inline)]
 pub use date::DateDuration;
@@ -801,7 +802,8 @@ impl Duration {
         Ok(result)
     }
 
-    // TODO: Refactor relative_to's into a RelativeTo struct?
+    // TODO (nekevss): Refactor relative_to's into a RelativeTo struct?
+    // TODO (nekevss): Update to `Duration` normalization.
     /// Abstract Operation 7.5.26 `RoundDuration ( years, months, weeks, days, hours, minutes,
     ///   seconds, milliseconds, microseconds, nanoseconds, increment, unit,
     ///   roundingMode [ , plainRelativeTo [, zonedRelativeTo [, precalculatedDateTime]]] )`
@@ -922,15 +924,7 @@ impl Duration {
     /// Calls `TimeDuration`'s balance method on the current `Duration`.
     #[inline]
     pub fn balance_time_duration(&self, unit: TemporalUnit) -> TemporalResult<(f64, TimeDuration)> {
-        TimeDuration::new_unchecked(
-            self.hours(),
-            self.minutes(),
-            self.seconds(),
-            self.milliseconds(),
-            self.microseconds(),
-            self.nanoseconds(),
-        )
-        .balance(self.days(), unit)
+        self.time().balance(unit)
     }
 }
 

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -11,8 +11,8 @@ use std::str::FromStr;
 use super::{calendar::CalendarProtocol, tz::TzProtocol};
 
 mod date;
+pub(crate) mod normalized;
 mod time;
-mod normalized;
 
 #[doc(inline)]
 pub use date::DateDuration;
@@ -924,7 +924,7 @@ impl Duration {
     /// Calls `TimeDuration`'s balance method on the current `Duration`.
     #[inline]
     pub fn balance_time_duration(&self, unit: TemporalUnit) -> TemporalResult<(f64, TimeDuration)> {
-        self.time().balance(unit)
+        TimeDuration::from_normalized(self.time().as_norm(), unit)
     }
 }
 

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -9,7 +9,6 @@ const MAX_TIME_DURATION: f64 = 2e53 * 10e9 - 1.0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
 pub(crate) struct NormalizedTimeDuration(pub(crate) f64);
 
-
 impl NormalizedTimeDuration {
     /// Equivalent: 7.5.20 NormalizeTimeDuration ( hours, minutes, seconds, milliseconds, microseconds, nanoseconds )
     pub(crate) fn from_time_duration(time: &TimeDuration) -> Self {
@@ -28,7 +27,8 @@ impl NormalizedTimeDuration {
     pub(crate) fn add(&self, other: &Self) -> TemporalResult<Self> {
         let result = self.0 + other.0;
         if result.abs() > MAX_TIME_DURATION {
-            return Err(TemporalError::range().with_message("normalizedTimeDuration exceeds maxTimeDuration."))
+            return Err(TemporalError::range()
+                .with_message("normalizedTimeDuration exceeds maxTimeDuration."));
         }
         Ok(Self(result))
     }
@@ -38,7 +38,8 @@ impl NormalizedTimeDuration {
     pub(crate) fn add_days(&self, days: f64) -> TemporalResult<Self> {
         let result = self.0 + days * NS_PER_DAY as f64;
         if result.abs() > MAX_TIME_DURATION {
-            return Err(TemporalError::range().with_message("normalizedTimeDuration exceeds maxTimeDuration."))
+            return Err(TemporalError::range()
+                .with_message("normalizedTimeDuration exceeds maxTimeDuration."));
         }
         Ok(Self(result))
     }
@@ -49,11 +50,10 @@ impl NormalizedTimeDuration {
     /// Equivalent: 7.5.31 NormalizedTimeDurationSign ( d )
     pub(crate) fn sign(&self) -> f64 {
         if self.0 < 0.0 {
-            return -1.0
+            return -1.0;
         } else if self.0 > 0.0 {
-            return 1.0
+            return 1.0;
         }
         0.0
     }
 }
-

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -1,0 +1,59 @@
+//! This module implements the normalized `Duration` records.
+
+use crate::{TemporalError, TemporalResult, NS_PER_DAY};
+
+use super::TimeDuration;
+
+const MAX_TIME_DURATION: f64 = 2e53 * 10e9 - 1.0;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
+pub(crate) struct NormalizedTimeDuration(pub(crate) f64);
+
+
+impl NormalizedTimeDuration {
+    /// Equivalent: 7.5.20 NormalizeTimeDuration ( hours, minutes, seconds, milliseconds, microseconds, nanoseconds )
+    pub(crate) fn from_time_duration(time: &TimeDuration) -> Self {
+        let minutes = time.minutes + time.hours * 60.0;
+        let seconds = time.seconds + minutes * 60.0;
+        let milliseconds = time.milliseconds + seconds * 1000.0;
+        let microseconds = time.microseconds + milliseconds * 1000.0;
+        let nanoseconds = time.nanoseconds + microseconds * 1000.0;
+        // NOTE(nekevss): Is it worth returning a `RangeError` below.
+        debug_assert!(nanoseconds.abs() <= MAX_TIME_DURATION);
+        Self(nanoseconds)
+    }
+
+    /// Equivalent: 7.5.22 AddNormalizedTimeDuration ( one, two )
+    #[allow(unused)]
+    pub(crate) fn add(&self, other: &Self) -> TemporalResult<Self> {
+        let result = self.0 + other.0;
+        if result.abs() > MAX_TIME_DURATION {
+            return Err(TemporalError::range().with_message("normalizedTimeDuration exceeds maxTimeDuration."))
+        }
+        Ok(Self(result))
+    }
+
+    /// Equivalent: 7.5.23 Add24HourDaysToNormalizedTimeDuration ( d, days )
+    #[allow(unused)]
+    pub(crate) fn add_days(&self, days: f64) -> TemporalResult<Self> {
+        let result = self.0 + days * NS_PER_DAY as f64;
+        if result.abs() > MAX_TIME_DURATION {
+            return Err(TemporalError::range().with_message("normalizedTimeDuration exceeds maxTimeDuration."))
+        }
+        Ok(Self(result))
+    }
+
+    // NOTE: DivideNormalizedTimeDuration probably requires `__float128` support as `NormalizedTimeDuration` is not `safe integer`.
+    // Tracking issue: https://github.com/rust-lang/rfcs/pull/3453
+
+    /// Equivalent: 7.5.31 NormalizedTimeDurationSign ( d )
+    pub(crate) fn sign(&self) -> f64 {
+        if self.0 < 0.0 {
+            return -1.0
+        } else if self.0 > 0.0 {
+            return 1.0
+        }
+        0.0
+    }
+}
+

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -5,7 +5,7 @@ use crate::{
     utils, TemporalError, TemporalResult,
 };
 
-use super::is_valid_duration;
+use super::{is_valid_duration, normalized::NormalizedTimeDuration};
 
 /// `TimeDuration` represents the [Time Duration record][spec] of the `Duration.`
 ///
@@ -54,186 +54,6 @@ impl TimeDuration {
             .mul_add(1_000_f64, self.milliseconds)
             .mul_add(1_000_f64, self.microseconds)
             .mul_add(1_000_f64, self.nanoseconds)
-    }
-
-    /// Abstract Operation 7.5.18 `BalancePossiblyInfiniteDuration ( days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, largestUnit )`
-    ///
-    /// This function will balance the current `TimeDuration`. It returns the balanced `day` and `TimeDuration` value.
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn balance_possibly_infinite_time_duration(
-        days: f64,
-        hours: f64,
-        minutes: f64,
-        seconds: f64,
-        milliseconds: f64,
-        microseconds: f64,
-        nanoseconds: f64,
-        largest_unit: TemporalUnit,
-    ) -> TemporalResult<(f64, Option<Self>)> {
-        // 1. Set hours to hours + days × 24.
-        let hours = hours + (days * 24f64);
-
-        // 2. Set nanoseconds to TotalDurationNanoseconds(hours, minutes, seconds, milliseconds, microseconds, nanoseconds).
-        let mut nanoseconds = Self::new_unchecked(
-            hours,
-            minutes,
-            seconds,
-            milliseconds,
-            microseconds,
-            nanoseconds,
-        )
-        .as_nanos();
-
-        // 3. Set days, hours, minutes, seconds, milliseconds, and microseconds to 0.
-        let mut days = 0f64;
-        let mut hours = 0f64;
-        let mut minutes = 0f64;
-        let mut seconds = 0f64;
-        let mut milliseconds = 0f64;
-        let mut microseconds = 0f64;
-
-        // 4. If nanoseconds < 0, let sign be -1; else, let sign be 1.
-        let sign = if nanoseconds < 0f64 { -1 } else { 1 };
-        // 5. Set nanoseconds to abs(nanoseconds).
-        nanoseconds = nanoseconds.abs();
-
-        match largest_unit {
-            // 9. If largestUnit is "year", "month", "week", "day", or "hour", then
-            TemporalUnit::Year
-            | TemporalUnit::Month
-            | TemporalUnit::Week
-            | TemporalUnit::Day
-            | TemporalUnit::Hour => {
-                // a. Set microseconds to floor(nanoseconds / 1000).
-                microseconds = (nanoseconds / 1000f64).floor();
-                // b. Set nanoseconds to nanoseconds modulo 1000.
-                nanoseconds %= 1000f64;
-
-                // c. Set milliseconds to floor(microseconds / 1000).
-                milliseconds = (microseconds / 1000f64).floor();
-                // d. Set microseconds to microseconds modulo 1000.
-                microseconds %= 1000f64;
-
-                // e. Set seconds to floor(milliseconds / 1000).
-                seconds = (milliseconds / 1000f64).floor();
-                // f. Set milliseconds to milliseconds modulo 1000.
-                milliseconds %= 1000f64;
-
-                // g. Set minutes to floor(seconds / 60).
-                minutes = (seconds / 60f64).floor();
-                // h. Set seconds to seconds modulo 60.
-                seconds %= 60f64;
-
-                // i. Set hours to floor(minutes / 60).
-                hours = (minutes / 60f64).floor();
-                // j. Set minutes to minutes modulo 60.
-                minutes %= 60f64;
-
-                // k. Set days to floor(hours / 24).
-                days = (hours / 24f64).floor();
-                // l. Set hours to hours modulo 24.
-                hours %= 24f64;
-            }
-            // 10. Else if largestUnit is "minute", then
-            TemporalUnit::Minute => {
-                // a. Set microseconds to floor(nanoseconds / 1000).
-                // b. Set nanoseconds to nanoseconds modulo 1000.
-                microseconds = (nanoseconds / 1000f64).floor();
-                nanoseconds %= 1000f64;
-
-                // c. Set milliseconds to floor(microseconds / 1000).
-                // d. Set microseconds to microseconds modulo 1000.
-                milliseconds = (microseconds / 1000f64).floor();
-                microseconds %= 1000f64;
-
-                // e. Set seconds to floor(milliseconds / 1000).
-                // f. Set milliseconds to milliseconds modulo 1000.
-                seconds = (milliseconds / 1000f64).floor();
-                milliseconds %= 1000f64;
-
-                // g. Set minutes to floor(seconds / 60).
-                // h. Set seconds to seconds modulo 60.
-                minutes = (seconds / 60f64).floor();
-                seconds %= 60f64;
-            }
-            // 11. Else if largestUnit is "second", then
-            TemporalUnit::Second => {
-                // a. Set microseconds to floor(nanoseconds / 1000).
-                // b. Set nanoseconds to nanoseconds modulo 1000.
-                microseconds = (nanoseconds / 1000f64).floor();
-                nanoseconds %= 1000f64;
-
-                // c. Set milliseconds to floor(microseconds / 1000).
-                // d. Set microseconds to microseconds modulo 1000.
-                milliseconds = (microseconds / 1000f64).floor();
-                microseconds %= 1000f64;
-
-                // e. Set seconds to floor(milliseconds / 1000).
-                // f. Set milliseconds to milliseconds modulo 1000.
-                seconds = (milliseconds / 1000f64).floor();
-                milliseconds %= 1000f64;
-            }
-            // 12. Else if largestUnit is "millisecond", then
-            TemporalUnit::Millisecond => {
-                // a. Set microseconds to floor(nanoseconds / 1000).
-                // b. Set nanoseconds to nanoseconds modulo 1000.
-                microseconds = (nanoseconds / 1000f64).floor();
-                nanoseconds %= 1000f64;
-
-                // c. Set milliseconds to floor(microseconds / 1000).
-                // d. Set microseconds to microseconds modulo 1000.
-                milliseconds = (microseconds / 1000f64).floor();
-                microseconds %= 1000f64;
-            }
-            // 13. Else if largestUnit is "microsecond", then
-            TemporalUnit::Microsecond => {
-                // a. Set microseconds to floor(nanoseconds / 1000).
-                // b. Set nanoseconds to nanoseconds modulo 1000.
-                microseconds = (nanoseconds / 1000f64).floor();
-                nanoseconds %= 1000f64;
-            }
-            // 14. Else,
-            // a. Assert: largestUnit is "nanosecond".
-            _ => debug_assert!(largest_unit == TemporalUnit::Nanosecond),
-        }
-
-        let result_values = Vec::from(&[
-            days,
-            hours,
-            minutes,
-            seconds,
-            milliseconds,
-            microseconds,
-            nanoseconds,
-        ]);
-        // 15. For each value v of « days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds », do
-        for value in result_values {
-            // a. If 𝔽(v) is not finite, then
-            if !value.is_finite() {
-                // i. If sign = 1, then
-                if sign == 1 {
-                    // 1. Return positive overflow.
-                    return Ok((f64::INFINITY, None));
-                }
-                // ii. Else if sign = -1, then
-                // 1. Return negative overflow.
-                return Ok((f64::NEG_INFINITY, None));
-            }
-        }
-
-        let sign = f64::from(sign);
-
-        // 16. Return ? CreateTimeDurationRecord(days, hours × sign, minutes × sign, seconds × sign, milliseconds × sign, microseconds × sign, nanoseconds × sign).
-        let result = Self::new(
-            hours * sign,
-            minutes * sign,
-            seconds * sign,
-            milliseconds * sign,
-            microseconds * sign,
-            nanoseconds * sign,
-        )?;
-
-        Ok((days, Some(result)))
     }
 }
 
@@ -348,21 +168,160 @@ impl TimeDuration {
     ///
     /// # Errors:
     ///   - Will error if provided duration is invalid
-    pub fn balance(&self, days: f64, largest_unit: TemporalUnit) -> TemporalResult<(f64, Self)> {
-        let result = Self::balance_possibly_infinite_time_duration(
-            days,
-            self.hours,
-            self.minutes,
-            self.seconds,
-            self.milliseconds,
-            self.microseconds,
-            self.nanoseconds,
-            largest_unit,
-        )?;
-        let Some(time_duration) = result.1 else {
+    pub fn balance(&self, largest_unit: TemporalUnit) -> TemporalResult<(f64, Self)> {
+        let norm = NormalizedTimeDuration::from_time_duration(&self);
+
+        // 1. Let days, hours, minutes, seconds, milliseconds, and microseconds be 0.
+        let mut days = 0f64;
+        let mut hours = 0f64;
+        let mut minutes = 0f64;
+        let mut seconds = 0f64;
+        let mut milliseconds = 0f64;
+        let mut microseconds = 0f64;
+
+        // 2. Let sign be NormalizedTimeDurationSign(norm).
+        let sign = norm.sign();
+        // 3. Let nanoseconds be NormalizedTimeDurationAbs(norm).[[TotalNanoseconds]].
+        let mut nanoseconds = norm.0.abs();
+
+        match largest_unit {
+            // 4. If largestUnit is "year", "month", "week", or "day", then
+            TemporalUnit::Year
+            | TemporalUnit::Month
+            | TemporalUnit::Week
+            | TemporalUnit::Day => {
+                // a. Set microseconds to floor(nanoseconds / 1000).
+                microseconds = (nanoseconds / 1000f64).floor();
+                // b. Set nanoseconds to nanoseconds modulo 1000.
+                nanoseconds %= 1000f64;
+
+                // c. Set milliseconds to floor(microseconds / 1000).
+                milliseconds = (microseconds / 1000f64).floor();
+                // d. Set microseconds to microseconds modulo 1000.
+                microseconds %= 1000f64;
+
+                // e. Set seconds to floor(milliseconds / 1000).
+                seconds = (milliseconds / 1000f64).floor();
+                // f. Set milliseconds to milliseconds modulo 1000.
+                milliseconds %= 1000f64;
+
+                // g. Set minutes to floor(seconds / 60).
+                minutes = (seconds / 60f64).floor();
+                // h. Set seconds to seconds modulo 60.
+                seconds %= 60f64;
+
+                // i. Set hours to floor(minutes / 60).
+                hours = (minutes / 60f64).floor();
+                // j. Set minutes to minutes modulo 60.
+                minutes %= 60f64;
+
+                // k. Set days to floor(hours / 24).
+                days = (hours / 24f64).floor();
+                // l. Set hours to hours modulo 24.
+                hours %= 24f64;
+            }
+            // 5. Else if largestUnit is "hour", then
+            TemporalUnit::Hour => {
+                // a. Set microseconds to floor(nanoseconds / 1000).
+                microseconds = (nanoseconds / 1000f64).floor();
+                // b. Set nanoseconds to nanoseconds modulo 1000.
+                nanoseconds %= 1000f64;
+
+                // c. Set milliseconds to floor(microseconds / 1000).
+                milliseconds = (microseconds / 1000f64).floor();
+                // d. Set microseconds to microseconds modulo 1000.
+                microseconds %= 1000f64;
+
+                // e. Set seconds to floor(milliseconds / 1000).
+                seconds = (milliseconds / 1000f64).floor();
+                // f. Set milliseconds to milliseconds modulo 1000.
+                milliseconds %= 1000f64;
+
+                // g. Set minutes to floor(seconds / 60).
+                minutes = (seconds / 60f64).floor();
+                // h. Set seconds to seconds modulo 60.
+                seconds %= 60f64;
+
+                // i. Set hours to floor(minutes / 60).
+                hours = (minutes / 60f64).floor();
+                // j. Set minutes to minutes modulo 60.
+                minutes %= 60f64;
+            }
+            // 6. Else if largestUnit is "minute", then
+            TemporalUnit::Minute => {
+                // a. Set microseconds to floor(nanoseconds / 1000).
+                // b. Set nanoseconds to nanoseconds modulo 1000.
+                microseconds = (nanoseconds / 1000f64).floor();
+                nanoseconds %= 1000f64;
+
+                // c. Set milliseconds to floor(microseconds / 1000).
+                // d. Set microseconds to microseconds modulo 1000.
+                milliseconds = (microseconds / 1000f64).floor();
+                microseconds %= 1000f64;
+
+                // e. Set seconds to floor(milliseconds / 1000).
+                // f. Set milliseconds to milliseconds modulo 1000.
+                seconds = (milliseconds / 1000f64).floor();
+                milliseconds %= 1000f64;
+
+                // g. Set minutes to floor(seconds / 60).
+                // h. Set seconds to seconds modulo 60.
+                minutes = (seconds / 60f64).floor();
+                seconds %= 60f64;
+            }
+            // 7. Else if largestUnit is "second", then
+            TemporalUnit::Second => {
+                // a. Set microseconds to floor(nanoseconds / 1000).
+                // b. Set nanoseconds to nanoseconds modulo 1000.
+                microseconds = (nanoseconds / 1000f64).floor();
+                nanoseconds %= 1000f64;
+
+                // c. Set milliseconds to floor(microseconds / 1000).
+                // d. Set microseconds to microseconds modulo 1000.
+                milliseconds = (microseconds / 1000f64).floor();
+                microseconds %= 1000f64;
+
+                // e. Set seconds to floor(milliseconds / 1000).
+                // f. Set milliseconds to milliseconds modulo 1000.
+                seconds = (milliseconds / 1000f64).floor();
+                milliseconds %= 1000f64;
+            }
+            // 8. Else if largestUnit is "millisecond", then
+            TemporalUnit::Millisecond => {
+                // a. Set microseconds to floor(nanoseconds / 1000).
+                // b. Set nanoseconds to nanoseconds modulo 1000.
+                microseconds = (nanoseconds / 1000f64).floor();
+                nanoseconds %= 1000f64;
+
+                // c. Set milliseconds to floor(microseconds / 1000).
+                // d. Set microseconds to microseconds modulo 1000.
+                milliseconds = (microseconds / 1000f64).floor();
+                microseconds %= 1000f64;
+            }
+            // 9. Else if largestUnit is "microsecond", then
+            TemporalUnit::Microsecond => {
+                // a. Set microseconds to floor(nanoseconds / 1000).
+                // b. Set nanoseconds to nanoseconds modulo 1000.
+                microseconds = (nanoseconds / 1000f64).floor();
+                nanoseconds %= 1000f64;
+            }
+            // 10. Else,
+            // a. Assert: largestUnit is "nanosecond".
+            _ => debug_assert!(largest_unit == TemporalUnit::Nanosecond),
+        }
+        // 11. NOTE: When largestUnit is "millisecond", "microsecond", or "nanosecond", milliseconds, microseconds, or nanoseconds may be an unsafe integer. In this case,
+        // care must be taken when implementing the calculation using floating point arithmetic. It can be implemented in C++ using std::fma(). String manipulation will also
+        // give an exact result, since the multiplication is by a power of 10.
+        // 12. Return ! CreateTimeDurationRecord(days × sign, hours × sign, minutes × sign, seconds × sign, milliseconds × sign, microseconds × sign, nanoseconds × sign).
+        let days = days.mul_add(sign, 0.0);
+        let result = Self::new_unchecked(hours.mul_add(sign, 0.0), minutes.mul_add(sign, 0.0), seconds.mul_add(sign, 0.0), milliseconds.mul_add(sign, 0.0), microseconds.mul_add(sign, 0.0), nanoseconds.mul_add(sign, 0.0));
+
+        let td = Vec::from(&[days, result.hours, result.minutes, result.seconds, result.milliseconds, result.microseconds, result.nanoseconds]);
+        if !is_valid_duration(&td) {
             return Err(TemporalError::range().with_message("Invalid balance TimeDuration."));
-        };
-        Ok((result.0, time_duration))
+        }
+
+        Ok((days, result))
     }
 
     /// Utility function for returning if values in a valid range.
@@ -423,6 +382,7 @@ impl TimeDuration {
 // ==== TimeDuration method impls ====
 
 impl TimeDuration {
+    // TODO: Update round to accomodate `Normalization`.
     /// Rounds the current `TimeDuration` given a rounding increment, unit and rounding mode. `round` will return a tuple of the rounded `TimeDuration` and
     /// the `total` value of the smallest unit prior to rounding.
     #[inline]

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -399,8 +399,8 @@ impl TimeDuration {
     }
 
     /// Returns this `TimeDuration` as a `NormalizedTimeDuration`.
-    pub(crate) fn as_norm(&self) -> NormalizedTimeDuration {
-        NormalizedTimeDuration::from_time_duration(self)
+    pub(crate) fn to_normalized(self) -> NormalizedTimeDuration {
+        NormalizedTimeDuration::from_time_duration(&self)
     }
 }
 

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -78,7 +78,8 @@ impl Instant {
 
         if smallest_unit == TemporalUnit::Nanosecond {
             let (_, result) = TimeDuration::from_normalized(
-                TimeDuration::new_unchecked(0f64, 0f64, secs, millis, micros, nanos).as_norm(),
+                TimeDuration::new_unchecked(0f64, 0f64, secs, millis, micros, nanos)
+                    .to_normalized(),
                 largest_unit,
             )?;
             return Ok(result);
@@ -89,7 +90,8 @@ impl Instant {
             smallest_unit,
             rounding_mode,
         )?;
-        let (_, result) = TimeDuration::from_normalized(round_result.as_norm(), largest_unit)?;
+        let (_, result) =
+            TimeDuration::from_normalized(round_result.to_normalized(), largest_unit)?;
         Ok(result)
     }
 

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -77,8 +77,10 @@ impl Instant {
         // Steps 11-13 of 13.47 GetDifferenceSettings
 
         if smallest_unit == TemporalUnit::Nanosecond {
-            let (_, result) = TimeDuration::new_unchecked(0f64, 0f64, secs, millis, micros, nanos)
-                .balance(largest_unit)?;
+            let (_, result) = TimeDuration::from_normalized(
+                TimeDuration::new_unchecked(0f64, 0f64, secs, millis, micros, nanos).as_norm(),
+                largest_unit,
+            )?;
             return Ok(result);
         }
 
@@ -87,7 +89,7 @@ impl Instant {
             smallest_unit,
             rounding_mode,
         )?;
-        let (_, result) = round_result.balance(largest_unit)?;
+        let (_, result) = TimeDuration::from_normalized(round_result.as_norm(), largest_unit)?;
         Ok(result)
     }
 

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -78,7 +78,7 @@ impl Instant {
 
         if smallest_unit == TemporalUnit::Nanosecond {
             let (_, result) = TimeDuration::new_unchecked(0f64, 0f64, secs, millis, micros, nanos)
-                .balance(0f64, largest_unit)?;
+                .balance(largest_unit)?;
             return Ok(result);
         }
 
@@ -87,7 +87,7 @@ impl Instant {
             smallest_unit,
             rounding_mode,
         )?;
-        let (_, result) = round_result.balance(0f64, largest_unit)?;
+        let (_, result) = round_result.balance(largest_unit)?;
         Ok(result)
     }
 


### PR DESCRIPTION
This draft PR is meant to eventually address #19

Currently, this PR is small baseline changes focused on `NormativeTime` records and `balance` methods (EDIT: it also adds `CalendarDateAdd` functionality for the `ISO8601`). ~~The changes overall are pretty widespread across large sections of `Duration` that could really use more tests, so the plan is to come back to this once it can be tested a bit more or split it into a couple of PRs.~~

I'm going to switch this into a normal PR from a draft. After looking through it, #19 will still need to be implemented in a couple PRs, but I think it makes more sense to break the overall update down into smaller chunks