### PR TITLE
Extract temporal tests from the test262 suite

### DIFF
--- a/test262_config.toml
+++ b/test262_config.toml
@@ -1,0 +1,1 @@
+commit = "6f7ae1f311a7b01ef2358de7f4f6fd42c3ae3839"

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "temporal-tests"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+boa_engine = "0.18.0"
+boa_gc = "0.18.0"
+color-eyre = "0.6.2"
+rustc-hash = "1.1.0"
+serde = { version = "1.0.197", features = ["derive"] }
+serde_repr = "0.1.18"
+serde_yaml = "0.9.32"
+bitflags = "2.4.2"
+regex = "1.10.3"
+phf = "0.11.2"
+rayon = "1.9.0"
+log = "0.4.21"
+simple_logger = "4.3.3"

--- a/testgen/edition.rs
+++ b/testgen/edition.rs
@@ -1,0 +1,351 @@
+//! Edition detection utilities.
+//!
+//! This module contains the [`SpecEdition`] struct, which is used in the tester to
+//! classify all tests per minimum required ECMAScript edition.
+
+use std::fmt::Display;
+
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::read::{MetaData, TestFlag};
+
+/// Minimum edition required by a specific feature in the `test262` repository.
+static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
+    // Proposed language features
+
+    // Intl.Locale Info
+    // https://github.com/tc39/proposal-intl-locale-info
+    "Intl.Locale-info"  => SpecEdition::ESNext,
+
+    // FinalizationRegistry#cleanupSome
+    // https://github.com/tc39/proposal-cleanup-some
+    "FinalizationRegistry.prototype.cleanupSome" => SpecEdition::ESNext,
+
+    // Intl.NumberFormat V3
+    // https://github.com/tc39/proposal-intl-numberformat-v3
+    "Intl.NumberFormat-v3" => SpecEdition::ESNext,
+
+    // Legacy RegExp features
+    // https://github.com/tc39/proposal-regexp-legacy-features
+    "legacy-regexp"  => SpecEdition::ESNext,
+
+    // Import Attributes
+    // https://github.com/tc39/proposal-import-attributes/
+    "import-attributes" => SpecEdition::ESNext,
+
+    // Import Assertions
+    // https://github.com/tc39/proposal-import-assertions/
+    "import-assertions"  => SpecEdition::ESNext,
+
+    // JSON modules
+    // https://github.com/tc39/proposal-json-modules
+    "json-modules"  => SpecEdition::ESNext,
+
+    // ArrayBuffer transfer
+    // https://github.com/tc39/proposal-arraybuffer-transfer
+    "arraybuffer-transfer" => SpecEdition::ESNext,
+
+    // Temporal
+    // https://github.com/tc39/proposal-temporal
+    "Temporal" => SpecEdition::ESNext,
+
+    // ShadowRealm, née Callable Boundary Realms
+    // https://github.com/tc39/proposal-realms
+    "ShadowRealm" => SpecEdition::ESNext,
+
+    // Intl.DurationFormat
+    // https://github.com/tc39/proposal-intl-duration-format
+    "Intl.DurationFormat" => SpecEdition::ESNext,
+
+    // Decorators
+    // https://github.com/tc39/proposal-decorators
+    "decorators" => SpecEdition::ESNext,
+
+    // Duplicate named capturing groups
+    // https://github.com/tc39/proposal-duplicate-named-capturing-groups
+    "regexp-duplicate-named-groups" => SpecEdition::ESNext,
+
+    // Array.fromAsync
+    // https://github.com/tc39/proposal-array-from-async
+    "Array.fromAsync" => SpecEdition::ESNext,
+
+    // JSON.parse with source
+    // https://github.com/tc39/proposal-json-parse-with-source
+    "json-parse-with-source" => SpecEdition::ESNext,
+
+    // Iterator Helpers
+    // https://github.com/tc39/proposal-iterator-helpers
+    "iterator-helpers" => SpecEdition::ESNext,
+
+    // Set methods
+    // https://github.com/tc39/proposal-set-methods
+    "set-methods" => SpecEdition::ESNext,
+
+    // Part of the next ES15 edition
+    "Atomics.waitAsync"  => SpecEdition::ESNext,
+    "regexp-v-flag" => SpecEdition::ESNext,
+    "String.prototype.isWellFormed" => SpecEdition::ESNext,
+    "String.prototype.toWellFormed" => SpecEdition::ESNext,
+    "resizable-arraybuffer" => SpecEdition::ESNext,
+    "promise-with-resolvers" => SpecEdition::ESNext,
+    "array-grouping" => SpecEdition::ESNext,
+
+    // Standard language features
+    "AggregateError" => SpecEdition::ES12,
+    "align-detached-buffer-semantics-with-web-reality" => SpecEdition::ES12,
+    "arbitrary-module-namespace-names" => SpecEdition::ES13,
+    "ArrayBuffer" => SpecEdition::ES6,
+    "array-find-from-last" => SpecEdition::ES14,
+    "Array.prototype.at" => SpecEdition::ES13,
+    "Array.prototype.flat" => SpecEdition::ES10,
+    "Array.prototype.flatMap" => SpecEdition::ES10,
+    "Array.prototype.includes" => SpecEdition::ES7,
+    "Array.prototype.values" => SpecEdition::ES6,
+    "arrow-function" => SpecEdition::ES6,
+    "async-iteration" => SpecEdition::ES9,
+    "async-functions" => SpecEdition::ES8,
+    "Atomics" => SpecEdition::ES8,
+    "BigInt" => SpecEdition::ES11,
+    "caller" => SpecEdition::ES5,
+    "change-array-by-copy" => SpecEdition::ES14,
+    "class" => SpecEdition::ES6,
+    "class-fields-private" => SpecEdition::ES13,
+    "class-fields-private-in" => SpecEdition::ES13,
+    "class-fields-public" => SpecEdition::ES13,
+    "class-methods-private" => SpecEdition::ES13,
+    "class-static-block" => SpecEdition::ES13,
+    "class-static-fields-private" => SpecEdition::ES13,
+    "class-static-fields-public" => SpecEdition::ES13,
+    "class-static-methods-private" => SpecEdition::ES13,
+    "coalesce-expression" => SpecEdition::ES11,
+    "computed-property-names" => SpecEdition::ES6,
+    "const" => SpecEdition::ES6,
+    "cross-realm" => SpecEdition::ES6,
+    "DataView" => SpecEdition::ES6,
+    "DataView.prototype.getFloat32" => SpecEdition::ES6,
+    "DataView.prototype.getFloat64" => SpecEdition::ES6,
+    "DataView.prototype.getInt16" => SpecEdition::ES6,
+    "DataView.prototype.getInt32" => SpecEdition::ES6,
+    "DataView.prototype.getInt8" => SpecEdition::ES6,
+    "DataView.prototype.getUint16" => SpecEdition::ES6,
+    "DataView.prototype.getUint32" => SpecEdition::ES6,
+    "DataView.prototype.setUint8" => SpecEdition::ES6,
+    "default-parameters" => SpecEdition::ES6,
+    "destructuring-assignment" => SpecEdition::ES6,
+    "destructuring-binding" => SpecEdition::ES6,
+    "dynamic-import" => SpecEdition::ES11,
+    "error-cause" => SpecEdition::ES13,
+    "exponentiation" => SpecEdition::ES7,
+    "export-star-as-namespace-from-module" => SpecEdition::ES11,
+    "FinalizationRegistry" => SpecEdition::ES12,
+    "for-in-order" => SpecEdition::ES11,
+    "for-of" => SpecEdition::ES6,
+    "Float32Array" => SpecEdition::ES6,
+    "Float64Array" => SpecEdition::ES6,
+    "generators" => SpecEdition::ES6,
+    "globalThis" => SpecEdition::ES11,
+    "hashbang" => SpecEdition::ES14,
+    "import.meta" => SpecEdition::ES11,
+    "Int8Array" => SpecEdition::ES6,
+    "Int16Array" => SpecEdition::ES6,
+    "Int32Array" => SpecEdition::ES6,
+    "Intl-enumeration" => SpecEdition::ES14,
+    "intl-normative-optional" => SpecEdition::ES8,
+    "Intl.DateTimeFormat-datetimestyle" => SpecEdition::ES12,
+    "Intl.DateTimeFormat-dayPeriod" => SpecEdition::ES8,
+    "Intl.DateTimeFormat-extend-timezonename" => SpecEdition::ES13,
+    "Intl.DateTimeFormat-formatRange" => SpecEdition::ES12,
+    "Intl.DateTimeFormat-fractionalSecondDigits" => SpecEdition::ES12,
+    "Intl.DisplayNames" => SpecEdition::ES12,
+    "Intl.DisplayNames-v2" => SpecEdition::ES13,
+    "Intl.ListFormat" => SpecEdition::ES12,
+    "Intl.Locale" => SpecEdition::ES12,
+    "Intl.NumberFormat-unified" => SpecEdition::ES11,
+    "Intl.RelativeTimeFormat" => SpecEdition::ES11,
+    "Intl.Segmenter" => SpecEdition::ES13,
+    "json-superset" => SpecEdition::ES10,
+    "let" => SpecEdition::ES6,
+    "logical-assignment-operators" => SpecEdition::ES12,
+    "Map" => SpecEdition::ES6,
+    "new.target" => SpecEdition::ES6,
+    "numeric-separator-literal" => SpecEdition::ES12,
+    "object-rest" => SpecEdition::ES9,
+    "object-spread" => SpecEdition::ES9,
+    "Object.fromEntries" => SpecEdition::ES10,
+    "Object.hasOwn" => SpecEdition::ES13,
+    "Object.is" => SpecEdition::ES6,
+    "optional-catch-binding" => SpecEdition::ES10,
+    "optional-chaining" => SpecEdition::ES11,
+    "Promise" => SpecEdition::ES6,
+    "Promise.allSettled" => SpecEdition::ES11,
+    "Promise.any" => SpecEdition::ES12,
+    "Promise.prototype.finally" => SpecEdition::ES9,
+    "Proxy" => SpecEdition::ES6,
+    "proxy-missing-checks" => SpecEdition::ES6,
+    "Reflect" => SpecEdition::ES6,
+    "Reflect.construct" => SpecEdition::ES6,
+    "Reflect.set" => SpecEdition::ES6,
+    "Reflect.setPrototypeOf" => SpecEdition::ES6,
+    "regexp-dotall" => SpecEdition::ES9,
+    "regexp-lookbehind" => SpecEdition::ES9,
+    "regexp-match-indices" => SpecEdition::ES13,
+    "regexp-named-groups" => SpecEdition::ES9,
+    "regexp-unicode-property-escapes" => SpecEdition::ES9,
+    "rest-parameters" => SpecEdition::ES6,
+    "Set" => SpecEdition::ES6,
+    "SharedArrayBuffer" => SpecEdition::ES8,
+    "string-trimming" => SpecEdition::ES10,
+    "String.fromCodePoint" => SpecEdition::ES6,
+    "String.prototype.at" => SpecEdition::ES13,
+    "String.prototype.endsWith" => SpecEdition::ES6,
+    "String.prototype.includes" => SpecEdition::ES6,
+    "String.prototype.matchAll" => SpecEdition::ES11,
+    "String.prototype.replaceAll" => SpecEdition::ES12,
+    "String.prototype.trimEnd" => SpecEdition::ES10,
+    "String.prototype.trimStart" => SpecEdition::ES10,
+    "super" => SpecEdition::ES6,
+    "Symbol" => SpecEdition::ES6,
+    "symbols-as-weakmap-keys" => SpecEdition::ES14,
+    "Symbol.asyncIterator" => SpecEdition::ES9,
+    "Symbol.hasInstance" => SpecEdition::ES6,
+    "Symbol.isConcatSpreadable" => SpecEdition::ES6,
+    "Symbol.iterator" => SpecEdition::ES6,
+    "Symbol.match" => SpecEdition::ES6,
+    "Symbol.matchAll" => SpecEdition::ES11,
+    "Symbol.prototype.description" => SpecEdition::ES10,
+    "Symbol.replace" => SpecEdition::ES6,
+    "Symbol.search" => SpecEdition::ES6,
+    "Symbol.species" => SpecEdition::ES6,
+    "Symbol.split" => SpecEdition::ES6,
+    "Symbol.toPrimitive" => SpecEdition::ES6,
+    "Symbol.toStringTag" => SpecEdition::ES6,
+    "Symbol.unscopables" => SpecEdition::ES6,
+    "tail-call-optimization" => SpecEdition::ES6,
+    "template" => SpecEdition::ES6,
+    "top-level-await" => SpecEdition::ES13,
+    "TypedArray" => SpecEdition::ES6,
+    "TypedArray.prototype.at" => SpecEdition::ES13,
+    "u180e" => SpecEdition::ES7,
+    "Uint8Array" => SpecEdition::ES6,
+    "Uint16Array" => SpecEdition::ES6,
+    "Uint32Array" => SpecEdition::ES6,
+    "Uint8ClampedArray" => SpecEdition::ES6,
+    "WeakMap" => SpecEdition::ES6,
+    "WeakRef" => SpecEdition::ES12,
+    "WeakSet" => SpecEdition::ES6,
+    "well-formed-json-stringify" => SpecEdition::ES10,
+    "__proto__" => SpecEdition::ES6,
+    "__getter__" => SpecEdition::ES8,
+    "__setter__" => SpecEdition::ES8,
+
+    // Test-Harness Features
+
+    "IsHTMLDDA" => SpecEdition::ES9,
+    "host-gc-required" => SpecEdition::ES5,
+};
+
+/// List of ECMAScript editions that can be tested in the `test262` repository.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    Serialize_repr,
+    Deserialize_repr,
+)]
+#[repr(u8)]
+pub(crate) enum SpecEdition {
+    /// ECMAScript 5.1 Edition
+    ///
+    /// <https://262.ecma-international.org/5.1>
+    ES5 = 5,
+    /// ECMAScript 6th Edition
+    ///
+    /// <https://262.ecma-international.org/6.0>
+    ES6,
+    /// ECMAScript 7th Edition
+    ///
+    /// <https://262.ecma-international.org/7.0>
+    ES7,
+    /// ECMAScript 8th Edition
+    ///
+    /// <https://262.ecma-international.org/8.0>
+    ES8,
+    /// ECMAScript 9th Edition
+    ///
+    /// <https://262.ecma-international.org/9.0>
+    ES9,
+    /// ECMAScript 10th Edition
+    ///
+    /// <https://262.ecma-international.org/10.0>
+    ES10,
+    /// ECMAScript 11th Edition
+    ///
+    /// <https://262.ecma-international.org/11.0>
+    ES11,
+    /// ECMAScript 12th Edition
+    ///
+    /// <https://262.ecma-international.org/12.0>
+    ES12,
+    /// ECMAScript 13th Edition
+    ///
+    /// <https://262.ecma-international.org/13.0>
+    ES13,
+    /// ECMAScript 14th Edition
+    ///
+    /// <https://262.ecma-international.org/14.0>
+    ES14,
+    /// The edition being worked on right now.
+    ///
+    /// A draft is currently available [here](https://tc39.es/ecma262).
+    #[default]
+    ESNext = 255,
+}
+
+impl Display for SpecEdition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::ESNext => write!(f, "ECMAScript Next"),
+            Self::ES5 => write!(f, "ECMAScript 5.1"),
+            v => write!(f, "ECMAScript {}", v as u8),
+        }
+    }
+}
+
+impl SpecEdition {
+    /// Gets the minimum required ECMAScript edition of a test from its metadata.
+    ///
+    /// If the function finds unknown features in `metadata`, returns an `Err(Vec<&str>)` containing
+    /// the list of unknown features.
+    pub(crate) fn from_test_metadata(metadata: &MetaData) -> Result<Self, Vec<&str>> {
+        let mut min_edition = if metadata.flags.contains(&TestFlag::Async) {
+            Self::ES8
+        } else if metadata.flags.contains(&TestFlag::Module)
+            || metadata.esid.is_some()
+            || metadata.es6id.is_some()
+        {
+            Self::ES6
+        } else {
+            Self::ES5
+        };
+
+        let mut unknowns = Vec::new();
+        for feature in &*metadata.features {
+            let Some(feature_edition) = FEATURE_EDITION.get(feature).copied() else {
+                unknowns.push(&**feature);
+                continue;
+            };
+            min_edition = std::cmp::max(min_edition, feature_edition);
+        }
+
+        if unknowns.is_empty() {
+            Ok(min_edition)
+        } else {
+            Err(unknowns)
+        }
+    }
+}

