### PR TITLE
Reject `IsoDate` when outside the allowed range

### DIFF
--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -680,12 +680,6 @@ impl<C: CalendarProtocol> FromStr for Date<C> {
             ArithmeticOverflow::Reject,
         )?;
 
-        if !date.is_within_limits() {
-            return Err(
-                TemporalError::range().with_message("Date is not within ISO date time limits.")
-            );
-        }
-
         Ok(Self::new_unchecked(date, CalendarSlot::from_str(calendar)?))
     }
 }

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -369,6 +369,10 @@ impl IsoDate {
         // 17. Return ! CreateDateDurationRecord(years, months, weeks, days).
         DateDuration::new(years as f64, months as f64, weeks as f64, days as f64)
     }
+
+    pub(crate) fn is_within_limits(self) -> bool {
+        IsoDateTime::new_unchecked(self, IsoTime::noon()).is_within_limits()
+    }
 }
 
 impl IsoDate {

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -200,22 +200,30 @@ impl IsoDate {
         day: i32,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<Self> {
-        match overflow {
+        let id = match overflow {
             ArithmeticOverflow::Constrain => {
                 let month = month.clamp(1, 12);
                 let days_in_month = utils::iso_days_in_month(year, month);
                 let d = day.clamp(1, days_in_month);
                 // NOTE: Values are clamped in a u8 range.
-                Ok(Self::new_unchecked(year, month as u8, d as u8))
+                Self::new_unchecked(year, month as u8, d as u8)
             }
             ArithmeticOverflow::Reject => {
                 if !is_valid_date(year, month, day) {
                     return Err(TemporalError::range().with_message("not a valid ISO date."));
                 }
                 // NOTE: Values have been verified to be in a u8 range.
-                Ok(Self::new_unchecked(year, month as u8, day as u8))
+                Self::new_unchecked(year, month as u8, day as u8)
             }
+        };
+
+        if !iso_dt_within_valid_limits(id, &IsoTime::noon()) {
+            return Err(
+                TemporalError::range().with_message("Date is not within ISO date time limits.")
+            );
         }
+
+        Ok(id)
     }
 
     /// Create a balanced `IsoDate`
@@ -368,10 +376,6 @@ impl IsoDate {
         };
         // 17. Return ! CreateDateDurationRecord(years, months, weeks, days).
         DateDuration::new(years as f64, months as f64, weeks as f64, days as f64)
-    }
-
-    pub(crate) fn is_within_limits(self) -> bool {
-        IsoDateTime::new_unchecked(self, IsoTime::noon()).is_within_limits()
     }
 }
 

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -57,7 +57,7 @@ impl<T: Roundable> IncrementRounder<T> {
     pub(crate) fn from_positive_parts(number: T, increment: NonZeroU64) -> TemporalResult<Self> {
         let increment = <T as NumCast>::from(increment.get()).temporal_unwrap()?;
 
-        debug_assert!(number > T::ZERO);
+        debug_assert!(number >= T::ZERO);
 
         Ok(Self {
             sign: true,


### PR DESCRIPTION
Maybe we could move the check to `IsoDate`'s constructor? For now this is enough to pass test262.