### PR TITLE
Duration Normalization - Part 2

### DIFF
--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -826,7 +826,7 @@ impl Duration {
         match unit {
             TemporalUnit::Year | TemporalUnit::Month | TemporalUnit::Week | TemporalUnit::Day => {
                 let round_result = self.date().round(
-                    Some(self.time), // TODO: Adjust to NormalizedTimeDuration.
+                    Some(self.time.to_normalized()),
                     increment,
                     unit,
                     rounding_mode,

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -8,6 +8,8 @@ use crate::{
 };
 use std::str::FromStr;
 
+use self::normalized::{NormalizedDurationRecord, NormalizedTimeDuration};
+
 use super::{calendar::CalendarProtocol, tz::TzProtocol};
 
 mod date;
@@ -803,14 +805,15 @@ impl Duration {
     }
 
     // TODO (nekevss): Refactor relative_to's into a RelativeTo struct?
-    // TODO (nekevss): Update to `Duration` normalization.
+    // TODO (nekevss): Impl `Duration::round` -> Potentially rename to `round_internal`
     /// Abstract Operation 7.5.26 `RoundDuration ( years, months, weeks, days, hours, minutes,
     ///   seconds, milliseconds, microseconds, nanoseconds, increment, unit,
     ///   roundingMode [ , plainRelativeTo [, zonedRelativeTo [, precalculatedDateTime]]] )`
     #[allow(clippy::type_complexity)]
-    pub fn round_duration<C: CalendarProtocol, Z: TzProtocol>(
+    #[allow(dead_code)]
+    pub(crate) fn round_duration<C: CalendarProtocol, Z: TzProtocol>(
         &self,
-        increment: f64,
+        increment: u64,
         unit: TemporalUnit,
         rounding_mode: TemporalRoundingMode,
         relative_targets: (
@@ -819,19 +822,22 @@ impl Duration {
             Option<&DateTime<C>>,
         ),
         context: &mut C::Context,
-    ) -> TemporalResult<(Self, f64)> {
+    ) -> TemporalResult<(NormalizedDurationRecord, f64)> {
         match unit {
             TemporalUnit::Year | TemporalUnit::Month | TemporalUnit::Week | TemporalUnit::Day => {
                 let round_result = self.date().round(
-                    Some(self.time),
+                    Some(self.time), // TODO: Adjust to NormalizedTimeDuration.
                     increment,
                     unit,
                     rounding_mode,
                     relative_targets,
                     context,
                 )?;
-                let result = Self::from_date_duration(round_result.0);
-                Ok((result, round_result.1))
+                let norm_record = NormalizedDurationRecord::new(
+                    round_result.0,
+                    NormalizedTimeDuration::default(),
+                )?;
+                Ok((norm_record, round_result.1))
             }
             TemporalUnit::Hour
             | TemporalUnit::Minute
@@ -840,11 +846,8 @@ impl Duration {
             | TemporalUnit::Microsecond
             | TemporalUnit::Nanosecond => {
                 let round_result = self.time().round(increment, unit, rounding_mode)?;
-                let result = Self {
-                    date: self.date,
-                    time: round_result.0,
-                };
-                Ok((result, round_result.1))
+                let norm = NormalizedDurationRecord::new(DateDuration::default(), round_result.0)?;
+                Ok((norm, round_result.1 as f64))
             }
             TemporalUnit::Auto => {
                 Err(TemporalError::range().with_message("Invalid TemporalUnit for Duration.round"))

--- a/src/components/duration/date.rs
+++ b/src/components/duration/date.rs
@@ -109,6 +109,13 @@ impl DateDuration {
         }
     }
 
+    /// Returns the sign for the current `DateDuration`.
+    #[inline]
+    #[must_use]
+    pub fn sign(&self) -> i32 {
+        super::duration_sign(&self.iter().collect())
+    }
+
     /// Returns the `[[years]]` value.
     #[must_use]
     pub const fn years(&self) -> f64 {
@@ -149,7 +156,7 @@ impl DateDuration {
     pub fn round<C: CalendarProtocol, Z: TzProtocol>(
         &self,
         additional_time: Option<TimeDuration>,
-        increment: f64,
+        increment: u64,
         unit: TemporalUnit,
         rounding_mode: TemporalRoundingMode,
         relative_targets: (
@@ -300,11 +307,11 @@ impl DateDuration {
 
                 // ab. Set years to RoundNumberToIncrement(fractionalYears, increment, roundingMode).
                 let rounded_years =
-                    utils::round_number_to_increment(frac_years, increment, rounding_mode);
+                    utils::round_number_to_increment(frac_years as i64, increment, rounding_mode);
 
                 // ac. Set total to fractionalYears.
                 // ad. Set months and weeks to 0.
-                let result = Self::new(rounded_years, 0f64, 0f64, 0f64)?;
+                let result = Self::new(rounded_years as f64, 0f64, 0f64, 0f64)?;
                 Ok((result, frac_years))
             }
             // 9. Else if unit is "month", then
@@ -391,11 +398,11 @@ impl DateDuration {
 
                 // r. Set months to RoundNumberToIncrement(fractionalMonths, increment, roundingMode).
                 let rounded_months =
-                    utils::round_number_to_increment(frac_months, increment, rounding_mode);
+                    utils::round_number_to_increment(frac_months as i64, increment, rounding_mode);
 
                 // s. Set total to fractionalMonths.
                 // t. Set weeks to 0.
-                let result = Self::new(self.years, rounded_months, 0f64, 0f64)?;
+                let result = Self::new(self.years, rounded_months as f64, 0f64, 0f64)?;
                 Ok((result, frac_months))
             }
             // 10. Else if unit is "week", then
@@ -443,18 +450,23 @@ impl DateDuration {
 
                 // k. Set weeks to RoundNumberToIncrement(fractionalWeeks, increment, roundingMode).
                 let rounded_weeks =
-                    utils::round_number_to_increment(frac_weeks, increment, rounding_mode);
+                    utils::round_number_to_increment(frac_weeks as i64, increment, rounding_mode);
                 // l. Set total to fractionalWeeks.
-                let result = Self::new(self.years, self.months, rounded_weeks, 0f64)?;
+                let result = Self::new(self.years, self.months, rounded_weeks as f64, 0f64)?;
                 Ok((result, frac_weeks))
             }
             // 11. Else if unit is "day", then
             TemporalUnit::Day => {
                 // a. Set days to RoundNumberToIncrement(fractionalDays, increment, roundingMode).
-                let rounded_days =
-                    utils::round_number_to_increment(fractional_days, increment, rounding_mode);
+                let rounded_days = utils::round_number_to_increment(
+                    fractional_days as i64,
+                    increment,
+                    rounding_mode,
+                );
+
                 // b. Set total to fractionalDays.
-                let result = Self::new(self.years, self.months, self.weeks, rounded_days)?;
+                // c. Set norm to ZeroTimeDuration().
+                let result = Self::new(self.years, self.months, self.weeks, rounded_days as f64)?;
                 Ok((result, fractional_days))
             }
             _ => unreachable!("All other TemporalUnits were returned early as invalid."),

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -48,17 +48,6 @@ impl TimeDuration {
             nanoseconds,
         }
     }
-
-    /// Returns the current `TimeDuration` as nanoseconds.
-    #[inline]
-    pub(crate) fn as_nanos(&self) -> f64 {
-        self.hours
-            .mul_add(60_f64, self.minutes)
-            .mul_add(60_f64, self.seconds)
-            .mul_add(1_000_f64, self.milliseconds)
-            .mul_add(1_000_f64, self.microseconds)
-            .mul_add(1_000_f64, self.nanoseconds)
-    }
 }
 
 // ==== TimeDuration's public API ====

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -2,10 +2,14 @@
 
 use crate::{
     options::{TemporalRoundingMode, TemporalUnit},
-    utils, TemporalError, TemporalResult,
+    TemporalError, TemporalResult,
 };
 
 use super::{is_valid_duration, normalized::NormalizedTimeDuration};
+
+const NANOSECONDS_PER_SECOND: u64 = 1_000_000_000;
+const NANOSECONDS_PER_MINUTE: u64 = NANOSECONDS_PER_SECOND * 60;
+const NANOSECONDS_PER_HOUR: u64 = NANOSECONDS_PER_MINUTE * 60;
 
 /// `TimeDuration` represents the [Time Duration record][spec] of the `Duration.`
 ///
@@ -155,7 +159,7 @@ impl TimeDuration {
         let mut microseconds = 0f64;
 
         // 2. Let sign be NormalizedTimeDurationSign(norm).
-        let sign = norm.sign();
+        let sign = f64::from(norm.sign());
         // 3. Let nanoseconds be NormalizedTimeDurationAbs(norm).[[TotalNanoseconds]].
         let mut nanoseconds = norm.0.abs();
 
@@ -413,11 +417,11 @@ impl TimeDuration {
     #[inline]
     pub fn round(
         &self,
-        increment: f64,
+        increment: u64,
         unit: TemporalUnit,
-        rounding_mode: TemporalRoundingMode,
-    ) -> TemporalResult<(Self, f64)> {
-        let fraction_seconds = match unit {
+        mode: TemporalRoundingMode,
+    ) -> TemporalResult<(NormalizedTimeDuration, i64)> {
+        let norm = match unit {
             TemporalUnit::Year
             | TemporalUnit::Month
             | TemporalUnit::Week
@@ -426,117 +430,64 @@ impl TimeDuration {
                 return Err(TemporalError::r#type()
                     .with_message("Invalid unit provided to for TimeDuration to round."))
             }
-            _ => self.nanoseconds().mul_add(
-                1_000_000_000f64,
-                self.microseconds().mul_add(
-                    1_000_000f64,
-                    self.milliseconds().mul_add(1000f64, self.seconds()),
-                ),
-            ),
+            _ => self.to_normalized(),
         };
 
         match unit {
             // 12. Else if unit is "hour", then
             TemporalUnit::Hour => {
-                // a. Let fractionalHours be (fractionalSeconds / 60 + minutes) / 60 + hours.
-                let frac_hours = (fraction_seconds / 60f64 + self.minutes) / 60f64 + self.hours;
-                // b. Set hours to RoundNumberToIncrement(fractionalHours, increment, roundingMode).
-                let rounded_hours =
-                    utils::round_number_to_increment(frac_hours, increment, rounding_mode);
-                // c. Set total to fractionalHours.
-                // d. Set minutes, seconds, milliseconds, microseconds, and nanoseconds to 0.
-                let result = Self::new(rounded_hours, 0f64, 0f64, 0f64, 0f64, 0f64)?;
-                Ok((result, frac_hours))
+                // a. Let divisor be 3.6 × 10**12.
+                // b. Set total to DivideNormalizedTimeDuration(norm, divisor).
+                let total = norm.divide(NANOSECONDS_PER_HOUR as i64);
+                // c. Set norm to ? RoundNormalizedTimeDurationToIncrement(norm, divisor × increment, roundingMode).
+                let norm = norm.round(NANOSECONDS_PER_HOUR * increment, mode)?;
+                Ok((norm, total))
             }
             // 13. Else if unit is "minute", then
             TemporalUnit::Minute => {
-                // a. Let fractionalMinutes be fractionalSeconds / 60 + minutes.
-                let frac_minutes = fraction_seconds / 60f64 + self.minutes;
-                // b. Set minutes to RoundNumberToIncrement(fractionalMinutes, increment, roundingMode).
-                let rounded_minutes =
-                    utils::round_number_to_increment(frac_minutes, increment, rounding_mode);
-                // c. Set total to fractionalMinutes.
-                // d. Set seconds, milliseconds, microseconds, and nanoseconds to 0.
-                let result = Self::new(self.hours, rounded_minutes, 0f64, 0f64, 0f64, 0f64)?;
-
-                Ok((result, frac_minutes))
+                // a. Let divisor be 6 × 10**10.
+                // b. Set total to DivideNormalizedTimeDuration(norm, divisor).
+                let total = norm.divide(NANOSECONDS_PER_HOUR as i64);
+                // c. Set norm to ? RoundNormalizedTimeDurationToIncrement(norm, divisor × increment, roundingMode).
+                let norm = norm.round(NANOSECONDS_PER_HOUR * increment, mode)?;
+                Ok((norm, total))
             }
             // 14. Else if unit is "second", then
             TemporalUnit::Second => {
-                // a. Set seconds to RoundNumberToIncrement(fractionalSeconds, increment, roundingMode).
-                let rounded_seconds =
-                    utils::round_number_to_increment(fraction_seconds, increment, rounding_mode);
-                // b. Set total to fractionalSeconds.
-                // c. Set milliseconds, microseconds, and nanoseconds to 0.
-                let result =
-                    Self::new(self.hours, self.minutes, rounded_seconds, 0f64, 0f64, 0f64)?;
-
-                Ok((result, fraction_seconds))
+                // a. Let divisor be 10**9.
+                // b. Set total to DivideNormalizedTimeDuration(norm, divisor).
+                let total = norm.divide(NANOSECONDS_PER_HOUR as i64);
+                // c. Set norm to ? RoundNormalizedTimeDurationToIncrement(norm, divisor × increment, roundingMode).
+                let norm = norm.round(NANOSECONDS_PER_HOUR * increment, mode)?;
+                Ok((norm, total))
             }
             // 15. Else if unit is "millisecond", then
             TemporalUnit::Millisecond => {
-                // a. Let fractionalMilliseconds be nanoseconds × 10-6 + microseconds × 10-3 + milliseconds.
-                let fraction_millis = self.nanoseconds.mul_add(
-                    1_000_000f64,
-                    self.microseconds.mul_add(1_000f64, self.milliseconds),
-                );
-
-                // b. Set milliseconds to RoundNumberToIncrement(fractionalMilliseconds, increment, roundingMode).
-                let rounded_millis =
-                    utils::round_number_to_increment(fraction_millis, increment, rounding_mode);
-
-                // c. Set total to fractionalMilliseconds.
-                // d. Set microseconds and nanoseconds to 0.
-                let result = Self::new(
-                    self.hours,
-                    self.minutes,
-                    self.seconds,
-                    rounded_millis,
-                    0f64,
-                    0f64,
-                )?;
-                Ok((result, fraction_millis))
+                // a. Let divisor be 10**6.
+                // b. Set total to DivideNormalizedTimeDuration(norm, divisor).
+                let total = norm.divide(NANOSECONDS_PER_HOUR as i64);
+                // c. Set norm to ? RoundNormalizedTimeDurationToIncrement(norm, divisor × increment, roundingMode).
+                let norm = norm.round(NANOSECONDS_PER_HOUR * increment, mode)?;
+                Ok((norm, total))
             }
             // 16. Else if unit is "microsecond", then
             TemporalUnit::Microsecond => {
-                // a. Let fractionalMicroseconds be nanoseconds × 10-3 + microseconds.
-                let frac_micros = self.nanoseconds.mul_add(1_000f64, self.microseconds);
-
-                // b. Set microseconds to RoundNumberToIncrement(fractionalMicroseconds, increment, roundingMode).
-                let rounded_micros =
-                    utils::round_number_to_increment(frac_micros, increment, rounding_mode);
-
-                // c. Set total to fractionalMicroseconds.
-                // d. Set nanoseconds to 0.
-                let result = Self::new(
-                    self.hours,
-                    self.minutes,
-                    self.seconds,
-                    self.milliseconds,
-                    rounded_micros,
-                    0f64,
-                )?;
-                Ok((result, frac_micros))
+                // a. Let divisor be 10**3.
+                // b. Set total to DivideNormalizedTimeDuration(norm, divisor).
+                let total = norm.divide(NANOSECONDS_PER_HOUR as i64);
+                // c. Set norm to ? RoundNormalizedTimeDurationToIncrement(norm, divisor × increment, roundingMode).
+                let norm = norm.round(NANOSECONDS_PER_HOUR * increment, mode)?;
+                Ok((norm, total))
             }
             // 17. Else,
             TemporalUnit::Nanosecond => {
                 // a. Assert: unit is "nanosecond".
-                // b. Set total to nanoseconds.
-                let total = self.nanoseconds;
-                // c. Set nanoseconds to RoundNumberToIncrement(nanoseconds, increment, roundingMode).
-                let rounded_nanos =
-                    utils::round_number_to_increment(self.nanoseconds, increment, rounding_mode);
-
-                let result = Self::new(
-                    self.hours,
-                    self.minutes,
-                    self.seconds,
-                    self.milliseconds,
-                    self.microseconds,
-                    rounded_nanos,
-                )?;
-
-                Ok((result, total))
+                // b. Set total to NormalizedTimeDurationSeconds(norm) × 10**9 + NormalizedTimeDurationSubseconds(norm).
+                let total =
+                    norm.seconds() * (NANOSECONDS_PER_SECOND as i64) + i64::from(norm.subseconds());
+                // c. Set norm to ? RoundNormalizedTimeDurationToIncrement(norm, increment, roundingMode).
+                let norm = norm.round(increment, mode)?;
+                Ok((norm, total))
             }
             _ => unreachable!("All other units early return error."),
         }

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -409,7 +409,7 @@ impl IsoTime {
     /// Rounds the current `IsoTime` according to the provided settings.
     pub(crate) fn round(
         &self,
-        increment: f64,
+        increment: u64,
         unit: TemporalUnit,
         mode: TemporalRoundingMode,
         day_length_ns: Option<i64>,
@@ -470,16 +470,18 @@ impl IsoTime {
         };
 
         let ns_per_unit = if unit == TemporalUnit::Day {
-            day_length_ns.unwrap_or(NS_PER_DAY) as f64
+            day_length_ns.unwrap_or(NS_PER_DAY)
         } else {
-            unit.as_nanoseconds().expect("Only valid time values are ")
+            unit.as_nanoseconds().expect("Only valid time values are ") as i64
         };
 
         // TODO: Verify validity of cast or handle better.
         // 9. Let result be RoundNumberToIncrement(quantity, increment, roundingMode).
-        let result =
-            utils::round_number_to_increment(quantity as f64, ns_per_unit * increment, mode)
-                / ns_per_unit;
+        let result = (utils::round_number_to_increment(
+            quantity as i64,
+            (ns_per_unit as u64) * increment,
+            mode,
+        ) / ns_per_unit) as f64;
 
         let result = match unit {
             // 10. If unit is "day", then


### PR DESCRIPTION
This PR is a continuation on #20 implementing the `Duration` normalization changes. I think this gets close to covering most a decent portion of the changes major changes. This also shifts the `round_to_increment` functions to `i64`.