### PR TITLE
Add `with_*` methods to `Date` and `DateTime`

### DIFF
--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -35,6 +35,8 @@ use icu_calendar::{
 };
 use tinystr::TinyAsciiStr;
 
+use super::ZonedDateTime;
+
 /// The ECMAScript defined protocol methods
 pub const CALENDAR_PROTOCOL_METHODS: [&str; 21] = [
     "dateAdd",
@@ -615,6 +617,36 @@ impl Calendar {
     ) -> TemporalResult<()> {
         // TODO: Research and implement the appropriate ResolveFields for all `BuiltinCalendars.`
         Err(TemporalError::range().with_message("CalendarResolveFields is not yet implemented."))
+    }
+}
+
+impl From<Date> for Calendar {
+    fn from(value: Date) -> Self {
+        value.calendar().clone()
+    }
+}
+
+impl From<DateTime> for Calendar {
+    fn from(value: DateTime) -> Self {
+        value.calendar().clone()
+    }
+}
+
+impl From<ZonedDateTime> for Calendar {
+    fn from(value: ZonedDateTime) -> Self {
+        value.calendar().clone()
+    }
+}
+
+impl From<MonthDay> for Calendar {
+    fn from(value: MonthDay) -> Self {
+        value.calendar().clone()
+    }
+}
+
+impl From<YearMonth> for Calendar {
+    fn from(value: YearMonth) -> Self {
+        value.calendar().clone()
     }
 }
 

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -193,13 +193,18 @@ impl Date {
         Ok(Self::new_unchecked(iso, calendar))
     }
 
