### PR TITLE
Implement `MonthCode`, `PartialDate`, and `Date::with`

### DIFF
--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -638,7 +638,7 @@ impl Calendar {
         &self,
         keys: &[TemporalFieldKey],
     ) -> TemporalResult<Vec<TemporalFieldKey>> {
-        let mut ignored_keys = Vec::default();
+        let mut ignored_keys = Vec::with_capacity(5);
         if self.is_iso() {
             // NOTE: It is okay for ignored keys to have duplicates?
             for key in keys {

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -26,7 +26,7 @@ use super::{
 
 // TODO: PrepareTemporalFields expects a type error to be thrown when all partial fields are None/undefined.
 /// A partial Date that may or may not be complete.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct PartialDate {
     pub(crate) year: Option<i32>,
     pub(crate) month: Option<i32>,
@@ -637,6 +637,74 @@ mod tests {
             .since(&earlier, DifferenceSettings::default())
             .unwrap();
         assert_eq!(result.days(), 9719.0,);
+    }
+
+    #[test]
+    fn basic_date_with() {
+        let base = Date::new(
+            1976,
+            11,
+            18,
+            Calendar::default(),
+            ArithmeticOverflow::Constrain,
+        )
+        .unwrap();
+
+        // Year
+        let partial = PartialDate {
+            year: Some(2019),
+            ..Default::default()
+        };
+        let with_year = base.with(partial, None).unwrap();
+        assert_eq!(with_year.year().unwrap(), 2019);
+        assert_eq!(with_year.month().unwrap(), 11);
+        assert_eq!(
+            with_year.month_code().unwrap(),
+            TinyAsciiStr::<4>::from_str("M11").unwrap()
+        );
+        assert_eq!(with_year.day().unwrap(), 18);
+
+        // Month
+        let partial = PartialDate {
+            month: Some(5),
+            ..Default::default()
+        };
+        let with_month = base.with(partial, None).unwrap();
+        assert_eq!(with_month.year().unwrap(), 1976);
+        assert_eq!(with_month.month().unwrap(), 5);
+        assert_eq!(
+            with_month.month_code().unwrap(),
+            TinyAsciiStr::<4>::from_str("M05").unwrap()
+        );
+        assert_eq!(with_month.day().unwrap(), 18);
+
+        // Month Code
+        let partial = PartialDate {
+            month_code: Some(MonthCode::Five),
+            ..Default::default()
+        };
+        let with_mc = base.with(partial, None).unwrap();
+        assert_eq!(with_mc.year().unwrap(), 1976);
+        assert_eq!(with_mc.month().unwrap(), 5);
+        assert_eq!(
+            with_mc.month_code().unwrap(),
+            TinyAsciiStr::<4>::from_str("M05").unwrap()
+        );
+        assert_eq!(with_mc.day().unwrap(), 18);
+
+        // Day
+        let partial = PartialDate {
+            day: Some(17),
+            ..Default::default()
+        };
+        let with_day = base.with(partial, None).unwrap();
+        assert_eq!(with_day.year().unwrap(), 1976);
+        assert_eq!(with_day.month().unwrap(), 11);
+        assert_eq!(
+            with_day.month_code().unwrap(),
+            TinyAsciiStr::<4>::from_str("M11").unwrap()
+        );
+        assert_eq!(with_day.day().unwrap(), 17);
     }
 
     // test262/test/built-ins/Temporal/Calendar/prototype/month/argument-string-invalid.js

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -32,6 +32,8 @@ pub struct PartialDate {
     pub(crate) month: Option<i32>,
     pub(crate) month_code: Option<MonthCode>,
     pub(crate) day: Option<i32>,
+    pub(crate) era: Option<TinyAsciiStr<16>>,
+    pub(crate) era_year: Option<i32>,
 }
 
 impl PartialDate {
@@ -41,8 +43,13 @@ impl PartialDate {
         month: Option<i32>,
         month_code: Option<MonthCode>,
         day: Option<i32>,
+        era: Option<TinyAsciiStr<16>>,
+        era_year: Option<i32>,
     ) -> TemporalResult<Self> {
-        if year.is_none() && month.is_none() && month_code.is_none() && day.is_none() {
+        if !(day.is_some()
+            && (month.is_some() || month_code.is_some())
+            && (year.is_some() || (era.is_some() && era_year.is_some())))
+        {
             return Err(TemporalError::r#type()
                 .with_message("A partial date must have at least one defined field."));
         }
@@ -51,6 +58,8 @@ impl PartialDate {
             month,
             month_code,
             day,
+            era,
+            era_year,
         })
     }
 }

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -24,6 +24,13 @@ use super::{
     MonthDay, Time, YearMonth,
 };
 
+pub struct PartialDate {
+    pub year: Option<i32>,
+    pub month: Option<i32>,
+    pub month_code: Option<&str>,
+    pub day: Option<i32>,
+}
+
 /// The native Rust implementation of `Temporal.PlainDate`.
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -45,3 +45,23 @@ pub use year_month::YearMonth;
 pub use year_month::YearMonthFields;
 #[doc(inline)]
 pub use zoneddatetime::ZonedDateTime;
+
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum MonthCode {
+    One = 1,
+    Two,
+    Three,
+    Four,
+    Five,
+    Six,
+    Seven,
+    Eight,
+    Nine,
+    Ten,
+    Eleven,
+    Twelve,
+    Thirteen,
+}
+

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -28,8 +28,10 @@ mod time;
 mod year_month;
 mod zoneddatetime;
 
+use std::str::FromStr;
+
 #[doc(inline)]
-pub use date::Date;
+pub use date::{Date, PartialDate};
 #[doc(inline)]
 pub use datetime::DateTime;
 #[doc(inline)]
@@ -46,8 +48,9 @@ pub use year_month::YearMonthFields;
 #[doc(inline)]
 pub use zoneddatetime::ZonedDateTime;
 
+use crate::TemporalError;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum MonthCode {
     One = 1,
@@ -65,3 +68,69 @@ pub enum MonthCode {
     Thirteen,
 }
 
+impl MonthCode {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::One => "M01",
+            Self::Two => "M02",
+            Self::Three => "M03",
+            Self::Four => "M04",
+            Self::Five => "M05",
+            Self::Six => "M06",
+            Self::Seven => "M07",
+            Self::Eight => "M08",
+            Self::Nine => "M09",
+            Self::Ten => "M10",
+            Self::Eleven => "M11",
+            Self::Twelve => "M12",
+            Self::Thirteen => "M13",
+        }
+    }
+}
+
+impl FromStr for MonthCode {
+    type Err = TemporalError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "M01" => Ok(Self::One),
+            "M02" => Ok(Self::Two),
+            "M03" => Ok(Self::Three),
+            "M04" => Ok(Self::Four),
+            "M05" => Ok(Self::Five),
+            "M06" => Ok(Self::Six),
+            "M07" => Ok(Self::Seven),
+            "M08" => Ok(Self::Eight),
+            "M09" => Ok(Self::Nine),
+            "M10" => Ok(Self::Ten),
+            "M11" => Ok(Self::Eleven),
+            "M12" => Ok(Self::Twelve),
+            "M13" => Ok(Self::Thirteen),
+            _ => {
+                Err(TemporalError::range()
+                    .with_message("monthCode is not within the valid values."))
+            }
+        }
+    }
+}
+
+impl TryFrom<u8> for MonthCode {
+    type Error = TemporalError;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::One),
+            2 => Ok(Self::Two),
+            3 => Ok(Self::Three),
+            4 => Ok(Self::Four),
+            5 => Ok(Self::Five),
+            6 => Ok(Self::Six),
+            7 => Ok(Self::Seven),
+            8 => Ok(Self::Eight),
+            9 => Ok(Self::Nine),
+            10 => Ok(Self::Ten),
+            11 => Ok(Self::Eleven),
+            12 => Ok(Self::Twelve),
+            13 => Ok(Self::Thirteen),
+            _ => Err(TemporalError::range().with_message("Invalid MonthCode value.")),
+        }
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -50,6 +50,7 @@ pub use zoneddatetime::ZonedDateTime;
 
 use crate::TemporalError;
 
