### PR TITLE
Add is empty for partialDuration

### DIFF
--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -50,6 +50,15 @@ pub struct PartialDuration {
     pub nanoseconds: Option<FiniteF64>,
 }
 
+impl PartialDuration {
+    /// Returns whether the `PartialDuration` is empty.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
 /// The native Rust implementation of `Temporal.Duration`.
 ///
 /// `Duration` is made up of a `DateDuration` and `TimeDuration` as primarily

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -136,9 +136,3 @@ impl PartialOrd<f64> for FiniteF64 {
         self.0.partial_cmp(other)
     }
 }
-
-impl From<FiniteF64> for f64 {
-    fn from(value: FiniteF64) -> Self {
-        value.0
-    }
-}

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -136,3 +136,9 @@ impl PartialOrd<f64> for FiniteF64 {
         self.0.partial_cmp(other)
     }
 }
+
+impl From<FiniteF64> for f64 {
+    fn from(value: FiniteF64) -> Self {
+        value.0
+    }
+}


### PR DESCRIPTION
Changes here are needed for https://github.com/boa-dev/boa/pull/3856

- We need a way of checking if a partialDuration is empty, I don't know if the changes here would work, open to ideas.
- We  need to be able to convert from Finite64 back to f64 so I've added a From impl (for more info see the errors [here](https://github.com/boa-dev/boa/actions/runs/10188786383/job/28185603728?pr=3856):