--- a/testgen/exec/mod.rs
+++ b/testgen/exec/mod.rs
@@ -1,0 +1,206 @@
+//! Execution module for the test runner.
+
+mod temporal;
+
+use crate::{
+    exec::temporal::inject, read::ErrorType, Harness, Outcome, Phase, SpecEdition, Test, TestFlags,
+    TestSuite,
+};
+use boa_engine::{
+    error::JsErasedError, js_string, Context, JsError, JsNativeErrorKind, JsValue, Source,
+};
+use color_eyre::{
+    eyre::{bail, eyre, WrapErr},
+    Result,
+};
+use log::{debug, info, warn};
+use rayon::prelude::*;
+
+impl TestSuite {
+    /// Runs the test suite.
+    pub(crate) fn run(
+        &self,
+        harness: &Harness,
+        parallel: bool,
+        max_edition: SpecEdition,
+    ) -> Result<()> {
+        info!("Running suite `{}`.", self.path.display());
+
+        let suites: Result<Vec<_>> = if parallel {
+            self.suites
+                .par_iter()
+                .map(|suite| suite.run(harness, parallel, max_edition))
+                .collect()
+        } else {
+            self.suites
+                .iter()
+                .map(|suite| suite.run(harness, parallel, max_edition))
+                .collect()
+        };
+
+        suites?;
+
+        let tests: Result<Vec<_>> = if parallel {
+            self.tests
+                .par_iter()
+                .filter(|test| test.edition <= max_edition)
+                .map(|test| test.run(harness))
+                .collect()
+        } else {
+            self.tests
+                .iter()
+                .filter(|test| test.edition <= max_edition)
+                .map(|test| test.run(harness))
+                .collect()
+        };
+
+        tests?;
+
+        Ok(())
+    }
+}
+
+impl Test {
+    /// Runs the test.
+    pub(crate) fn run(&self, harness: &Harness) -> Result<()> {
+        let skip = if self
+            .flags
+            .intersects(TestFlags::MODULE | TestFlags::RAW | TestFlags::ASYNC)
+            || !self
+                .flags
+                .contains(TestFlags::STRICT | TestFlags::NO_STRICT)
+        {
+            Some("incompatible test flags")
+        } else if matches!(
+            self.expected_outcome,
+            Outcome::Negative {
+                phase: Phase::Parse | Phase::Resolution,
+                ..
+            }
+        ) {
+            Some("can only run negative outcomes in the execution phase")
+        } else {
+            None
+        };
+
+        if let Some(skip) = skip {
+            debug!("Skipping test `{}` ({})", self.path.display(), skip);
+            return Ok(());
+        }
+
+        self.run_once(harness)
+    }
+
+    /// Runs the test once, in strict or non-strict mode
+    fn run_once(&self, harness: &Harness) -> Result<()> {
+        let Ok(source) = Source::from_filepath(&self.path) else {
+            bail!("could not read file `{}`", self.path.display());
+        };
+
+        debug!(target: "tests", "starting test `{}`", self.path.display());
+
+        let value = std::panic::catch_unwind(|| match self.expected_outcome {
+            Outcome::Positive => {
+                let context = &mut Context::default();
+
+                self.set_up_env(harness, context)?;
+
+                context
+                    .eval(source)
+                    .map_err(|e| e.into_erased(context).into())
+            }
+            _ => Err(eyre!("invalid outcome for test `{}`", self.path.display())),
+        })
+        .map_err(|_| eyre!("detected panic on test `{}`", self.path.display()))?;
+
+        match value {
+            Ok(v) => {
+                debug!(target: "tests", "`{}`: result text", self.path.display());
+                debug!(target: "tests", "{}", v.display());
+            }
+            Err(e) => {
+                if let Some(e) = e
+                    .downcast_ref::<JsErasedError>()
+                    .and_then(JsErasedError::as_native)
+                {
+                    if e.to_string() == "Error: TemporalTester:unsupported" {
+                        debug!(target: "tests", "`{}`: Filtered test", self.path.display());
+                        return Ok(());
+                    }
+                }
+
+                warn!(target: "tests", "`{}`: FAILED. Ignoring...", self.path.display());
+                warn!(target: "tests", "`{}`: {e}", self.path.display());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Sets the environment up to run the test.
+    fn set_up_env(&self, harness: &Harness, context: &mut Context) -> Result<()> {
+        // add the $262 object.
+        let _js262 = temporal::register_js262(context);
+
+        let assert = Source::from_reader(
+            harness.assert.content.as_bytes(),
+            Some(&harness.assert.path),
+        );
+        let sta = Source::from_reader(harness.sta.content.as_bytes(), Some(&harness.sta.path));
+
+        context
+            .eval(assert)
+            .map_err(|e| e.into_erased(context))
+            .wrap_err("could not run assert.js")?;
+        context
+            .eval(sta)
+            .map_err(|e| e.into_erased(context))
+            .wrap_err("could not run sta.js")?;
+
+        for include_name in &self.includes {
+            let include = harness
+                .includes
+                .get(include_name)
+                .ok_or_else(|| eyre!("could not find the {include_name} include file."))?;
+            let source = Source::from_reader(include.content.as_bytes(), Some(&include.path));
+            context
+                .eval(source)
+                .map_err(|e| e.into_erased(context))
+                .wrap_err_with(|| eyre!("could not run the harness `{include_name}`"))?;
+        }
+
+        inject(context)
+            .map_err(|e| e.into_erased(context))
+            .wrap_err("could not patch the `Temporal` utils")?;
+
+        Ok(())
+    }
+}
+
+/// Returns `true` if `error` is a `target_type` error.
+fn is_error_type(error: &JsError, target_type: ErrorType, context: &mut Context) -> bool {
+    if let Ok(error) = error.try_native(context) {
+        match &error.kind {
+            JsNativeErrorKind::Syntax if target_type == ErrorType::SyntaxError => {}
+            JsNativeErrorKind::Reference if target_type == ErrorType::ReferenceError => {}
+            JsNativeErrorKind::Range if target_type == ErrorType::RangeError => {}
+            JsNativeErrorKind::Type if target_type == ErrorType::TypeError => {}
+            _ => return false,
+        }
+        true
+    } else {
+        let passed = error
+            .as_opaque()
+            .expect("try_native cannot fail if e is not opaque")
+            .as_object()
+            .and_then(|o| o.get(js_string!("constructor"), context).ok())
+            .as_ref()
+            .and_then(JsValue::as_object)
+            .and_then(|o| o.get(js_string!("name"), context).ok())
+            .as_ref()
+            .and_then(JsValue::as_string)
+            .map(|s| s == target_type.as_str())
+            .unwrap_or_default();
+        passed
+    }
+}

--- a/testgen/exec/temporal.rs
+++ b/testgen/exec/temporal.rs
@@ -1,0 +1,87 @@
+use boa_engine::{
+    js_string,
+    native_function::NativeFunction,
+    object::{JsObject, ObjectInitializer},
+    property::Attribute,
+    Context, JsError, JsNativeError, JsResult,
+};
+use boa_gc::{Finalize, Trace};
+use serde::Serialize;
+
+use self::duration::Duration;
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct TemporalUnsupported;
+
+impl From<TemporalUnsupported> for JsError {
+    fn from(value: TemporalUnsupported) -> Self {
+        JsNativeError::error()
+            .with_message("Temporal:unsupported")
+            .into()
+    }
+}
+
+mod duration;
+
+enum Assertion {
+    DurationFullValue {
+        target: Duration,
+        years: i32,
+        months: i32,
+        weeks: i32,
+        days: i32,
+        hours: i32,
+        minutes: i32,
+        seconds: i32,
+        milliseconds: i32,
+        microseconds: i32,
+        nanoseconds: i32,
+    },
+    DurationDateValue {},
+}
+
+struct AssertionsTracker {
+    assertions: Vec<Assertion>,
+}
+
+pub(crate) fn inject(context: &mut Context, tracker: TemporalTracker) -> JsResult<()> {}
+
+/// Creates the object $262 in the context.
+pub(super) fn register_js262(context: &mut Context) -> JsObject {
+    let global_obj = context.global_object();
+
+    let throw_fn = NativeFunction::from_fn_ptr(|_, _, _| {
+        Err(JsNativeError::error()
+            .with_message("TemporalTester:unsupported")
+            .into())
+    });
+    let throw_fn_obj = throw_fn.clone().to_js_function(context.realm());
+
+    let js262 = ObjectInitializer::new(context)
+        .function(throw_fn.clone(), js_string!("createRealm"), 0)
+        .function(throw_fn.clone(), js_string!("detachArrayBuffer"), 2)
+        .function(throw_fn.clone(), js_string!("evalScript"), 1)
+        .function(throw_fn.clone(), js_string!("gc"), 0)
+        .property(
+            js_string!("global"),
+            global_obj,
+            Attribute::WRITABLE | Attribute::CONFIGURABLE,
+        )
+        .accessor(
+            js_string!("agent"),
+            Some(throw_fn_obj),
+            None,
+            Attribute::CONFIGURABLE,
+        )
+        .build();
+
+    context
+        .register_global_property(
+            js_string!("$262"),
+            js262.clone(),
+            Attribute::WRITABLE | Attribute::CONFIGURABLE,
+        )
+        .expect("shouldn't fail with the default global");
+
+    js262
+}

--- a/testgen/exec/temporal/duration.rs
+++ b/testgen/exec/temporal/duration.rs
@@ -1,0 +1,166 @@
+use boa_engine::prelude::*;
+use boa_engine::{
+    class::{Class, ClassBuilder},
+    js_string, Context, JsArgs, JsResult,
+};
+use boa_gc::{Finalize, Trace};
+use serde::{Deserialize, Serialize};
+
+use super::TemporalUnsupported;
+
+#[derive(Clone, Debug, Trace, Finalize, Serialize, Deserialize)]
+enum DurationInitializer {
+    Full {
+        years: i32,
+        months: i32,
+        weeks: i32,
+        days: i32,
+        hours: i32,
+        minutes: i32,
+        seconds: i32,
+        milliseconds: i32,
+        microseconds: i32,
+        nanoseconds: i32,
+    },
+    String(String),
+}
+
+#[derive(Clone, Debug, Trace, Finalize, Serialize, Deserialize, JsData)]
+pub(crate) enum Duration {
+    Plain(DurationInitializer),
+    Add {
+        target: Box<Duration>,
+        other: Box<Duration>,
+        // TODO: relativeTo,
+    },
+    Subtract {
+        target: Box<Duration>,
+        other: Box<Duration>,
+        // TODO: relativeTo,
+    },
+    Negated(Box<Duration>),
+    Abs(Box<Duration>),
+    // TODO: round
+}
+
+impl Class for Duration {
+    const NAME: &'static str = "Temporal.Duration";
+
+    fn init(class: &mut ClassBuilder<'_>) -> JsResult<()> {
+        class
+            .static_method(
+                js_string!("from"),
+                1,
+                NativeFunction::from_fn_ptr(Self::from),
+            )
+            .method(js_string!("add"), 1, NativeFunction::from_fn_ptr(Self::add));
+
+        Ok(())
+    }
+
+    fn data_constructor(
+        new_target: &boa_engine::prelude::JsValue,
+        args: &[boa_engine::prelude::JsValue],
+        context: &mut Context,
+    ) -> boa_engine::JsResult<Self> {
+        fn to_integer_if_integral(args: &[JsValue], idx: usize) -> JsResult<i32> {
+            let value = args.get_or_undefined(0);
+            if value.is_undefined() {
+                Ok(0)
+            } else if let JsValue::Integer(i) = value {
+                Ok(*i)
+            } else {
+                Err(JsNativeError::error()
+                    .with_message("TemporalTester:unsupported")
+                    .into())
+            }
+        }
+        let years = to_integer_if_integral(args, 0)?;
+        let months = to_integer_if_integral(args, 1)?;
+        let weeks = to_integer_if_integral(args, 2)?;
+        let days = to_integer_if_integral(args, 3)?;
+        let hours = to_integer_if_integral(args, 4)?;
+        let minutes = to_integer_if_integral(args, 5)?;
+        let seconds = to_integer_if_integral(args, 6)?;
+        let milliseconds = to_integer_if_integral(args, 7)?;
+        let microseconds = to_integer_if_integral(args, 8)?;
+        let nanoseconds = to_integer_if_integral(args, 9)?;
+
+        Ok(Self::Plain(DurationInitializer::Full {
+            years,
+            months,
+            weeks,
+            days,
+            hours,
+            minutes,
+            seconds,
+            milliseconds,
+            microseconds,
+            nanoseconds,
+        }))
+    }
+}
+
+impl Duration {
+    fn from_js_value(duration: &JsValue, context: &mut Context) -> JsResult<Duration> {
+        if let Some(o) = duration.as_object().and_then(|o| o.downcast_ref::<Self>()) {
+            return Ok(o.clone());
+        }
+
+        if let JsValue::String(s) = duration {
+            return Ok(Duration::Plain(DurationInitializer::String(
+                s.to_std_string_escaped(),
+            )));
+        }
+
+        Err(JsNativeError::error()
+            .with_message("TemporalTester:unsupported")
+            .into())
+    }
+    fn from(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let duration = args.get_or_undefined(0);
+        if args.len() > 1 {
+            return Err(JsNativeError::error()
+                .with_message("TemporalTester:unsupported")
+                .into());
+        }
+
+        let prototype = context
+            .eval(Source::from_bytes("Temporal.Duration.prototype"))?
+            .as_object()
+            .cloned()
+            .ok_or_else(|| JsNativeError::error().with_message("TemporalTester:unsupported"))?;
+
+        let duration = Self::from_js_value(duration, context)?;
+
+        Ok(JsObject::from_proto_and_data(prototype, duration).into())
+    }
+
+    fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        if args.len() > 1 {
+            return Err(JsNativeError::error()
+                .with_message("TemporalTester:unsupported")
+                .into());
+        }
+        let lhs = this
+            .as_object()
+            .cloned()
+            .and_then(|o| o.downcast::<Duration>().ok())
+            .ok_or(TemporalUnsupported)?;
+        let rhs = Self::from_js_value(args.get_or_undefined(0), context)?;
+
+        let prototype = context
+            .eval(Source::from_bytes("Temporal.Duration.prototype"))?
+            .as_object()
+            .cloned()
+            .ok_or_else(|| JsNativeError::error().with_message("TemporalTester:unsupported"))?;
+
+        Ok(JsObject::from_proto_and_data(
+            prototype,
+            Duration::Add {
+                target: Box::new(lhs.borrow().data().clone()),
+                other: Box::new(rhs),
+            },
+        ).into())
+    }
+}

--- a/testgen/main.rs
+++ b/testgen/main.rs
@@ -1,0 +1,437 @@
+//! Test262 test runner
+//!
+//! This crate will run the full ECMAScript test suite (Test262) and report compliance of the
+//! `boa` engine.
+#![cfg_attr(not(test), deny(clippy::unwrap_used))]
+#![allow(
+    clippy::too_many_lines,
+    clippy::redundant_pub_crate,
+    clippy::cast_precision_loss
+)]
+
+mod edition;
+mod exec;
+mod read;
+
+use self::read::{read_harness, read_suite, MetaData, Negative, TestFlag};
+use bitflags::bitflags;
+use color_eyre::{
+    eyre::{bail, eyre, WrapErr},
+    Result,
+};
+use edition::SpecEdition;
+use log::{info, warn};
+use read::ErrorType;
+use rustc_hash::{FxHashMap, FxHashSet};
+use serde::{
+    de::{Unexpected, Visitor},
+    Deserialize, Deserializer,
+};
+use std::{path::Path, process::Command};
+
+const DEFAULT_TEST262_DIRECTORY: &str = "test262";
+
+/// Program entry point.
+fn main() -> Result<()> {
+    const TEST262_COMMIT: &str = "6f7ae1f311a7b01ef2358de7f4f6fd42c3ae3839";
+    color_eyre::install()?;
+    simple_logger::init_with_level(log::Level::Info)?;
+
+    let threading = true;
+    let output: Option<&Path> = None;
+
+    clone_test262(Some(TEST262_COMMIT))?;
+    let test262_path = Path::new(DEFAULT_TEST262_DIRECTORY);
+
+    run_temporal_suite(threading, test262_path, output.as_deref())
+}
+
+/// Returns the commit hash and commit message of the provided branch name.
+fn get_last_branch_commit(branch: &str) -> Result<(String, String)> {
+    info!("Getting last commit on '{branch}' branch");
+
+    let result = Command::new("git")
+        .arg("log")
+        .args(["-n", "1"])
+        .arg("--pretty=format:%H %s")
+        .arg(branch)
+        .current_dir(DEFAULT_TEST262_DIRECTORY)
+        .output()?;
+
+    if !result.status.success() {
+        bail!(
+            "test262 getting commit hash and message failed with return code {:?}",
+            result.status.code()
+        );
+    }
+
+    let output = std::str::from_utf8(&result.stdout)?.trim();
+
+    let (hash, message) = output
+        .split_once(' ')
+        .expect("git log output to contain hash and message");
+
+    Ok((hash.into(), message.into()))
+}
+
+fn reset_test262_commit(commit: &str) -> Result<()> {
+    info!("Reset test262 to commit: {commit}...");
+
+    let result = Command::new("git")
+        .arg("reset")
+        .arg("--hard")
+        .arg(commit)
+        .current_dir(DEFAULT_TEST262_DIRECTORY)
+        .status()?;
+
+    if !result.success() {
+        bail!(
+            "test262 commit {commit} checkout failed with return code: {:?}",
+            result.code()
+        );
+    }
+
+    Ok(())
+}
+
+fn clone_test262(commit: Option<&str>) -> Result<()> {
+    const TEST262_REPOSITORY: &str = "https://github.com/tc39/test262";
+
+    let update = commit.is_none();
+
+    if Path::new(DEFAULT_TEST262_DIRECTORY).is_dir() {
+        let (current_commit_hash, current_commit_message) = get_last_branch_commit("HEAD")?;
+
+        if let Some(commit) = commit {
+            if current_commit_hash == commit {
+                return Ok(());
+            }
+        }
+
+        info!("Fetching latest test262 commits...");
+
+        let result = Command::new("git")
+            .arg("fetch")
+            .current_dir(DEFAULT_TEST262_DIRECTORY)
+            .status()?;
+
+        if !result.success() {
+            bail!(
+                "Test262 fetching latest failed with return code {:?}",
+                result.code()
+            );
+        }
+
+        if let Some(commit) = commit {
+            println!("Test262 switching to commit {commit}...");
+            reset_test262_commit(commit)?;
+            return Ok(());
+        }
+
+        info!("Checking latest Test262 with current HEAD...");
+
+        let (latest_commit_hash, latest_commit_message) = get_last_branch_commit("origin/main")?;
+
+        if current_commit_hash != latest_commit_hash {
+            if update {
+                info!("Updating Test262 repository:");
+            } else {
+                warn!("Test262 repository is not in sync, use '--test262-commit latest' to automatically update it:");
+            }
+
+            info!("    Current commit: {current_commit_hash} {current_commit_message}");
+            info!("    Latest commit:  {latest_commit_hash} {latest_commit_message}");
+
+            if update {
+                reset_test262_commit(&latest_commit_hash)?;
+            }
+        }
+
+        return Ok(());
+    }
+
+    println!("Cloning test262...");
+    let result = Command::new("git")
+        .arg("clone")
+        .arg(TEST262_REPOSITORY)
+        .arg(DEFAULT_TEST262_DIRECTORY)
+        .status()?;
+
+    if !result.success() {
+        bail!(
+            "Cloning Test262 repository failed with return code {:?}",
+            result.code()
+        );
+    }
+
+    if let Some(commit) = commit {
+        info!("Reset Test262 to commit: {commit}...");
+
+        reset_test262_commit(commit)?;
+    }
+
+    Ok(())
+}
+
+/// Runs the full test suite.
+fn run_temporal_suite(parallel: bool, test262_path: &Path, output: Option<&Path>) -> Result<()> {
+    if let Some(path) = output {
+        if path.exists() {
+            if !path.is_dir() {
+                bail!("the output path must be a directory.");
+            }
+        } else {
+            std::fs::create_dir_all(path).wrap_err("could not create the output directory")?;
+        }
+    }
+
+    info!("Loading the test suite...");
+    let harness = read_harness(test262_path).wrap_err("could not read the harness file")?;
+
+    let suite_path = test262_path.join(Path::new("test/built-ins/Temporal"));
+
+    let suite = read_suite(&suite_path).wrap_err_with(|| {
+        eyre!(
+            "could not read the Temporal suite at `{}`",
+            suite_path.display()
+        )
+    })?;
+    info!("Test suite loaded, starting tests...");
+    suite.run(&harness, parallel, SpecEdition::ESNext)?;
+
+    Ok(())
+}
+
+/// All the harness include files.
+#[derive(Debug, Clone)]
+struct Harness {
+    assert: HarnessFile,
+    sta: HarnessFile,
+    doneprint_handle: HarnessFile,
+    includes: FxHashMap<Box<str>, HarnessFile>,
+}
+
+#[derive(Debug, Clone)]
+struct HarnessFile {
+    content: Box<str>,
+    path: Box<Path>,
+}
+
+/// Represents a test suite.
+#[derive(Debug, Clone)]
+struct TestSuite {
+    name: Box<str>,
+    path: Box<Path>,
+    suites: Box<[TestSuite]>,
+    tests: Box<[Test]>,
+}
+
+/// Represents a test.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct Test {
+    name: Box<str>,
+    path: Box<Path>,
+    description: Box<str>,
+    esid: Option<Box<str>>,
+    edition: SpecEdition,
+    flags: TestFlags,
+    information: Box<str>,
+    expected_outcome: Outcome,
+    features: FxHashSet<Box<str>>,
+    includes: FxHashSet<Box<str>>,
+    locale: Locale,
+    ignored: bool,
+}
+
+impl Test {
+    /// Creates a new test.
+    fn new<N, C>(name: N, path: C, metadata: MetaData) -> Result<Self>
+    where
+        N: Into<Box<str>>,
+        C: Into<Box<Path>>,
+    {
+        let edition = SpecEdition::from_test_metadata(&metadata)
+            .map_err(|feats| eyre!("test metadata contained unknown features: {feats:?}"))?;
+
+        Ok(Self {
+            edition,
+            name: name.into(),
+            description: metadata.description,
+            esid: metadata.esid,
+            flags: metadata.flags.into(),
+            information: metadata.info,
+            features: metadata.features.into_vec().into_iter().collect(),
+            expected_outcome: Outcome::from(metadata.negative),
+            includes: metadata.includes.into_vec().into_iter().collect(),
+            locale: metadata.locale,
+            path: path.into(),
+            ignored: false,
+        })
+    }
+
+    /// Sets the test as ignored.
+    #[inline]
+    fn set_ignored(&mut self) {
+        self.ignored = true;
+    }
+
+    /// Checks if this is a module test.
+    #[inline]
+    const fn is_module(&self) -> bool {
+        self.flags.contains(TestFlags::MODULE)
+    }
+}
+
+/// An outcome for a test.
+#[derive(Debug, Clone)]
+enum Outcome {
+    Positive,
+    Negative { phase: Phase, error_type: ErrorType },
+}
+
+impl Default for Outcome {
+    fn default() -> Self {
+        Self::Positive
+    }
+}
+
+impl From<Option<Negative>> for Outcome {
+    fn from(neg: Option<Negative>) -> Self {
+        neg.map(|neg| Self::Negative {
+            phase: neg.phase,
+            error_type: neg.error_type,
+        })
+        .unwrap_or_default()
+    }
+}
+
+bitflags! {
+    #[derive(Debug, Clone, Copy)]
+    struct TestFlags: u16 {
+        const STRICT = 0b0_0000_0001;
+        const NO_STRICT = 0b0_0000_0010;
+        const MODULE = 0b0_0000_0100;
+        const RAW = 0b0_0000_1000;
+        const ASYNC = 0b0_0001_0000;
+        const GENERATED = 0b0_0010_0000;
+        const CAN_BLOCK_IS_FALSE = 0b0_0100_0000;
+        const CAN_BLOCK_IS_TRUE = 0b0_1000_0000;
+        const NON_DETERMINISTIC = 0b1_0000_0000;
+    }
+}
+
+impl Default for TestFlags {
+    fn default() -> Self {
+        Self::STRICT | Self::NO_STRICT
+    }
+}
+
+impl From<TestFlag> for TestFlags {
+    fn from(flag: TestFlag) -> Self {
+        match flag {
+            TestFlag::OnlyStrict => Self::STRICT,
+            TestFlag::NoStrict => Self::NO_STRICT,
+            TestFlag::Module => Self::MODULE,
+            TestFlag::Raw => Self::RAW,
+            TestFlag::Async => Self::ASYNC,
+            TestFlag::Generated => Self::GENERATED,
+            TestFlag::CanBlockIsFalse => Self::CAN_BLOCK_IS_FALSE,
+            TestFlag::CanBlockIsTrue => Self::CAN_BLOCK_IS_TRUE,
+            TestFlag::NonDeterministic => Self::NON_DETERMINISTIC,
+        }
+    }
+}
+
+impl<T> From<T> for TestFlags
+where
+    T: AsRef<[TestFlag]>,
+{
+    fn from(flags: T) -> Self {
+        let flags = flags.as_ref();
+        if flags.is_empty() {
+            Self::default()
+        } else {
+            let mut result = Self::empty();
+            for flag in flags {
+                result |= Self::from(*flag);
+            }
+
+            if !result.intersects(Self::default()) {
+                result |= Self::default();
+            }
+
+            result
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TestFlags {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct FlagsVisitor;
+
+        impl<'de> Visitor<'de> for FlagsVisitor {
+            type Value = TestFlags;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(formatter, "a sequence of flags")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut flags = TestFlags::empty();
+                while let Some(elem) = seq.next_element::<TestFlag>()? {
+                    flags |= elem.into();
+                }
+                Ok(flags)
+            }
+        }
+
+        struct RawFlagsVisitor;
+
+        impl Visitor<'_> for RawFlagsVisitor {
+            type Value = TestFlags;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(formatter, "a flags number")
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                TestFlags::from_bits(v).ok_or_else(|| {
+                    E::invalid_value(Unexpected::Unsigned(v.into()), &"a valid flag number")
+                })
+            }
+        }
+
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_seq(FlagsVisitor)
+        } else {
+            deserializer.deserialize_u16(RawFlagsVisitor)
+        }
+    }
+}
+
+/// Phase for an error.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Phase {
+    Parse,
+    Resolution,
+    Runtime,
+}
+
+/// Locale information structure.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(transparent)]
+#[allow(dead_code)]
+struct Locale {
+    locale: Box<[Box<str>]>,
+}

