### PR TITLE
Fix method call in days_in_month

### DIFF
--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -761,7 +761,7 @@ impl<C: CalendarProtocol> CalendarSlot<C> {
         match self {
             CalendarSlot::Builtin(AnyCalendar::Iso(_)) => {
                 // NOTE: Cast shouldn't fail in this instance.
-                Ok(date_like.as_iso_date().as_icu4x()?.day_of_month().0 as u16)
+                Ok(date_like.as_iso_date().as_icu4x()?.days_in_month() as u16)
             }
             CalendarSlot::Builtin(_) => {
                 Err(TemporalError::range().with_message("Not yet implemented."))


### PR DESCRIPTION
Fixes an incorrect call to `day_of_month` to `days_in_month` that @jasonwilliams  noticed.