### PR TITLE
Remove keywords from Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * Add CI and rename license by @jedel1043 in https://github.com/boa-dev/temporal/pull/3
 * Create LICENSE-Apache by @jedel1043 in https://github.com/boa-dev/temporal/pull/6
 * Setup publish CI by @jedel1043 in https://github.com/boa-dev/temporal/pull/26
-* Remove keyword from Cargo.toml by @jedel1043 in https://github.com/boa-dev/temporal/pull/28
+* Remove keywords from Cargo.toml by @jedel1043 in https://github.com/boa-dev/temporal/pull/28
 
 ## New Contributors
 * @nekevss made their first contribution in https://github.com/boa-dev/temporal/pull/1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Add CI and rename license by @jedel1043 in https://github.com/boa-dev/temporal/pull/3
 * Create LICENSE-Apache by @jedel1043 in https://github.com/boa-dev/temporal/pull/6
 * Setup publish CI by @jedel1043 in https://github.com/boa-dev/temporal/pull/26
+* Remove keyword from Cargo.toml by @jedel1043 in https://github.com/boa-dev/temporal/pull/28
 
 ## New Contributors
 * @nekevss made their first contribution in https://github.com/boa-dev/temporal/pull/1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temporal_rs"
-keywords = ["javascript", "temporal", "calendar", "date", "time", "timezone"]
+keywords = ["javascript", "temporal", "calendar", "datetime", "timezone"]
 categories = ["date", "time", "calendars"]
 readme = "./README.md"
 description = "Temporal in Rust is an implementation of the TC39 Temporal Builtin Proposal in Rust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "temporal_rs"
-keywords = ["javascript", "temporal", "calendar", "datetime", "timezone"]
-categories = ["date", "time", "calendars"]
+keywords = ["date", "time", "calendar", "timezone", "duration"]
+categories = ["date-and-time", "internationalization"]
 readme = "./README.md"
 description = "Temporal in Rust is an implementation of the TC39 Temporal Builtin Proposal in Rust."
 version = "0.0.1"
 edition = "2021"
 authors = ["boa-dev"]
-license = "MIT"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/boa-dev/temporal"
 rust-version = "1.74"
 exclude = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temporal_rs"
-keywords = ["javascript", "js", "temporal", "calendar", "date", "time", "timezone"]
+keywords = ["javascript", "temporal", "calendar", "date", "time", "timezone"]
 categories = ["date", "time", "calendars"]
 readme = "./README.md"
 description = "Temporal in Rust is an implementation of the TC39 Temporal Builtin Proposal in Rust."


### PR DESCRIPTION
```
error: failed to publish to registry at https://crates.io/
Caused by:
  the remote server responded with an error: expected at most 5 keywords per crate
```