### PR TITLE
Implement `DateTime` round method

### DIFF
--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -543,7 +543,10 @@ mod tests {
     use crate::{
         components::{calendar::Calendar, duration::DateDuration, Duration},
         iso::{IsoDate, IsoTime},
-        options::{DifferenceSettings, RoundingIncrement, RoundingOptions, TemporalRoundingMode, TemporalUnit},
+        options::{
+            DifferenceSettings, RoundingIncrement, RoundingOptions, TemporalRoundingMode,
+            TemporalUnit,
+        },
         primitive::FiniteF64,
     };
 
@@ -744,33 +747,45 @@ mod tests {
             assert_eq!(dt.nanosecond(), expected.8);
         };
 
-        let gen_rounding_options = | smallest: TemporalUnit, increment: u32 | -> RoundingOptions {
+        let gen_rounding_options = |smallest: TemporalUnit, increment: u32| -> RoundingOptions {
             RoundingOptions {
                 largest_unit: None,
                 smallest_unit: Some(smallest),
                 increment: Some(RoundingIncrement::try_new(increment).unwrap()),
                 rounding_mode: None,
             }
-
         };
-        let dt = DateTime::new(1976, 11, 18, 14, 23, 30, 123, 456, 789, Calendar::default()).unwrap(); 
+        let dt =
+            DateTime::new(1976, 11, 18, 14, 23, 30, 123, 456, 789, Calendar::default()).unwrap();
 
-        let result = dt.round(gen_rounding_options(TemporalUnit::Hour, 4)).unwrap();
+        let result = dt
+            .round(gen_rounding_options(TemporalUnit::Hour, 4))
+            .unwrap();
         assert_datetime(result, (1976, 11, 18, 16, 0, 0, 0, 0, 0));
 
-        let result = dt.round(gen_rounding_options(TemporalUnit::Minute, 15)).unwrap();
+        let result = dt
+            .round(gen_rounding_options(TemporalUnit::Minute, 15))
+            .unwrap();
         assert_datetime(result, (1976, 11, 18, 14, 30, 0, 0, 0, 0));
-        
-        let result = dt.round(gen_rounding_options(TemporalUnit::Second, 30)).unwrap();
+
+        let result = dt
+            .round(gen_rounding_options(TemporalUnit::Second, 30))
+            .unwrap();
         assert_datetime(result, (1976, 11, 18, 14, 23, 30, 0, 0, 0));
-        
-        let result = dt.round(gen_rounding_options(TemporalUnit::Millisecond, 10)).unwrap();
+
+        let result = dt
+            .round(gen_rounding_options(TemporalUnit::Millisecond, 10))
+            .unwrap();
         assert_datetime(result, (1976, 11, 18, 14, 23, 30, 120, 0, 0));
-        
-        let result = dt.round(gen_rounding_options(TemporalUnit::Microsecond, 10)).unwrap();
+
+        let result = dt
+            .round(gen_rounding_options(TemporalUnit::Microsecond, 10))
+            .unwrap();
         assert_datetime(result, (1976, 11, 18, 14, 23, 30, 123, 460, 0));
-        
-        let result = dt.round(gen_rounding_options(TemporalUnit::Nanosecond, 10)).unwrap();
+
+        let result = dt
+            .round(gen_rounding_options(TemporalUnit::Nanosecond, 10))
+            .unwrap();
         assert_datetime(result, (1976, 11, 18, 14, 23, 30, 123, 456, 790));
     }
 }

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -429,7 +429,7 @@ impl Duration {
         // 25. If maximum is not undefined, perform ? ValidateTemporalRoundingIncrement(roundingIncrement, maximum, false).
         let existing_largest_unit = self.default_largest_unit();
         let resolved_options =
-            ResolvedRoundingOptions::from_options(options, existing_largest_unit)?;
+            ResolvedRoundingOptions::from_duration_options(options, existing_largest_unit)?;
 
         // 26. Let hoursToDaysConversionMayOccur be false.
         // 27. If duration.[[Days]] ≠ 0 and zonedRelativeTo is not undefined, set hoursToDaysConversionMayOccur to true.

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -255,7 +255,7 @@ impl Time {
         rounding_mode: Option<TemporalRoundingMode>,
     ) -> TemporalResult<Self> {
         let increment = RoundingIncrement::try_from(rounding_increment.unwrap_or(1.0))?;
-        let mode = rounding_mode.unwrap_or(TemporalRoundingMode::HalfExpand);
+        let rounding_mode = rounding_mode.unwrap_or(TemporalRoundingMode::HalfExpand);
 
         let max = smallest_unit
             .to_maximum_rounding_increment()
@@ -266,7 +266,14 @@ impl Time {
         // Safety (nekevss): to_rounding_increment returns a value in the range of a u32.
         increment.validate(u64::from(max), false)?;
 
-        let (_, result) = self.iso.round(increment, smallest_unit, mode, None)?;
+        let resolved = ResolvedRoundingOptions {
+            largest_unit: TemporalUnit::Auto,
+            increment,
+            smallest_unit,
+            rounding_mode,
+        };
+
+        let (_, result) = self.iso.round(resolved)?;
 
         Ok(Self::new_unchecked(result))
     }

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -175,7 +175,11 @@ impl IsoDateTime {
 
     pub(crate) fn round(&self, resolved_options: ResolvedRoundingOptions) -> TemporalResult<Self> {
         let (rounded_days, rounded_time) = self.time.round(resolved_options)?;
-        let balance_result = IsoDate::balance(self.date.year, self.date.month.into(), i32::from(self.date.day) + rounded_days);
+        let balance_result = IsoDate::balance(
+            self.date.year,
+            self.date.month.into(),
+            i32::from(self.date.day) + rounded_days,
+        );
         Self::new(balance_result, rounded_time)
     }
 
@@ -724,7 +728,7 @@ impl IsoTime {
             }
             _ => {
                 return Err(TemporalError::range()
-                    .with_message("Invalid smallestUNit value for time rounding."))
+                    .with_message("Invalid smallestUnit value for time rounding."))
             }
         };
         // 7. Let unitLength be the value in the "Length in Nanoseconds" column of the row of Table 22 whose "Singular" column contains unit.

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -682,38 +682,32 @@ impl IsoTime {
             TemporalUnit::Day | TemporalUnit::Hour => {
                 // a. Let quantity be ((((hour × 60 + minute) × 60 + second) × 1000 + millisecond)
                 // × 1000 + microsecond) × 1000 + nanosecond.
-                ((((i128::from(self.hour) * 60 + i128::from(self.minute)) * 60
-                    + i128::from(self.second))
-                    * 1000
-                    + i128::from(self.millisecond))
-                    * 1000
-                    + i128::from(self.microsecond))
-                    * 1000
-                    + i128::from(self.nanosecond)
+                let minutes = i128::from(self.hour) * 60 + i128::from(self.minute);
+                let seconds = minutes * 60 + i128::from(self.second);
+                let millis = seconds * 1000 + i128::from(self.millisecond);
+                let micros = millis * 1000 + i128::from(self.microsecond);
+                micros * 1000 + i128::from(self.nanosecond)
             }
             // 2. Else if unit is "minute", then
             TemporalUnit::Minute => {
                 // a. Let quantity be (((minute × 60 + second) × 1000 + millisecond) × 1000 + microsecond) × 1000 + nanosecond.
-                (((i128::from(self.minute) * 60 + i128::from(self.second)) * 1000
-                    + i128::from(self.millisecond))
-                    * 1000
-                    + i128::from(self.microsecond))
-                    * 1000
-                    + i128::from(self.nanosecond)
+                let seconds = i128::from(self.minute) * 60 + i128::from(self.second);
+                let millis = seconds * 1000 + i128::from(self.millisecond);
+                let micros = millis * 1000 + i128::from(self.microsecond);
+                micros * 1000 + i128::from(self.nanosecond)
             }
             // 3. Else if unit is "second", then
             TemporalUnit::Second => {
                 // a. Let quantity be ((second × 1000 + millisecond) × 1000 + microsecond) × 1000 + nanosecond.
-                ((i128::from(self.second) * 1000 + i128::from(self.millisecond)) * 1000
-                    + i128::from(self.microsecond))
-                    * 1000
-                    + i128::from(self.nanosecond)
+                let millis = i128::from(self.second) * 1000 + i128::from(self.millisecond);
+                let micros = millis * 1000 + i128::from(self.microsecond);
+                micros * 1000 + i128::from(self.nanosecond)
             }
             // 4. Else if unit is "millisecond", then
             TemporalUnit::Millisecond => {
                 // a. Let quantity be (millisecond × 1000 + microsecond) × 1000 + nanosecond.
-                (i128::from(self.millisecond) * 1000 + i128::from(self.microsecond)) * 1000
-                    + i128::from(self.nanosecond)
+                let micros = i128::from(self.millisecond) * 1000 + i128::from(self.microsecond);
+                micros * 1000 + i128::from(self.nanosecond)
             }
             // 5. Else if unit is "microsecond", then
             TemporalUnit::Microsecond => {


### PR DESCRIPTION
This PR implements `DateTime:round`. In order to do this, `IsoDateTime::round` needed to be implemented, and `IsoTime::round` was updated to the current specification version