### PR TITLE
Add prefix option to commit-message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: weekly
     commit-message:
+      prefix: "chore(dependabot)"
       prefix-development: "chore(dependabot)"
     groups:
       ci-dependencies:
@@ -18,6 +19,7 @@ updates:
     schedule:
       interval: weekly
     commit-message:
+      prefix: "chore(dependabot)"
       prefix-development: "chore(dependabot)"
     groups:
       rust-dependencies:


### PR DESCRIPTION
This should fix the failing CI. There's one other field, but that one seems to definitely be optional based off the examples.