### PR TITLE
Implement `DateTime` diffing methods `Until` and `Since`

### DIFF
--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -247,6 +247,8 @@ impl Date {
         other.iso.to_epoch_days() - self.iso.to_epoch_days()
     }
 
+    #[inline]
+    /// Adds a `Duration` to the current `Date`
     pub fn add(
         &self,
         duration: &Duration,
@@ -255,6 +257,8 @@ impl Date {
         self.add_date(duration, overflow)
     }
 
+    #[inline]
+    /// Subtracts a `Duration` to the current `Date`
     pub fn subtract(
         &self,
         duration: &Duration,
@@ -263,10 +267,14 @@ impl Date {
         self.add_date(&duration.negated(), overflow)
     }
 
+    #[inline]
+    /// Returns a `Duration` representing the time from this `Date` until the other `Date`.
     pub fn until(&self, other: &Self, settings: DifferenceSettings) -> TemporalResult<Duration> {
         self.diff_date(DifferenceOperation::Until, other, settings)
     }
 
+    #[inline]
+    /// Returns a `Duration` representing the time passed from this `Date` since the other `Date`.
     pub fn since(&self, other: &Self, settings: DifferenceSettings) -> TemporalResult<Duration> {
         self.diff_date(DifferenceOperation::Since, other, settings)
     }

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -8,7 +8,7 @@ use crate::{
         TemporalUnit,
     },
     parsers::parse_date_time,
-    temporal_assert, TemporalError, TemporalResult, TemporalUnwrap,
+    temporal_assert, Sign, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
 use std::{cmp::Ordering, str::FromStr};
@@ -123,9 +123,8 @@ impl DateTime {
 
         // Step 12
         match sign {
-            crate::Sign::Positive => Ok(result),
-            crate::Sign::Negative => Ok(result.negated()),
-            _ => unreachable!("Unreachable: sign must be Sign::Negative or Sign::Positive."),
+            Sign::Positive | Sign::Zero => Ok(result),
+            Sign::Negative => Ok(result.negated()),
         }
     }
 
@@ -607,7 +606,7 @@ mod tests {
         DifferenceSettings {
             largest_unit: None,
             smallest_unit: Some(smallest),
-            increment: Some(unsafe { RoundingIncrement::new_unchecked(increment) }),
+            increment: Some(RoundingIncrement::try_new(increment).unwrap()),
             rounding_mode: Some(rounding_mode),
         }
     }

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -486,6 +486,7 @@ mod tests {
     use crate::{
         components::{calendar::Calendar, duration::DateDuration, Duration},
         iso::{IsoDate, IsoTime},
+        options::{DifferenceSettings, RoundingIncrement, TemporalRoundingMode, TemporalUnit},
     };
 
     use super::DateTime;
@@ -596,5 +597,62 @@ mod tests {
                 nanosecond: 102
             }
         );
+    }
+
+    fn create_diff_setting(
+        smallest: TemporalUnit,
+        increment: u32,
+        rounding_mode: TemporalRoundingMode,
+    ) -> DifferenceSettings {
+        DifferenceSettings {
+            largest_unit: None,
+            smallest_unit: Some(smallest),
+            increment: Some(unsafe { RoundingIncrement::new_unchecked(increment) }),
+            rounding_mode: Some(rounding_mode),
+        }
+    }
+
+    #[test]
+    fn dt_until_basic() {
+        let earlier =
+            DateTime::new(2019, 1, 8, 8, 22, 36, 123, 456, 789, Calendar::default()).unwrap();
+        let later =
+            DateTime::new(2021, 9, 7, 12, 39, 40, 987, 654, 321, Calendar::default()).unwrap();
+
+        let settings = create_diff_setting(TemporalUnit::Hour, 3, TemporalRoundingMode::HalfExpand);
+        let result = earlier.until(&later, settings).unwrap();
+
+        assert_eq!(result.days(), 973.0);
+        assert_eq!(result.hours(), 3.0);
+
+        let settings =
+            create_diff_setting(TemporalUnit::Minute, 30, TemporalRoundingMode::HalfExpand);
+        let result = earlier.until(&later, settings).unwrap();
+
+        assert_eq!(result.days(), 973.0);
+        assert_eq!(result.hours(), 4.0);
+        assert_eq!(result.minutes(), 30.0);
+    }
+
+    #[test]
+    fn dt_since_basic() {
+        let earlier =
+            DateTime::new(2019, 1, 8, 8, 22, 36, 123, 456, 789, Calendar::default()).unwrap();
+        let later =
+            DateTime::new(2021, 9, 7, 12, 39, 40, 987, 654, 321, Calendar::default()).unwrap();
+
+        let settings = create_diff_setting(TemporalUnit::Hour, 3, TemporalRoundingMode::HalfExpand);
+        let result = later.since(&earlier, settings).unwrap();
+
+        assert_eq!(result.days(), 973.0);
+        assert_eq!(result.hours(), 3.0);
+
+        let settings =
+            create_diff_setting(TemporalUnit::Minute, 30, TemporalRoundingMode::HalfExpand);
+        let result = later.since(&earlier, settings).unwrap();
+
+        assert_eq!(result.days(), 973.0);
+        assert_eq!(result.hours(), 4.0);
+        assert_eq!(result.minutes(), 30.0);
     }
 }

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -100,7 +100,7 @@ impl Roundable for i128 {
     }
 
     fn compare_remainder(dividend: Self, divisor: Self) -> Option<Ordering> {
-        Some(dividend.rem_euclid(divisor).cmp(&divisor.div_euclid(2)))
+        Some((dividend.abs() % divisor).cmp(&(divisor / 2)))
     }
 
     fn is_even_cardinal(dividend: Self, divisor: Self) -> bool {
@@ -284,6 +284,14 @@ mod tests {
         .unwrap()
         .round(TemporalRoundingMode::Floor);
         assert_eq!(result, -10);
+
+        let result = IncrementRounder::<i128>::from_potentially_negative_parts(
+            -14,
+            NonZeroU128::new(3).unwrap(),
+        )
+        .unwrap()
+        .round(TemporalRoundingMode::HalfExpand);
+        assert_eq!(result, -15);
     }
 
     #[test]
@@ -303,5 +311,17 @@ mod tests {
         .unwrap()
         .round(TemporalRoundingMode::Floor);
         assert_eq!(result, -9);
+    }
+
+    #[test]
+    fn dt_since_basic_rounding() {
+        let result = IncrementRounder::<i128>::from_potentially_negative_parts(
+            -84082624864197532,
+            NonZeroU128::new(1800000000000).unwrap(),
+        )
+        .unwrap()
+        .round(TemporalRoundingMode::HalfExpand);
+
+        assert_eq!(result, -84083400000000000);
     }
 }


### PR DESCRIPTION
This implements diffing for `DateTime` and the corresponding `since` and `until` methods.

TODO: add basic unit tests for the methods. 