### PR TITLE
Fix clippy lints and bump bitflags version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "calendrical_calculations"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ exclude = [
 tinystr = "0.7.4"
 icu_calendar = { version = "~1.4.0", default-features = true }
 rustc-hash = { version = "1.1.0", features = ["std"] }
-bitflags = "2.4.2"
+bitflags = "2.5.0"
 num-bigint = { version = "0.4.4", features = ["serde"] }
 num-traits = "0.2.18"

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -523,9 +523,7 @@ impl Iterator for Keys {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let Some(field) = self.iter.next() else {
-            return None;
-        };
+        let field = self.iter.next()?;
 
         match field {
             FieldMap::YEAR => Some("year".to_owned()),
@@ -563,9 +561,8 @@ impl Iterator for Values<'_> {
     type Item = FieldValue;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let Some(field) = self.iter.next() else {
-            return None;
-        };
+        let field = self.iter.next()?;
+
         match field {
             FieldMap::YEAR => Some(
                 self.fields


### PR DESCRIPTION
It manually bumps the bitflags version and fixes the lints causing CI to fail.

This PR would supersede #37