### PR TITLE
Implement compare functionality and some more traits

### DIFF
--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -7,7 +7,9 @@ use crate::{
         calendar::{Calendar, CalendarDateLike, GetTemporalCalendar},
         duration::DateDuration,
         DateTime, Duration,
-    }, iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime}, options::{
+    },
+    iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime},
+    options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions,
         TemporalUnit,
     }, parsers::parse_date_time, TemporalError, TemporalFields, TemporalResult, TemporalUnwrap
@@ -199,7 +201,6 @@ impl Date {
             ArithmeticOverflow::Reject,
         )
     }
-
 
     #[inline]
     #[must_use]

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -7,14 +7,10 @@ use crate::{
         calendar::{Calendar, CalendarDateLike, GetTemporalCalendar},
         duration::DateDuration,
         DateTime, Duration,
-    },
-    iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime},
-    options::{
+    }, iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime}, options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions,
         TemporalUnit,
-    },
-    parsers::parse_date_time,
-    TemporalError, TemporalFields, TemporalResult, TemporalUnwrap,
+    }, parsers::parse_date_time, TemporalError, TemporalFields, TemporalResult, TemporalUnwrap
 };
 use std::str::FromStr;
 
@@ -203,6 +199,7 @@ impl Date {
             ArithmeticOverflow::Reject,
         )
     }
+
 
     #[inline]
     #[must_use]

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -12,7 +12,9 @@ use crate::{
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions,
         TemporalUnit,
-    }, parsers::parse_date_time, TemporalError, TemporalFields, TemporalResult, TemporalUnwrap
+    },
+    parsers::parse_date_time,
+    TemporalError, TemporalFields, TemporalResult, TemporalUnwrap,
 };
 use std::str::FromStr;
 

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -29,6 +29,18 @@ pub struct Date {
     calendar: Calendar,
 }
 
+impl Ord for Date {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.iso.cmp(&other.iso)
+    }
+}
+
+impl PartialOrd for Date {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 // ==== Private API ====
 
 impl Date {

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -1,10 +1,14 @@
 //! This module implements `DateTime` any directly related algorithms.
 
 use crate::{
-    components::{calendar::Calendar, duration::TimeDuration, Instant}, iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime}, options::{
+    components::{calendar::Calendar, duration::TimeDuration, Instant},
+    iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime},
+    options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions,
         TemporalUnit,
-    }, parsers::parse_date_time, temporal_assert, Sign, TemporalError, TemporalResult, TemporalUnwrap
+    },
+    parsers::parse_date_time,
+    temporal_assert, Sign, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
 use std::{cmp::Ordering, str::FromStr};

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -1,14 +1,10 @@
 //! This module implements `DateTime` any directly related algorithms.
 
 use crate::{
-    components::{calendar::Calendar, duration::TimeDuration, Instant},
-    iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime},
-    options::{
+    components::{calendar::Calendar, duration::TimeDuration, Instant}, iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime}, options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions,
         TemporalUnit,
-    },
-    parsers::parse_date_time,
-    temporal_assert, Sign, TemporalError, TemporalResult, TemporalUnwrap,
+    }, parsers::parse_date_time, temporal_assert, Sign, TemporalError, TemporalResult, TemporalUnwrap
 };
 
 use std::{cmp::Ordering, str::FromStr};
@@ -260,6 +256,11 @@ impl DateTime {
             self.nanosecond().into(),
             calendar,
         )
+    }
+
+    /// Compares two `DateTime`s, regardless of calendars
+    pub fn compare(&self, other: &Self) -> Sign {
+        (self.iso.cmp(&other.iso) as i8).into()
     }
 
     /// Validates whether ISO date slots are within iso limits at noon.

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -24,6 +24,18 @@ pub struct DateTime {
     calendar: Calendar,
 }
 
+impl Ord for DateTime {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.iso.cmp(&other.iso)
+    }
+}
+
+impl PartialOrd for DateTime {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 // ==== Private DateTime API ====
 
 impl DateTime {
@@ -256,11 +268,6 @@ impl DateTime {
             self.nanosecond().into(),
             calendar,
         )
-    }
-
-    /// Compares two `DateTime`s, regardless of calendars
-    pub fn compare(&self, other: &Self) -> Sign {
-        (self.iso.cmp(&other.iso) as i8).into()
     }
 
     /// Validates whether ISO date slots are within iso limits at noon.

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -13,8 +13,7 @@ pub const TIME_ZONE_PROPERTIES: [&str; 3] =
     ["getOffsetNanosecondsFor", "getPossibleInstantsFor", "id"];
 
 /// A Temporal `TimeZone`.
-#[derive(Debug, Clone)]
-#[allow(unused)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TimeZone {
     pub(crate) iana: Option<String>, // TODO: ICU4X IANA TimeZone support.
     pub(crate) offset: Option<i16>,

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -12,11 +12,17 @@ use super::calendar::CalendarDateLike;
 
 /// The native Rust implementation of `Temporal.ZonedDateTime`.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ZonedDateTime {
     instant: Instant,
     calendar: Calendar,
     tz: TimeZone,
+}
+
+impl PartialOrd for ZonedDateTime {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.instant.cmp(&other.instant))
+    }
 }
 
 // ==== Private API ====

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -27,7 +27,7 @@ impl Ord for ZonedDateTime {
 
 impl PartialOrd for ZonedDateTime {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -19,9 +19,15 @@ pub struct ZonedDateTime {
     tz: TimeZone,
 }
 
+impl Ord for ZonedDateTime {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.instant.cmp(&other.instant)
+    }
+}
+
 impl PartialOrd for ZonedDateTime {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.instant.cmp(&other.instant))
+        Some(self.cmp(&other))
     }
 }
 


### PR DESCRIPTION
This adds some `compare` functions to `Date` and `DateTime`, and Ordering for `ZonedDateTime`.

The compare functions are notably different from `Eq` and `PartialEq` as they compare the internal ISO representation ignoring the Calendar