-    #[must_use]
-    /// Creates a `Date` from a `DateTime`.
-    pub fn from_datetime(dt: &DateTime) -> Self {
-        Self {
-            iso: dt.iso_date(),
-            calendar: dt.calendar().clone(),
-        }
+    /// Creates a
+    pub fn with_calendar<I>(&self, calendar_like: Option<I>) -> TemporalResult<Self>
+    where
+        I: Into<Calendar>,
+    {
+        Self::new(
+            self.iso_year(),
+            self.iso_month().into(),
+            self.iso_day().into(),
+            calendar_like.map(Into::into).unwrap_or_default(),
+            ArithmeticOverflow::Reject,
+        )
     }
 
     #[inline]

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -194,15 +194,12 @@ impl Date {
     }
 
     /// Creates a
-    pub fn with_calendar<I>(&self, calendar_like: Option<I>) -> TemporalResult<Self>
-    where
-        I: Into<Calendar>,
-    {
+    pub fn with_calendar(&self, calendar: Option<Calendar>) -> TemporalResult<Self> {
         Self::new(
             self.iso_year(),
             self.iso_month().into(),
             self.iso_day().into(),
-            calendar_like.map(Into::into).unwrap_or_default(),
+            calendar.unwrap_or_default(),
             ArithmeticOverflow::Reject,
         )
     }

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -193,13 +193,13 @@ impl Date {
         Ok(Self::new_unchecked(iso, calendar))
     }
 
-    /// Creates a
-    pub fn with_calendar(&self, calendar: Option<Calendar>) -> TemporalResult<Self> {
+    /// Creates a new `Date` from the current `Date` and the provided calendar.
+    pub fn with_calendar(&self, calendar: Calendar) -> TemporalResult<Self> {
         Self::new(
             self.iso_year(),
             self.iso_month().into(),
             self.iso_day().into(),
-            calendar.unwrap_or_default(),
+            calendar,
             ArithmeticOverflow::Reject,
         )
     }

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -191,11 +191,8 @@ impl DateTime {
         ))
     }
 
-    pub fn with_time<I>(&self, time_like: Option<I>) -> TemporalResult<Self>
-    where
-        I: Into<Time>,
-    {
-        let time: Time = time_like.map(Into::into).unwrap_or_default();
+    pub fn with_time(&self, time: Option<Time>) -> TemporalResult<Self> {
+        let time = time.unwrap_or_default();
         Self::new(
             self.iso_year(),
             self.iso_month().into(),
@@ -210,10 +207,7 @@ impl DateTime {
         )
     }
 
-    pub fn with_calendar<I>(&self, calendar_like: Option<I>) -> TemporalResult<Self>
-    where
-        I: Into<Calendar>,
-    {
+    pub fn with_calendar(&self, calendar: Option<Calendar>) -> TemporalResult<Self> {
         Self::new(
             self.iso_year(),
             self.iso_month().into(),
@@ -224,7 +218,7 @@ impl DateTime {
             self.millisecond().into(),
             self.microsecond().into(),
             self.nanosecond().into(),
-            calendar_like.map(Into::into).unwrap_or_default(),
+            calendar.unwrap_or_default(),
         )
     }
 

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -14,7 +14,7 @@ use tinystr::TinyAsciiStr;
 use super::{
     calendar::{CalendarDateLike, GetTemporalCalendar},
     duration::normalized::{NormalizedTimeDuration, RelativeRoundResult},
-    Date, Duration,
+    Date, Duration, Time,
 };
 
 /// The native Rust implementation of `Temporal.PlainDateTime`
@@ -189,6 +189,43 @@ impl DateTime {
             IsoDateTime::new(iso_date, iso_time)?,
             calendar,
         ))
+    }
+
+    pub fn with_time<I>(&self, time_like: Option<I>) -> TemporalResult<Self>
+    where
+        I: Into<Time>,
+    {
+        let time: Time = time_like.map(Into::into).unwrap_or_default();
+        Self::new(
+            self.iso_year(),
+            self.iso_month().into(),
+            self.iso_day().into(),
+            time.hour().into(),
+            time.minute().into(),
+            time.second().into(),
+            time.millisecond().into(),
+            time.microsecond().into(),
+            time.nanosecond().into(),
+            self.calendar.clone(),
+        )
+    }
+
+    pub fn with_calendar<I>(&self, calendar_like: Option<I>) -> TemporalResult<Self>
+    where
+        I: Into<Calendar>,
+    {
+        Self::new(
+            self.iso_year(),
+            self.iso_month().into(),
+            self.iso_day().into(),
+            self.hour().into(),
+            self.minute().into(),
+            self.second().into(),
+            self.millisecond().into(),
+            self.microsecond().into(),
+            self.nanosecond().into(),
+            calendar_like.map(Into::into).unwrap_or_default(),
+        )
     }
 
     /// Validates whether ISO date slots are within iso limits at noon.

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -191,8 +191,8 @@ impl DateTime {
         ))
     }
 
-    pub fn with_time(&self, time: Option<Time>) -> TemporalResult<Self> {
-        let time = time.unwrap_or_default();
+    /// Creates a new `DateTime` from the current `DateTime` and the provided `Time`.
+    pub fn with_time(&self, time: Time) -> TemporalResult<Self> {
         Self::new(
             self.iso_year(),
             self.iso_month().into(),
@@ -207,7 +207,8 @@ impl DateTime {
         )
     }
 
-    pub fn with_calendar(&self, calendar: Option<Calendar>) -> TemporalResult<Self> {
+    /// Creates a new `DateTime` from the current `DateTime` and a provided `Calendar`.
+    pub fn with_calendar(&self, calendar: Calendar) -> TemporalResult<Self> {
         Self::new(
             self.iso_year(),
             self.iso_month().into(),
@@ -218,7 +219,7 @@ impl DateTime {
             self.millisecond().into(),
             self.microsecond().into(),
             self.nanosecond().into(),
-            calendar.unwrap_or_default(),
+            calendar,
         )
     }
 


### PR DESCRIPTION
Per title, this PR adds `with_calendar` and `with_time` methods to `Date` and `DateTime`. This also adds some `From` impls for `Calendar`.