### PR TITLE
Cleanup rounding increment usages with new struct

### DIFF
--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -4,7 +4,7 @@ use crate::{
     components::{duration::TimeDuration, Duration},
     iso::IsoTime,
     options::{ArithmeticOverflow, RoundingIncrement, TemporalRoundingMode, TemporalUnit},
-    utils, TemporalError, TemporalResult,
+    TemporalError, TemporalResult,
 };
 
 /// The native Rust implementation of `Temporal.PlainTime`.
@@ -265,7 +265,7 @@ impl Time {
         rounding_increment: Option<f64>,
         rounding_mode: Option<TemporalRoundingMode>,
     ) -> TemporalResult<Self> {
-        let increment = utils::to_rounding_increment(rounding_increment)?;
+        let increment = RoundingIncrement::try_from(rounding_increment.unwrap_or(1.0))?;
         let mode = rounding_mode.unwrap_or(TemporalRoundingMode::HalfExpand);
 
         let max = smallest_unit
@@ -275,7 +275,7 @@ impl Time {
             })?;
 
         // Safety (nekevss): to_rounding_increment returns a value in the range of a u32.
-        utils::validate_temporal_rounding_increment(increment, u64::from(max), false)?;
+        increment.validate(u64::from(max), false)?;
 
         let (_, result) = self.iso.round(increment, smallest_unit, mode, None)?;
 

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -19,7 +19,7 @@ use crate::{
         Date, Duration,
     },
     error::TemporalError,
-    options::{ArithmeticOverflow, TemporalRoundingMode, TemporalUnit},
+    options::{ArithmeticOverflow, RoundingIncrement, TemporalRoundingMode, TemporalUnit},
     utils, TemporalResult, NS_PER_DAY,
 };
 use icu_calendar::{Date as IcuDate, Iso};
