### PR TITLE
Implement PartialEq and Eq for `Calendar`, `Date`, and `DateTime`

### DIFF
--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -69,6 +69,14 @@ impl Default for Calendar {
     }
 }
 
+impl PartialEq for Calendar {
+    fn eq(&self, other: &Self) -> bool {
+        self.identifier() == other.identifier()
+    }
+}
+
+impl Eq for Calendar {}
+
 impl IcuCalendar for Calendar {
     type DateInner = AnyDateInner;
 
@@ -575,11 +583,11 @@ impl Calendar {
     }
 
     /// Returns the identifier of this calendar slot.
-    pub fn identifier(&self) -> TemporalResult<String> {
+    pub fn identifier(&self) -> String {
         if self.is_iso() {
-            return Ok(String::from("iso8601"));
+            return String::from("iso8601");
         }
-        Ok(String::from(self.0 .0.kind().as_bcp47_string()))
+        String::from(self.0 .0.kind().as_bcp47_string())
     }
 }
 

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -25,7 +25,7 @@ use super::{
 
 /// The native Rust implementation of `Temporal.PlainDate`.
 #[non_exhaustive]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Date {
     pub(crate) iso: IsoDate,
     calendar: Calendar,
@@ -118,7 +118,7 @@ impl Date {
         // 2. Set other to ? ToTemporalDate(other).
 
         // 3. If ? CalendarEquals(temporalDate.[[Calendar]], other.[[Calendar]]) is false, throw a RangeError exception.
-        if self.calendar().identifier()? != other.calendar().identifier()? {
+        if self.calendar().identifier() != other.calendar().identifier() {
             return Err(TemporalError::range()
                 .with_message("Calendars are for difference operation are not the same."));
         }

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -19,7 +19,7 @@ use super::{
 
 /// The native Rust implementation of `Temporal.PlainDateTime`
 #[non_exhaustive]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct DateTime {
     pub(crate) iso: IsoDateTime,
     calendar: Calendar,


### PR DESCRIPTION
Per title, this implements `PartialEq` and `Eq` for `Calendar` and some corresponding components. This should allow us to bypass the `equals` method.

There is a question for API ergonomics whether we provide an explicit `equals` method, but I'm not entirely sure that's needed with the trait implementations and feels counterproductive to a Rust API.