+// TODO: Update to account for https://tc39.es/proposal-intl-era-monthcode/
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum MonthCode {

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -4,10 +4,7 @@ use core::fmt;
 use std::str::FromStr;
 
 use crate::{
-    components::{
-        YearMonthFields,
-        {calendar::Calendar, Date, MonthCode, PartialDate},
-    },
+    components::{calendar::Calendar, Date, MonthCode, PartialDate, YearMonthFields},
     error::TemporalError,
     TemporalResult,
 };
@@ -467,13 +464,9 @@ impl TemporalFields {
                 self.get(key.try_into()?)
             };
 
-            let Some(value) = value else {
-                return Err(TemporalError::general(
-                    "Nonexistent TemporalFieldKey used when merging fields.",
-                ));
+            if let Some(value) = value {
+                result.insert(key.try_into()?, value)?;
             };
-
-            result.insert(key.try_into()?, value)?;
         }
 
         Ok(result)

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -4,9 +4,11 @@ use core::fmt;
 use std::str::FromStr;
 
 use crate::{
-    components::{calendar::Calendar, YearMonthFields},
+    components::{
+        YearMonthFields,
+        {calendar::Calendar, Date, MonthCode, PartialDate},
+    },
     error::TemporalError,
-    iso::IsoDate,
     TemporalResult,
 };
 
@@ -210,7 +212,7 @@ pub struct TemporalFields {
     bit_map: FieldMap,
     pub(crate) year: Option<i32>,
     pub(crate) month: Option<i32>,
-    pub(crate) month_code: Option<TinyAsciiStr<4>>,
+    pub(crate) month_code: Option<MonthCode>,
     pub(crate) day: Option<i32>,
     hour: i32,
     minute: i32,
@@ -260,7 +262,8 @@ impl TemporalFields {
             TemporalFieldKey::Year => Some(TemporalFieldValue::Integer(self.year)),
             TemporalFieldKey::Month => Some(TemporalFieldValue::Integer(self.month)),
             TemporalFieldKey::MonthCode => Some(TemporalFieldValue::String(
-                self.month_code.map_or(String::default(), |s| s.to_string()),
+                self.month_code
+                    .map_or(String::default(), |s| s.as_str().to_owned()),
             )),
             TemporalFieldKey::Day => Some(TemporalFieldValue::Integer(self.day)),
             TemporalFieldKey::Hour => Some(TemporalFieldValue::from(self.hour)),
@@ -312,10 +315,7 @@ impl TemporalFields {
                         TemporalError::r#type().with_message("Invalid type for temporal field.")
                     );
                 };
-                self.month_code = Some(
-                    TinyAsciiStr::<4>::from_str(&value)
-                        .map_err(|_| TemporalError::general("Invalid MonthCode id."))?,
-                );
+                self.month_code = Some(MonthCode::from_str(&value)?);
             }
             TemporalFieldKey::Day => {
                 let TemporalFieldValue::Integer(value) = value else {
@@ -436,9 +436,9 @@ impl TemporalFields {
 
         // MonthCode is present and needs to be resolved.
 
-        let month_code_integer = month_code_to_integer(mc)?;
+        let month_code_int: i32 = (mc as u8).into();
 
-        if self.month.is_some() && self.month != Some(month_code_integer) {
+        if self.month.is_some() && self.month != Some(month_code_int) {
             return Err(
                 TemporalError::range().with_message("month and monthCode cannot be resolved.")
             );
@@ -446,7 +446,7 @@ impl TemporalFields {
 
         self.insert(
             TemporalFieldKey::Month,
-            TemporalFieldValue::from(month_code_integer),
+            TemporalFieldValue::from(month_code_int),
         )?;
 
         Ok(())
@@ -455,7 +455,7 @@ impl TemporalFields {
     // TODO: Determine if this should be moved to `Calendar`.
     /// Merges two `TemporalFields` depending on the calendar.
     #[inline]
-    pub fn merge_fields(&self, other: &Self, calendar: Calendar) -> TemporalResult<Self> {
+    pub fn merge_fields(&self, other: &Self, calendar: &Calendar) -> TemporalResult<Self> {
         let add_keys = other.keys().collect::<Vec<_>>();
         let overridden_keys = calendar.field_keys_to_ignore(&add_keys)?;
 
@@ -481,13 +481,55 @@ impl TemporalFields {
     }
 }
 
-impl From<IsoDate> for TemporalFields {
-    fn from(value: IsoDate) -> Self {
+impl From<&Date> for TemporalFields {
+    fn from(value: &Date) -> Self {
         Self {
-            bit_map: FieldMap::YEAR | FieldMap::MONTH | FieldMap::DAY,
-            year: Some(value.year),
-            month: Some(value.month.into()),
-            day: Some(value.day.into()),
+            bit_map: FieldMap::YEAR | FieldMap::MONTH | FieldMap::MONTH_CODE | FieldMap::DAY,
+            year: Some(value.iso.year),
+            month: Some(value.iso.month.into()),
+            month_code: Some(
+                MonthCode::try_from(value.iso.month).expect("Date must always have a valid month."),
+            ),
+            day: Some(value.iso.day.into()),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<PartialDate> for TemporalFields {
+    fn from(value: PartialDate) -> Self {
+        let mut bit_map = FieldMap::empty();
+        if value.year.is_some() {
+            bit_map.set(FieldMap::YEAR, true)
+        };
+        if value.month.is_some() {
+            bit_map.set(FieldMap::MONTH, true)
+        };
+        if value.month_code.is_some() {
+            bit_map.set(FieldMap::MONTH_CODE, true)
+        };
+        if value.day.is_some() {
+            bit_map.set(FieldMap::DAY, true)
+        };
+
+        Self {
+            bit_map,
+            year: value.year,
+            month: value.month,
+            month_code: value.month_code,
+            day: value.day,
+            ..Default::default()
+        }
+    }
+}
+
+// Conversion to `TemporalFields`
+impl From<YearMonthFields> for TemporalFields {
+    fn from(value: YearMonthFields) -> Self {
+        TemporalFields {
+            bit_map: FieldMap::YEAR | FieldMap::MONTH,
+            year: Some(value.0),
+            month: Some(value.1.into()),
             ..Default::default()
         }
     }
@@ -536,7 +578,7 @@ impl Iterator for Values<'_> {
             FieldMap::MONTH_CODE => Some(TemporalFieldValue::String(
                 self.fields
                     .month_code
-                    .map_or(String::default(), |s| s.to_string()),
+                    .map_or(String::default(), |s| s.as_str().to_owned()),
             )),
             FieldMap::DAY => Some(TemporalFieldValue::Integer(self.fields.day)),
             FieldMap::HOUR => Some(TemporalFieldValue::from(self.fields.hour)),
@@ -560,37 +602,6 @@ impl Iterator for Values<'_> {
                     .map_or(String::default(), |s| s.to_string()),
             )),
             _ => None,
-        }
-    }
-}
-
-fn month_code_to_integer(mc: TinyAsciiStr<4>) -> TemporalResult<i32> {
-    match mc.as_str() {
-        "M01" => Ok(1),
-        "M02" => Ok(2),
-        "M03" => Ok(3),
-        "M04" => Ok(4),
-        "M05" => Ok(5),
-        "M06" => Ok(6),
-        "M07" => Ok(7),
-        "M08" => Ok(8),
-        "M09" => Ok(9),
-        "M10" => Ok(10),
-        "M11" => Ok(11),
-        "M12" => Ok(12),
-        "M13" => Ok(13),
-        _ => Err(TemporalError::range().with_message("monthCode is not within the valid values.")),
-    }
-}
-
-// Conversion to `TemporalFields`
-impl From<YearMonthFields> for TemporalFields {
-    fn from(value: YearMonthFields) -> Self {
-        TemporalFields {
-            bit_map: FieldMap::YEAR | FieldMap::MONTH,
-            year: Some(value.0),
-            month: Some(value.1.into()),
-            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
So the title basically says it all as far as implementation. That being said, there's a lot of interpretation going into this that I'd like feedback on if possible, and it could be the right direction or it could be the wrong direction (although I'm leaning the former over the latter).

The main culprit is basically [PrepareTemporalFields](https://tc39.es/proposal-temporal/#sec-temporal-preparetemporalfields).

Background for discussion/sanity check:

Up until recently, I basically thought it would be an implementation detail on the engine/interpreter side, but the thing that always bugged me was the `requiredFields` parameter, being either a List or PARTIAL. We could probably do that to specification, but we might be providing something like `Some(Vec::default())` as an argument, and it basically just felt clunky.

After the recent `TemporalFields` update, I went to implement the `TemporalFields` portion of the `toX` abstract ops in Boa and realized that PARTIAL is never called in the `toX` operations, and it's actually exclusively called in `with` methods. We already have a sort of precedence for partials with `PartialDuration`.

There's some benefits to this: we can have a with method on the native rust side, ideally the complexity that exists in `PrepareTemporalFields` can be made a bit easier to reason about.

Potential negatives: we might end up deviating from the specification as far as the order of when errors are thrown and observability (TBD...potentially a total non-issue) and this is probably opening up a can of worms around what would be the ideal API for a `PartialDate`, `PartialDateTime`, and `PartialTime`.

That all being said, I think the benefits do most likely outweigh any negatives, and it would be really cool to have `with` method implementations. I'm just not entirely sure around the API.

Also, there's an addition of a `MonthCode` enum to make `From<X> for TemporalFields` implementations easier.