@@ -550,7 +550,7 @@ impl IsoTime {
     /// Rounds the current `IsoTime` according to the provided settings.
     pub(crate) fn round(
         &self,
-        increment: u64,
+        increment: RoundingIncrement,
         unit: TemporalUnit,
         mode: TemporalRoundingMode,
         day_length_ns: Option<i64>,
@@ -620,7 +620,7 @@ impl IsoTime {
         // 9. Let result be RoundNumberToIncrement(quantity, increment, roundingMode).
         let result = (utils::round_number_to_increment(
             quantity as f64,
-            ((ns_per_unit as u64) * increment) as f64,
+            ((ns_per_unit as u64) * u64::from(increment.get())) as f64,
             mode,
         ) / ns_per_unit) as f64;
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -3,118 +3,15 @@
 //! Temporal has various instances where user's can define options for how an
 //! operation may be completed.
 
-use core::{fmt, num::NonZeroU32, str::FromStr};
+use core::{fmt, str::FromStr};
 
 use crate::{
     components::{calendar::CalendarProtocol, tz::TzProtocol, Date, ZonedDateTime},
-    TemporalError, TemporalResult,
+    TemporalError,
 };
 
-// ==== RoundingIncrement option ====
-// Invariants:
-// RoundingIncrement(n): 1 <= n < 10^9
-/// A numeric rounding increment.
-// TODO: Add explanation on what exactly are rounding increments.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RoundingIncrement(pub(crate) NonZeroU32);
-
-impl Default for RoundingIncrement {
-    fn default() -> Self {
-        Self::ONE
-    }
-}
-
-impl TryFrom<f64> for RoundingIncrement {
-    type Error = TemporalError;
-
-    fn try_from(value: f64) -> Result<Self, Self::Error> {
-        // GetRoundingIncrementOption ( options )
-        // https://tc39.es/proposal-temporal/#sec-temporal-getroundingincrementoption
-
-        // 4. If increment is not finite, throw a RangeError exception.
-        if !value.is_finite() {
-            return Err(TemporalError::range().with_message("roundingIncrement must be finite"));
-        }
-
-        // 5. Let integerIncrement be truncate(ℝ(increment)).
-        let integer_increment = value.trunc();
-        // 6. If integerIncrement < 1 or integerIncrement > 10**9, throw a RangeError exception.
-        if !(1.0..=1_000_000_000.0).contains(&integer_increment) {
-            return Err(TemporalError::range()
-                .with_message("roundingIncrement cannot be less that 1 or bigger than 10**9"));
-        }
-        // 7. Return integerIncrement.
-        // SAFETY: Check above guarantees that `integer_increment` is within the bounds of
-        // NonZeroU32.
-        unsafe { Ok(Self::new_unchecked(integer_increment as u32)) }
-    }
-}
-
-impl RoundingIncrement {
-    // Using `MIN` avoids either a panic or using NonZeroU32::new_unchecked
-    /// A rounding increment of 1 (normal rounding).
-    pub const ONE: Self = Self(NonZeroU32::MIN);
-
-    /// Create a new `RoundingIncrement`.
-    ///
-    /// # Errors
-    ///
-    /// - If `increment` is less than 1 or bigger than 10**9.
-    pub fn try_new(increment: u32) -> TemporalResult<Self> {
-        if !(1..=1_000_000_000).contains(&increment) {
-            Err(TemporalError::range()
-                .with_message("roundingIncrement cannot be less that 1 or bigger than 10**9"))
-        } else {
-            // SAFETY: The check above guarantees that `increment` is within the
-            // specified bounds.
-            unsafe { Ok(Self::new_unchecked(increment)) }
-        }
-    }
-
-    /// Create a new `RoundingIncrement` without checking the validity of the
-    /// increment.
-    ///
-    /// # Safety
-    ///
-    /// The increment must be equal or bigger than 1, but not bigger than 10**9.
-    pub const unsafe fn new_unchecked(increment: u32) -> Self {
-        // SAFETY: The caller must ensure the number is bigger than zero.
-        unsafe { Self(NonZeroU32::new_unchecked(increment)) }
-    }
-
-    /// Gets the numeric value of this `RoundingIncrement`.
-    pub const fn get(self) -> u32 {
-        self.0.get()
-    }
-
-    // ValidateTemporalRoundingIncrement ( increment, dividend, inclusive )
-    // https://tc39.es/proposal-temporal/#sec-validatetemporalroundingincrement
-    pub(crate) fn validate(self, dividend: u64, inclusive: bool) -> TemporalResult<()> {
-        // 1. If inclusive is true, then
-        //     a. Let maximum be dividend.
-        // 2. Else,
-        //     a. Assert: dividend > 1.
-        //     b. Let maximum be dividend - 1.
-        let max = dividend - u64::from(!inclusive);
-
-        let increment = u64::from(self.get());
-
-        // 3. If increment > maximum, throw a RangeError exception.
-        if increment > max {
-            return Err(TemporalError::range().with_message("roundingIncrement exceeds maximum"));
-        }
-
-        // 4. If dividend modulo increment ≠ 0, then
-        if dividend.rem_euclid(increment) != 0 {
-            //     a. Throw a RangeError exception.
-            return Err(TemporalError::range()
-                .with_message("dividend is not divisible by roundingIncrement"));
-        }
-
-        // 5. Return unused.
-        Ok(())
-    }
-}
+mod increment;
+pub use increment::RoundingIncrement;
 
 // ==== RelativeTo Object ====
 

--- a/src/options/increment.rs
+++ b/src/options/increment.rs
@@ -1,0 +1,109 @@
+use std::num::NonZeroU32;
+
+use crate::{TemporalError, TemporalResult};
+
+// ==== RoundingIncrement option ====
+// Invariants:
+// RoundingIncrement(n): 1 <= n < 10^9
+/// A numeric rounding increment.
+// TODO: Add explanation on what exactly are rounding increments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RoundingIncrement(pub(crate) NonZeroU32);
+
+impl Default for RoundingIncrement {
+    fn default() -> Self {
+        Self::ONE
+    }
+}
+
+impl TryFrom<f64> for RoundingIncrement {
+    type Error = TemporalError;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        // GetRoundingIncrementOption ( options )
+        // https://tc39.es/proposal-temporal/#sec-temporal-getroundingincrementoption
+
+        // 4. If increment is not finite, throw a RangeError exception.
+        if !value.is_finite() {
+            return Err(TemporalError::range().with_message("roundingIncrement must be finite"));
+        }
+
+        // 5. Let integerIncrement be truncate(ℝ(increment)).
+        let integer_increment = value.trunc();
+        // 6. If integerIncrement < 1 or integerIncrement > 10**9, throw a RangeError exception.
+        if !(1.0..=1_000_000_000.0).contains(&integer_increment) {
+            return Err(TemporalError::range()
+                .with_message("roundingIncrement cannot be less that 1 or bigger than 10**9"));
+        }
+        // 7. Return integerIncrement.
+        // SAFETY: Check above guarantees that `integer_increment` is within the bounds of
+        // NonZeroU32.
+        unsafe { Ok(Self::new_unchecked(integer_increment as u32)) }
+    }
+}
+
+impl RoundingIncrement {
+    // Using `MIN` avoids either a panic or using NonZeroU32::new_unchecked
+    /// A rounding increment of 1 (normal rounding).
+    pub const ONE: Self = Self(NonZeroU32::MIN);
+
+    /// Create a new `RoundingIncrement`.
+    ///
+    /// # Errors
+    ///
+    /// - If `increment` is less than 1 or bigger than 10**9.
+    pub fn try_new(increment: u32) -> TemporalResult<Self> {
+        if !(1..=1_000_000_000).contains(&increment) {
+            Err(TemporalError::range()
+                .with_message("roundingIncrement cannot be less that 1 or bigger than 10**9"))
+        } else {
+            // SAFETY: The check above guarantees that `increment` is within the
+            // specified bounds.
+            unsafe { Ok(Self::new_unchecked(increment)) }
+        }
+    }
+
+    /// Create a new `RoundingIncrement` without checking the validity of the
+    /// increment.
+    ///
+    /// # Safety
+    ///
+    /// The increment must be equal or bigger than 1, but not bigger than 10**9.
+    pub const unsafe fn new_unchecked(increment: u32) -> Self {
+        // SAFETY: The caller must ensure the number is bigger than zero.
+        unsafe { Self(NonZeroU32::new_unchecked(increment)) }
+    }
+
+    /// Gets the numeric value of this `RoundingIncrement`.
+    pub const fn get(self) -> u32 {
+        self.0.get()
+    }
+
+    // ValidateTemporalRoundingIncrement ( increment, dividend, inclusive )
+    // https://tc39.es/proposal-temporal/#sec-validatetemporalroundingincrement
+    pub(crate) fn validate(self, dividend: u64, inclusive: bool) -> TemporalResult<()> {
+        // 1. If inclusive is true, then
+        //     a. Let maximum be dividend.
+        // 2. Else,
+        //     a. Assert: dividend > 1.
+        //     b. Let maximum be dividend - 1.
+        let max = dividend - u64::from(!inclusive);
+
+        let increment = u64::from(self.get());
+
+        // 3. If increment > maximum, throw a RangeError exception.
+        if increment > max {
+            return Err(TemporalError::range().with_message("roundingIncrement exceeds maximum"));
+        }
+
+        // 4. If dividend modulo increment ≠ 0, then
+        if dividend.rem_euclid(increment) != 0 {
+            //     a. Throw a RangeError exception.
+            return Err(TemporalError::range()
+                .with_message("dividend is not divisible by roundingIncrement"));
+        }
+
+        // 5. Return unused.
+        Ok(())
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,29 +4,8 @@ use std::{cmp::Ordering, ops::Neg};
 
 use crate::{
     options::{TemporalRoundingMode, TemporalUnsignedRoundingMode},
-    TemporalError, TemporalResult, MS_PER_DAY,
+    MS_PER_DAY,
 };
-
-// NOTE: Review the below for optimizations and add ALOT of tests.
-
-/// Converts and validates an `Option<f64>` rounding increment value into a valid increment result.
-pub(crate) fn to_rounding_increment(increment: Option<f64>) -> TemporalResult<u64> {
-    let inc = increment.unwrap_or(1.0);
-
-    if !inc.is_finite() {
-        return Err(TemporalError::range().with_message("roundingIncrement must be finite."));
-    }
-
-    let integer = inc.trunc();
-
-    if !(1.0..=1_000_000_000f64).contains(&integer) {
-        return Err(
-            TemporalError::range().with_message("roundingIncrement is not within a valid range.")
-        );
-    }
-
-    Ok(integer as u64)
-}
 
 /// Applies the unsigned rounding mode.
 fn apply_unsigned_rounding_mode(
@@ -146,26 +125,6 @@ pub(crate) fn round_number_to_increment_as_if_positive(
     let rounded = apply_unsigned_rounding_mode(quotient, r1, r2, unsigned_rounding_mode);
     // 6. Return rounded × increment.
     rounded * (increment as u64)
-}
-
-pub(crate) fn validate_temporal_rounding_increment(
-    increment: u64,
-    dividend: u64,
-    inclusive: bool,
-) -> TemporalResult<()> {
-    let max = if inclusive { dividend } else { dividend - 1 };
-
-    if increment > max {
-        return Err(TemporalError::range().with_message("roundingIncrement exceeds maximum."));
-    }
-
-    if dividend.rem_euclid(increment) != 0 {
-        return Err(
-            TemporalError::range().with_message("dividend is not divisble by roundingIncrement.")
-        );
-    }
-
-    Ok(())
 }
 
 // ==== Begin Date Equations ====


### PR DESCRIPTION
Cleans up all usages of the rounding increment so that all have to pass through `RoundingIncrement`, increasing strictness.
Also moves the `RoundingIncrement` struct from `options.rs` to its own `increment.rs` file