### PR TITLE
Add commit-message prefix to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix-development: "chore(dependabot)"
     groups:
       ci-dependencies:
         applies-to: version-updates
@@ -15,6 +17,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix-development: "chore(dependabot)"
     groups:
       rust-dependencies:
         applies-to: version-updates

--- a/cliff.toml
+++ b/cliff.toml
@@ -69,7 +69,6 @@ commit_preprocessors = [
 ]
 # Commit grouping 
 commit_parsers = [
-  { message = "^Bump", skip = true },
   { message = "^chore(release):", skip = true},
   { message = "^chore(dependabot):", skip = true},
 ]

--- a/cliff.toml
+++ b/cliff.toml
@@ -71,6 +71,7 @@ commit_preprocessors = [
 commit_parsers = [
   { message = "^Bump", skip = true },
   { message = "^chore(release):", skip = true},
+  { message = "^chore(dependabot):", skip = true},
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false


### PR DESCRIPTION
As mentioned in #76, this should hopefully allow us to filter bot commits from future changelogs.