### PR TITLE
Add `non_exhaustive` attribute to component structs

### DIFF
--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -500,7 +500,7 @@ impl<C: CalendarProtocol> CalendarSlot<C> {
                     TemporalUnit::Day,
                 )?;
                 // 10. Let result be ? AddISODate(date.[[ISOYear]], date.[[ISOMonth]], date.[[ISODay]], duration.[[Years]], duration.[[Months]], duration.[[Weeks]], duration.[[Days]] + balanceResult.[[Days]], overflow).
-                let result = date.iso().add_iso_date(
+                let result = date.iso.add_iso_date(
                     &DateDuration::new_unchecked(
                         duration.days(),
                         duration.months(),

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -21,9 +21,10 @@ use super::{
 };
 
 /// The native Rust implementation of `Temporal.PlainDate`.
+#[non_exhaustive]
 #[derive(Debug, Default, Clone)]
 pub struct Date<C: CalendarProtocol> {
-    iso: IsoDate,
+    pub(crate) iso: IsoDate,
     calendar: CalendarSlot<C>,
 }
 
@@ -94,13 +95,6 @@ impl<C: CalendarProtocol> Date<C> {
     /// Returns this `Date`'s ISO day value.
     pub const fn iso_day(&self) -> u8 {
         self.iso.day
-    }
-
-    #[inline]
-    #[must_use]
-    /// Returns the `Date`'s inner `IsoDate` record.
-    pub const fn iso(&self) -> IsoDate {
-        self.iso
     }
 
     #[inline]

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -17,6 +17,7 @@ use tinystr::TinyAsciiStr;
 use super::calendar::{CalendarDateLike, GetCalendarSlot};
 
 /// The native Rust implementation of `Temporal.PlainDateTime`
+#[non_exhaustive]
 #[derive(Debug, Default, Clone)]
 pub struct DateTime<C: CalendarProtocol> {
     iso: IsoDateTime,

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -25,6 +25,7 @@ pub use time::TimeDuration;
 ///
 /// `Duration` is made up of a `DateDuration` and `TimeDuration` as primarily
 /// defined by Abtract Operation 7.5.1-5.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Duration {
     date: DateDuration,

--- a/src/components/duration/date.rs
+++ b/src/components/duration/date.rs
@@ -17,6 +17,7 @@ use super::normalized::NormalizedTimeDuration;
 ///
 /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal-date-duration-records
 /// [field spec]: https://tc39.es/proposal-temporal/#sec-properties-of-temporal-duration-instances
+#[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct DateDuration {
     pub(crate) years: f64,
@@ -254,7 +255,7 @@ impl DateDuration {
                 fractional_days += f64::from(months_weeks_in_days);
 
                 // k. Let isoResult be ! AddISODate(plainRelativeTo.[[ISOYear]]. plainRelativeTo.[[ISOMonth]], plainRelativeTo.[[ISODay]], 0, 0, 0, truncate(fractionalDays), "constrain").
-                let iso_result = plain_relative_to.iso().add_iso_date(
+                let iso_result = plain_relative_to.iso.add_iso_date(
                     &DateDuration::new_unchecked(0.0, 0.0, 0.0, fractional_days.trunc()),
                     ArithmeticOverflow::Constrain,
                 )?;

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -17,6 +17,7 @@ const NANOSECONDS_PER_HOUR: u64 = NANOSECONDS_PER_MINUTE * 60;
 ///
 /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal-time-duration-records
 /// [field spec]: https://tc39.es/proposal-temporal/#sec-properties-of-temporal-duration-instances
+#[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TimeDuration {
     pub(crate) hours: f64,

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -14,6 +14,7 @@ const NANOSECONDS_PER_MINUTE: f64 = 60f64 * NANOSECONDS_PER_SECOND;
 const NANOSECONDS_PER_HOUR: f64 = 60f64 * NANOSECONDS_PER_MINUTE;
 
 /// The native Rust implementation of `Temporal.Instant`
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Instant {
     pub(crate) nanos: BigInt,

--- a/src/components/month_day.rs
+++ b/src/components/month_day.rs
@@ -12,6 +12,7 @@ use crate::{
 use super::calendar::{CalendarProtocol, GetCalendarSlot};
 
 /// The native Rust implementation of `Temporal.PlainMonthDay`
+#[non_exhaustive]
 #[derive(Debug, Default, Clone)]
 pub struct MonthDay<C: CalendarProtocol> {
     iso: IsoDate,

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 /// The native Rust implementation of `Temporal.PlainTime`.
+#[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Time {
     iso: IsoTime,

--- a/src/components/year_month.rs
+++ b/src/components/year_month.rs
@@ -12,6 +12,7 @@ use crate::{
 use super::calendar::{CalendarProtocol, GetCalendarSlot};
 
 /// The native Rust implementation of `Temporal.YearMonth`.
+#[non_exhaustive]
 #[derive(Debug, Default, Clone)]
 pub struct YearMonth<C: CalendarProtocol> {
     iso: IsoDate,

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -15,6 +15,7 @@ use crate::{
 use super::tz::TzProtocol;
 
 /// The native Rust implementation of `Temporal.ZonedDateTime`.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ZonedDateTime<C: CalendarProtocol, Z: TzProtocol> {
     instant: Instant,

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -23,6 +23,7 @@ use num_bigint::BigInt;
 use num_traits::{cast::FromPrimitive, ToPrimitive};
 
 /// `IsoDateTime` is the record of the `IsoDate` and `IsoTime` internal slots.
+#[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct IsoDateTime {
     date: IsoDate,
@@ -141,6 +142,7 @@ pub trait IsoDateSlots {
 ///
 /// These fields are used for the `Temporal.PlainDate` object, the
 /// `Temporal.YearMonth` object, and the `Temporal.MonthDay` object.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct IsoDate {
     pub(crate) year: i32,
@@ -252,6 +254,7 @@ impl IsoDate {
 
 /// An `IsoTime` record that contains `Temporal`'s
 /// time slots.
+#[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct IsoTime {
     pub(crate) hour: u8,         // 0..=23


### PR DESCRIPTION
Updates public facing structs to have a `#[non_exhaustive]` attribute flag so that components cannot be constructed with a `StructExpression`.