### PR TITLE
Update duration validation and switch asserts to debug-asserts

### DIFF
--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -5,7 +5,7 @@ use crate::{
     iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime},
     options::{ArithmeticOverflow, ResolvedRoundingOptions, TemporalUnit},
     parsers::parse_date_time,
-    TemporalError, TemporalResult, TemporalUnwrap,
+    temporal_assert, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
 use std::{cmp::Ordering, str::FromStr};
@@ -77,7 +77,11 @@ impl DateTime {
         // 7. Assert: IsValidISODate(result.[[Year]], result.[[Month]], result.[[Day]]) is true.
         // 8. Assert: IsValidTime(result.[[Hour]], result.[[Minute]], result.[[Second]], result.[[Millisecond]],
         // result.[[Microsecond]], result.[[Nanosecond]]) is true.
-        debug_assert!(result.is_within_limits());
+        temporal_assert!(
+            result.is_within_limits(),
+            "Assertion failed: the below datetime is not within valid limits:\n{:?}",
+            result
+        );
 
         // 9. Return ? CreateTemporalDateTime(result.[[Year]], result.[[Month]], result.[[Day]], result.[[Hour]],
         // result.[[Minute]], result.[[Second]], result.[[Millisecond]], result.[[Microsecond]],

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -77,7 +77,7 @@ impl DateTime {
         // 7. Assert: IsValidISODate(result.[[Year]], result.[[Month]], result.[[Day]]) is true.
         // 8. Assert: IsValidTime(result.[[Hour]], result.[[Minute]], result.[[Second]], result.[[Millisecond]],
         // result.[[Microsecond]], result.[[Nanosecond]]) is true.
-        assert!(result.is_within_limits());
+        debug_assert!(result.is_within_limits());
 
         // 9. Return ? CreateTemporalDateTime(result.[[Year]], result.[[Month]], result.[[Day]], result.[[Hour]],
         // result.[[Minute]], result.[[Second]], result.[[Millisecond]], result.[[Microsecond]],

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -4,7 +4,7 @@ use crate::{
     components::{DateTime, Time},
     iso::{IsoDateTime, IsoTime},
     options::{RelativeTo, ResolvedRoundingOptions, RoundingOptions, TemporalUnit},
-    Sign, TemporalError, TemporalResult,
+    temporal_assert, Sign, TemporalError, TemporalResult,
 };
 use ixdtf::parsers::{records::TimeDurationRecord, IsoDurationParser};
 use std::str::FromStr;
@@ -549,7 +549,11 @@ impl Duration {
                     .with_message("Calendar units cannot be present without a relative point."));
             }
             // b. Assert: IsCalendarUnit(smallestUnit) is false.
-            debug_assert!(!resolved_options.smallest_unit.is_calendar_unit());
+            temporal_assert!(
+                !resolved_options.smallest_unit.is_calendar_unit(),
+                "Assertion failed: resolvedOptions contains a calendar unit\n{:?}",
+                resolved_options
+            );
 
             // c. Let roundRecord be ? RoundTimeDuration(duration.[[Days]], norm, roundingIncrement, smallestUnit, roundingMode).
             let (round_record, _) = TimeDuration::round(self.days(), &norm, resolved_options)?;

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -645,13 +645,14 @@ pub(crate) fn is_valid_duration(
         hours.mul_add(3600.0, minutes.mul_add(60.0, seconds)),
     );
     // Subseconds part
-    let normalized = milliseconds.mul_add(
+    let normalized_subseconds_parts = milliseconds.mul_add(
         10e-3,
-        microseconds.mul_add(10e-6, nanoseconds.mul_add(10e-9, normalized_seconds)),
+        microseconds.mul_add(10e-6, nanoseconds.mul_add(10e-9, 0.0)),
     );
 
+    let normalized_seconds = normalized_seconds + normalized_subseconds_parts;
     // 8. If abs(normalizedSeconds) ≥ 2**53, return false.
-    if normalized.abs() >= 2e53 {
+    if normalized_seconds.abs() >= 2e53 {
         return false;
     }
 
@@ -778,21 +779,17 @@ impl FromStr for Duration {
 
         let sign = f64::from(parse_record.sign as i8);
 
-        Ok(Self {
-            date: DateDuration::new(
-                f64::from(years) * sign,
-                f64::from(months) * sign,
-                f64::from(weeks) * sign,
-                f64::from(days) * sign,
-            )?,
-            time: TimeDuration::new(
-                hours * sign,
-                minutes * sign,
-                seconds * sign,
-                millis * sign,
-                micros * sign,
-                nanos * sign,
-            )?,
-        })
+        Self::new(
+            f64::from(years) * sign,
+            f64::from(months) * sign,
+            f64::from(weeks) * sign,
+            f64::from(days) * sign,
+            hours * sign,
+            minutes * sign,
+            seconds * sign,
+            millis * sign,
+            micros * sign,
+            nanos * sign,
+        )
     }
 }

--- a/src/components/duration/date.rs
+++ b/src/components/duration/date.rs
@@ -198,7 +198,7 @@ impl DateDuration {
     #[inline]
     pub fn new(years: f64, months: f64, weeks: f64, days: f64) -> TemporalResult<Self> {
         let result = Self::new_unchecked(years, months, weeks, days);
-        if !super::is_valid_duration(&result.fields()) {
+        if !super::is_valid_duration(years, months, weeks, days, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0) {
             return Err(TemporalError::range().with_message("Invalid DateDuration."));
         }
         Ok(result)

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -5,7 +5,7 @@ use std::num::NonZeroU128;
 use crate::{
     options::{ResolvedRoundingOptions, TemporalUnit},
     rounding::{IncrementRounder, Round},
-    TemporalError, TemporalResult, TemporalUnwrap,
+    temporal_assert, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
 use super::{
@@ -184,7 +184,7 @@ impl TimeDuration {
             }
             // 10. Else,
             // a. Assert: largestUnit is "nanosecond".
-            _ => debug_assert!(largest_unit == TemporalUnit::Nanosecond),
+            _ => temporal_assert!(largest_unit == TemporalUnit::Nanosecond),
         }
 
         // NOTE(nekevss): `mul_add` is essentially the Rust's implementation of `std::fma()`, so that's handy, but

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -206,8 +206,10 @@ impl TimeDuration {
             (nanoseconds as i32).mul_add(sign, 0).into(),
         );
 
-        // TODO: Stabilize casting and the value size.
-        let td = Vec::from(&[
+        if !is_valid_duration(
+            0.0,
+            0.0,
+            0.0,
             days as f64,
             result.hours,
             result.minutes,
@@ -215,8 +217,7 @@ impl TimeDuration {
             result.milliseconds,
             result.microseconds,
             result.nanoseconds,
-        ]);
-        if !is_valid_duration(&td) {
+        ) {
             return Err(TemporalError::range().with_message("Invalid balance TimeDuration."));
         }
 
@@ -265,7 +266,18 @@ impl TimeDuration {
             microseconds,
             nanoseconds,
         );
-        if !is_valid_duration(&result.fields()) {
+        if !is_valid_duration(
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            hours,
+            minutes,
+            seconds,
+            milliseconds,
+            microseconds,
+            nanoseconds,
+        ) {
             return Err(
                 TemporalError::range().with_message("Attempted to create an invalid TimeDuration.")
             );

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -26,7 +26,7 @@ use crate::{
     error::TemporalError,
     options::{ArithmeticOverflow, RoundingIncrement, TemporalRoundingMode, TemporalUnit},
     rounding::{IncrementRounder, Round},
-    utils, TemporalResult, TemporalUnwrap, NS_PER_DAY,
+    temporal_assert, utils, TemporalResult, TemporalUnwrap, NS_PER_DAY,
 };
 use icu_calendar::{Date as IcuDate, Iso};
 use num_bigint::BigInt;
@@ -58,6 +58,7 @@ impl IsoDateTime {
 
     // NOTE: The below assumes that nanos is from an `Instant` and thus in a valid range. -> Needs validation.
     /// Creates an `IsoDateTime` from a `BigInt` of epochNanoseconds.
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
     pub(crate) fn from_epoch_nanos(nanos: &BigInt, offset: f64) -> TemporalResult<Self> {
         // Skip the assert as nanos should be validated by Instant.
         // TODO: Determine whether value needs to be validated as integral.
@@ -88,7 +89,7 @@ impl IsoDateTime {
         // 11. Let microsecond be floor(remainderNs / 1000).
         let micros = (remainder_nanos / 1000f64).floor();
         // 12. Assert: microsecond < 1000.
-        debug_assert!(micros < 1000f64);
+        temporal_assert!(micros < 1000f64);
         // 13. Let nanosecond be remainderNs modulo 1000.
         let nanos = (remainder_nanos % 1000f64).floor();
 

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -852,7 +852,7 @@ fn iso_dt_within_valid_limits(date: IsoDate, time: &IsoTime) -> bool {
     let max = BigInt::from(crate::NS_MAX_INSTANT + i128::from(NS_PER_DAY));
     let min = BigInt::from(crate::NS_MIN_INSTANT - i128::from(NS_PER_DAY));
 
-    min < ns && max > ns
+    min <= ns && max >= ns
 }
 
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,21 @@ impl<T> TemporalUnwrap for Option<T> {
     }
 }
 
+#[macro_export]
+macro_rules! temporal_assert {
+    ($condition:expr $(,)*) => {
+        if !$condition {
+            return Err(TemporalError::assert());
+        }
+    };
+    ($condition:expr, $($args:tt)+) => {
+        if !$condition {
+            println!($($args)+);
+            return Err(TemporalError::assert());
+        }
+    };
+}
+
 #[repr(i8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Sign {

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -180,7 +180,7 @@ fn apply_unsigned_rounding_mode<T: Roundable>(
                 return Roundable::result_ceil(dividend, divisor);
             };
             // 13. Assert: unsignedRoundingMode is half-even.
-            assert!(unsigned_rounding_mode == TemporalUnsignedRoundingMode::HalfEven);
+            debug_assert!(unsigned_rounding_mode == TemporalUnsignedRoundingMode::HalfEven);
             // 14. Let cardinality be (r1 / (r2 – r1)) modulo 2.
             // 15. If cardinality is 0, return r1.
             if Roundable::is_even_cardinal(dividend, divisor) {

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     options::{TemporalRoundingMode, TemporalUnsignedRoundingMode},
-    TemporalResult, TemporalUnwrap,
+    temporal_assert, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
 use std::{
@@ -41,7 +41,7 @@ pub(crate) struct IncrementRounder<T: Roundable> {
 }
 
 impl<T: Roundable> IncrementRounder<T> {
-    // ==== PUBLIC ====
+    #[inline]
     pub(crate) fn from_potentially_negative_parts(
         number: T,
         increment: NonZeroU128,
@@ -54,10 +54,12 @@ impl<T: Roundable> IncrementRounder<T> {
         })
     }
 
+    #[inline]
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
     pub(crate) fn from_positive_parts(number: T, increment: NonZeroU128) -> TemporalResult<Self> {
         let increment = <T as NumCast>::from(increment.get()).temporal_unwrap()?;
 
-        debug_assert!(number >= T::ZERO);
+        temporal_assert!(number >= T::ZERO);
 
         Ok(Self {
             sign: true,
@@ -68,6 +70,7 @@ impl<T: Roundable> IncrementRounder<T> {
 }
 
 impl<T: Roundable> Round for IncrementRounder<T> {
+    #[inline]
     fn round(&self, mode: TemporalRoundingMode) -> i128 {
         let unsigned_rounding_mode = mode.get_unsigned_round_mode(self.sign);
         let mut rounded =
@@ -81,6 +84,7 @@ impl<T: Roundable> Round for IncrementRounder<T> {
             * <i128 as NumCast>::from(self.divisor).expect("increment is representable by a u64")
     }
 
+    #[inline]
     fn round_as_positive(&self, mode: TemporalRoundingMode) -> u64 {
         let unsigned_rounding_mode = mode.get_unsigned_round_mode(self.sign);
         let rounded =


### PR DESCRIPTION
This updates the `is_valid_duration` check to the current specification and also changes a couple `asserts` into `debug_asserts` to prevent panics.