--- a/testgen/read.rs
+++ b/testgen/read.rs
@@ -1,0 +1,228 @@
+//! Module to read the list of test suites from disk.
+
+use crate::HarnessFile;
+
+use super::{Harness, Locale, Phase, Test, TestSuite};
+use color_eyre::{
+    eyre::{eyre, OptionExt, WrapErr},
+    Result,
+};
+use rustc_hash::FxHashMap;
+use serde::Deserialize;
+use std::{
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
+
+/// Representation of the YAML metadata in Test262 tests.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct MetaData {
+    pub(super) description: Box<str>,
+    pub(super) esid: Option<Box<str>>,
+    #[allow(dead_code)]
+    pub(super) es5id: Option<Box<str>>,
+    pub(super) es6id: Option<Box<str>>,
+    #[serde(default)]
+    pub(super) info: Box<str>,
+    #[serde(default)]
+    pub(super) features: Box<[Box<str>]>,
+    #[serde(default)]
+    pub(super) includes: Box<[Box<str>]>,
+    #[serde(default)]
+    pub(super) flags: Box<[TestFlag]>,
+    #[serde(default)]
+    pub(super) negative: Option<Negative>,
+    #[serde(default)]
+    pub(super) locale: Locale,
+}
+
+/// Negative test information structure.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct Negative {
+    pub(super) phase: Phase,
+    #[serde(rename = "type")]
+    pub(super) error_type: ErrorType,
+}
+
+/// All possible error types
+#[derive(Debug, Copy, Clone, Deserialize, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)] // Better than appending `rename` to all variants
+pub(super) enum ErrorType {
+    Test262Error,
+    SyntaxError,
+    ReferenceError,
+    RangeError,
+    TypeError,
+}
+
+impl ErrorType {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Test262Error => "Test262Error",
+            Self::SyntaxError => "SyntaxError",
+            Self::ReferenceError => "ReferenceError",
+            Self::RangeError => "RangeError",
+            Self::TypeError => "TypeError",
+        }
+    }
+}
+
+/// Individual test flag.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) enum TestFlag {
+    OnlyStrict,
+    NoStrict,
+    Module,
+    Raw,
+    Async,
+    Generated,
+    #[serde(rename = "CanBlockIsFalse")]
+    CanBlockIsFalse,
+    #[serde(rename = "CanBlockIsTrue")]
+    CanBlockIsTrue,
+    #[serde(rename = "non-deterministic")]
+    NonDeterministic,
+}
+
+/// Reads the Test262 defined bindings.
+pub(super) fn read_harness(test262_path: &Path) -> Result<Harness> {
+    fn read_harness_file(path: PathBuf) -> Result<HarnessFile> {
+        let content = fs::read_to_string(path.as_path())
+            .wrap_err_with(|| format!("error reading the harness file `{}`", path.display()))?;
+
+        Ok(HarnessFile {
+            content: content.into_boxed_str(),
+            path: path.into_boxed_path(),
+        })
+    }
+    let mut includes = FxHashMap::default();
+
+    for entry in fs::read_dir(test262_path.join("harness"))
+        .wrap_err("error reading the harness directory")?
+    {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+
+        if file_name == "assert.js" || file_name == "sta.js" || file_name == "doneprintHandle.js" {
+            continue;
+        }
+
+        includes.insert(
+            file_name.into_owned().into_boxed_str(),
+            read_harness_file(entry.path())?,
+        );
+    }
+    let assert = read_harness_file(test262_path.join("harness/assert.js"))?;
+    let sta = read_harness_file(test262_path.join("harness/sta.js"))?;
+    let doneprint_handle = read_harness_file(test262_path.join("harness/doneprintHandle.js"))?;
+
+    Ok(Harness {
+        assert,
+        sta,
+        doneprint_handle,
+        includes,
+    })
+}
+
+/// Reads a test suite in the given path.
+pub(super) fn read_suite(path: &Path) -> Result<TestSuite> {
+    let name = path
+        .file_name()
+        .ok_or_else(|| eyre!(format!("test suite with no name found: {}", path.display())))?
+        .to_str()
+        .ok_or_else(|| eyre!(format!("non-UTF-8 suite name found: {}", path.display())))?;
+
+    let mut suites = Vec::new();
+    let mut tests = Vec::new();
+
+    // TODO: iterate in parallel
+    for entry in path.read_dir().wrap_err("could not retrieve entry")? {
+        let entry = entry?;
+        let filetype = entry.file_type().wrap_err("could not retrieve file type")?;
+
+        if filetype.is_dir() {
+            suites.push(read_suite(entry.path().as_path()).wrap_err_with(|| {
+                let path = entry.path();
+                let suite = path.display();
+                format!("error reading sub-suite {suite}")
+            })?);
+            continue;
+        }
+
+        let path = entry.path();
+
+        if path.extension() != Some(OsStr::new("js")) {
+            // Ignore files that aren't executable.
+            continue;
+        }
+
+        if path
+            .file_stem()
+            .is_some_and(|stem| stem.as_encoded_bytes().ends_with(b"FIXTURE"))
+        {
+            // Ignore files that are fixtures.
+            continue;
+        }
+
+        let test = read_test(&path).wrap_err_with(|| {
+            let path = entry.path();
+            let suite = path.display();
+            format!("error reading test {suite}")
+        })?;
+
+        tests.push(test);
+    }
+
+    Ok(TestSuite {
+        name: name.into(),
+        path: Box::from(path),
+        suites: suites.into_boxed_slice(),
+        tests: tests.into_boxed_slice(),
+    })
+}
+
+/// Reads information about a given test case.
+pub(super) fn read_test(path: &Path) -> Result<Test> {
+    let name = path
+        .file_stem()
+        .ok_or_else(|| eyre!("path for test `{}` has no file name", path.display()))?
+        .to_str()
+        .ok_or_else(|| {
+            eyre!(
+                "path for test `{}` is not a valid UTF-8 string",
+                path.display()
+            )
+        })?;
+
+    let metadata = read_metadata(path)?;
+
+    Test::new(name, path, metadata)
+}
+
+/// Reads the metadata from the input test code.
+fn read_metadata(test: &Path) -> Result<MetaData> {
+    use regex::bytes::Regex;
+
+    /// Regular expression to retrieve the metadata of a test.
+    static META_REGEX: OnceLock<Regex> = OnceLock::new();
+
+    let code = fs::read_to_string(test)?;
+
+    let yaml = META_REGEX
+        .get_or_init(|| {
+            Regex::new(r"/\*\-{3}((?:.|\n)*)\-{3}\*/")
+                .expect("could not compile metadata regular expression")
+        })
+        .captures(code.as_bytes())
+        .ok_or_eyre("missing metadata for test")?
+        .get(1)
+        .map(|m| String::from_utf8_lossy(m.as_bytes()))
+        .ok_or_eyre("invalid metadata for test")?
+        .replace('\r', "\n");
+
+    serde_yaml::from_str(&yaml).map_err(Into::into)
+}


### PR DESCRIPTION
Just a POC for now, and only generates tests for `Duration::add`, but theoretically with the correct glue code we could transform all Temporal tests into a better format for us.

Still need to setup the workspace for it.