### PR TITLE
Add `PartialTime` and `PartialDateTime` with corresponding `with` methods.

### DIFF
--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -247,14 +247,6 @@ impl Date {
         partial: PartialDate,
         overflow: Option<ArithmeticOverflow>,
     ) -> TemporalResult<Self> {
-        // Validate that the PartialDate is valid partial.
-        if !(partial.day.is_some()
-            && (partial.month.is_some() || partial.month_code.is_some())
-            && (partial.year.is_some() || (partial.era.is_some() && partial.era_year.is_some())))
-        {
-            return Err(TemporalError::r#type()
-                .with_message("A partial date must have at least one defined field."));
-        }
         // 6. Let fieldsResult be ? PrepareCalendarFieldsAndFieldNames(calendarRec, temporalDate, « "day", "month", "monthCode", "year" »).
         let fields = TemporalFields::from(self);
         // 7. Let partialDate be ? PrepareTemporalFields(temporalDateLike, fieldsResult.[[FieldNames]], partial).

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 
 use super::{
     duration::{normalized::NormalizedDurationRecord, TimeDuration},
-    MonthCode, MonthDay, PartialDateTime, Time, YearMonth,
+    MonthCode, MonthDay, Time, YearMonth,
 };
 
 // TODO: PrepareTemporalFields expects a type error to be thrown when all partial fields are None/undefined.
@@ -40,19 +40,6 @@ pub struct PartialDate {
     pub era: Option<TinyAsciiStr<16>>,
     // A potentially set `era_year` field.
     pub era_year: Option<i32>,
-}
-
-impl From<PartialDateTime> for PartialDate {
-    fn from(value: PartialDateTime) -> Self {
-        Self {
-            year: value.year,
-            month: value.month,
-            month_code: value.month_code,
-            day: value.day,
-            era: value.era,
-            era_year: value.era_year,
-        }
-    }
 }
 
 /// The native Rust implementation of `Temporal.PlainDate`.

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -55,34 +55,6 @@ impl From<PartialDateTime> for PartialDate {
     }
 }
 
-impl PartialDate {
-    /// Create a new `PartialDate`
-    pub fn new(
-        year: Option<i32>,
-        month: Option<i32>,
-        month_code: Option<MonthCode>,
-        day: Option<i32>,
-        era: Option<TinyAsciiStr<16>>,
-        era_year: Option<i32>,
-    ) -> TemporalResult<Self> {
-        if !(day.is_some()
-            && (month.is_some() || month_code.is_some())
-            && (year.is_some() || (era.is_some() && era_year.is_some())))
-        {
-            return Err(TemporalError::r#type()
-                .with_message("A partial date must have at least one defined field."));
-        }
-        Ok(Self {
-            year,
-            month,
-            month_code,
-            day,
-            era,
-            era_year,
-        })
-    }
-}
-
 /// The native Rust implementation of `Temporal.PlainDate`.
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -275,6 +247,14 @@ impl Date {
         partial: PartialDate,
         overflow: Option<ArithmeticOverflow>,
     ) -> TemporalResult<Self> {
+        // Validate that the PartialDate is valid partial.
+        if !(partial.day.is_some()
+            && (partial.month.is_some() || partial.month_code.is_some())
+            && (partial.year.is_some() || (partial.era.is_some() && partial.era_year.is_some())))
+        {
+            return Err(TemporalError::r#type()
+                .with_message("A partial date must have at least one defined field."));
+        }
         // 6. Let fieldsResult be ? PrepareCalendarFieldsAndFieldNames(calendarRec, temporalDate, « "day", "month", "monthCode", "year" »).
         let fields = TemporalFields::from(self);
         // 7. Let partialDate be ? PrepareTemporalFields(temporalDateLike, fieldsResult.[[FieldNames]], partial).

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -37,6 +37,26 @@ pub struct PartialDate {
 }
 
 impl PartialDate {
+    pub fn from_parts(
+        year: Option<i32>,
+        month: Option<i32>,
+        month_code: Option<MonthCode>,
+        day: Option<i32>,
+        era: Option<TinyAsciiStr<16>>,
+        era_year: Option<i32>,
+    ) -> Self {
+        Self {
+            year,
+            month,
+            month_code,
+            day,
+            era,
+            era_year,
+        }
+    }
+}
+
+impl PartialDate {
     /// Create a new `PartialDate`
     pub fn new(
         year: Option<i32>,

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -21,37 +21,36 @@ use std::str::FromStr;
 
 use super::{
     duration::{normalized::NormalizedDurationRecord, TimeDuration},
-    MonthCode, MonthDay, Time, YearMonth,
+    MonthCode, MonthDay, PartialDateTime, Time, YearMonth,
 };
 
 // TODO: PrepareTemporalFields expects a type error to be thrown when all partial fields are None/undefined.
 /// A partial Date that may or may not be complete.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PartialDate {
-    pub(crate) year: Option<i32>,
-    pub(crate) month: Option<i32>,
-    pub(crate) month_code: Option<MonthCode>,
-    pub(crate) day: Option<i32>,
-    pub(crate) era: Option<TinyAsciiStr<16>>,
-    pub(crate) era_year: Option<i32>,
+    // A potentially set `year` field.
+    pub year: Option<i32>,
+    // A potentially set `month` field.
+    pub month: Option<i32>,
+    // A potentially set `month_code` field.
+    pub month_code: Option<MonthCode>,
+    // A potentially set `day` field.
+    pub day: Option<i32>,
+    // A potentially set `era` field.
+    pub era: Option<TinyAsciiStr<16>>,
+    // A potentially set `era_year` field.
+    pub era_year: Option<i32>,
 }
 
-impl PartialDate {
-    pub fn from_parts(
-        year: Option<i32>,
-        month: Option<i32>,
-        month_code: Option<MonthCode>,
-        day: Option<i32>,
-        era: Option<TinyAsciiStr<16>>,
-        era_year: Option<i32>,
-    ) -> Self {
+impl From<PartialDateTime> for PartialDate {
+    fn from(value: PartialDateTime) -> Self {
         Self {
-            year,
-            month,
-            month_code,
-            day,
-            era,
-            era_year,
+            year: value.year,
+            month: value.month,
+            month_code: value.month_code,
+            day: value.day,
+            era: value.era,
+            era_year: value.era_year,
         }
     }
 }

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -279,6 +279,16 @@ impl DateTime {
         partial_datetime: PartialDateTime,
         overflow: Option<ArithmeticOverflow>,
     ) -> TemporalResult<Self> {
+        // Validate that the `PartialDate` is a valid, actionable `PartialDate`
+        if !(partial_datetime.day.is_some()
+            && (partial_datetime.month.is_some() || partial_datetime.month_code.is_some())
+            && (partial_datetime.year.is_some() || (partial_datetime.era.is_some() && partial_datetime.era_year.is_some())))
+        {
+            return Err(TemporalError::r#type()
+                .with_message("A partial date must have at least one defined field."));
+        }
+
+        // Determine the Date from the provided fields.
         let fields = TemporalFields::from(self);
         let partial_fields = TemporalFields::from(PartialDate::from(partial_datetime));
 
@@ -289,6 +299,7 @@ impl DateTime {
             overflow.unwrap_or(ArithmeticOverflow::Constrain),
         )?;
 
+        // Determine the `Time` based off the partial values.
         let time = self.iso.time.with(
             partial_datetime.into(),
             overflow.unwrap_or(ArithmeticOverflow::Constrain),

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -18,36 +18,14 @@ use tinystr::TinyAsciiStr;
 use super::{
     calendar::{CalendarDateLike, GetTemporalCalendar},
     duration::normalized::{NormalizedTimeDuration, RelativeRoundResult},
-    Date, Duration, MonthCode, PartialDate, Time,
+    Date, Duration, PartialDate, PartialTime, Time,
 };
 
 /// A partial DateTime record
 #[derive(Debug, Default, Copy, Clone)]
 pub struct PartialDateTime {
-    // A potentially set `year` field.
-    pub year: Option<i32>,
-    // A potentially set `month` field.
-    pub month: Option<i32>,
-    // A potentially set `month_code` field.
-    pub month_code: Option<MonthCode>,
-    // A potentially set `day` field.
-    pub day: Option<i32>,
-    // A potentially set `era` field.
-    pub era: Option<TinyAsciiStr<16>>,
-    // A potentially set `era_year` field.
-    pub era_year: Option<i32>,
-    // A potentially set `hour` field.
-    pub hour: Option<i32>,
-    // A potentially set `minute` field.
-    pub minute: Option<i32>,
-    // A potentially set `second` field.
-    pub second: Option<i32>,
-    // A potentially set `millisecond` field.
-    pub millisecond: Option<i32>,
-    // A potentially set `microsecond` field.
-    pub microsecond: Option<i32>,
-    // A potentially set `nanosecond` field.
-    pub nanosecond: Option<i32>,
+    date: PartialDate,
+    time: PartialTime,
 }
 
 /// The native Rust implementation of `Temporal.PlainDateTime`
@@ -281,7 +259,7 @@ impl DateTime {
     ) -> TemporalResult<Self> {
         // Determine the Date from the provided fields.
         let fields = TemporalFields::from(self);
-        let partial_fields = TemporalFields::from(PartialDate::from(partial_datetime));
+        let partial_fields = TemporalFields::from(partial_datetime.date);
 
         let mut merge_result = fields.merge_fields(&partial_fields, self.calendar())?;
 
@@ -292,7 +270,7 @@ impl DateTime {
 
         // Determine the `Time` based off the partial values.
         let time = self.iso.time.with(
-            partial_datetime.into(),
+            partial_datetime.time,
             overflow.unwrap_or(ArithmeticOverflow::Constrain),
         )?;
 
@@ -602,8 +580,8 @@ mod tests {
 
     use crate::{
         components::{
-            calendar::Calendar, duration::DateDuration, DateTime, Duration, MonthCode,
-            PartialDateTime,
+            calendar::Calendar, duration::DateDuration, DateTime, Duration, MonthCode, PartialDate,
+            PartialDateTime, PartialTime,
         },
         options::{
             DifferenceSettings, RoundingIncrement, RoundingOptions, TemporalRoundingMode,
@@ -658,8 +636,11 @@ mod tests {
 
         // Test year
         let partial = PartialDateTime {
-            year: Some(2019),
-            ..Default::default()
+            date: PartialDate {
+                year: Some(2019),
+                ..Default::default()
+            },
+            time: PartialTime::default(),
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -669,8 +650,11 @@ mod tests {
 
         // Test month
         let partial = PartialDateTime {
-            month: Some(5),
-            ..Default::default()
+            date: PartialDate {
+                month: Some(5),
+                ..Default::default()
+            },
+            time: PartialTime::default(),
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -680,8 +664,11 @@ mod tests {
 
         // Test monthCode
         let partial = PartialDateTime {
-            month_code: Some(MonthCode::Five),
-            ..Default::default()
+            date: PartialDate {
+                month_code: Some(MonthCode::Five),
+                ..Default::default()
+            },
+            time: PartialTime::default(),
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -691,8 +678,11 @@ mod tests {
 
         // Test day
         let partial = PartialDateTime {
-            day: Some(5),
-            ..Default::default()
+            date: PartialDate {
+                day: Some(5),
+                ..Default::default()
+            },
+            time: PartialTime::default(),
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -702,8 +692,11 @@ mod tests {
 
         // Test hour
         let partial = PartialDateTime {
-            hour: Some(5),
-            ..Default::default()
+            date: PartialDate::default(),
+            time: PartialTime {
+                hour: Some(5),
+                ..Default::default()
+            },
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -713,8 +706,11 @@ mod tests {
 
         // Test minute
         let partial = PartialDateTime {
-            minute: Some(5),
-            ..Default::default()
+            date: PartialDate::default(),
+            time: PartialTime {
+                minute: Some(5),
+                ..Default::default()
+            },
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -724,8 +720,11 @@ mod tests {
 
         // Test second
         let partial = PartialDateTime {
-            second: Some(5),
-            ..Default::default()
+            date: PartialDate::default(),
+            time: PartialTime {
+                second: Some(5),
+                ..Default::default()
+            },
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -735,8 +734,11 @@ mod tests {
 
         // Test second
         let partial = PartialDateTime {
-            millisecond: Some(5),
-            ..Default::default()
+            date: PartialDate::default(),
+            time: PartialTime {
+                millisecond: Some(5),
+                ..Default::default()
+            },
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -746,8 +748,11 @@ mod tests {
 
         // Test second
         let partial = PartialDateTime {
-            microsecond: Some(5),
-            ..Default::default()
+            date: PartialDate::default(),
+            time: PartialTime {
+                microsecond: Some(5),
+                ..Default::default()
+            },
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -757,8 +762,11 @@ mod tests {
 
         // Test second
         let partial = PartialDateTime {
-            nanosecond: Some(5),
-            ..Default::default()
+            date: PartialDate::default(),
+            time: PartialTime {
+                nanosecond: Some(5),
+                ..Default::default()
+            },
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -279,15 +279,6 @@ impl DateTime {
         partial_datetime: PartialDateTime,
         overflow: Option<ArithmeticOverflow>,
     ) -> TemporalResult<Self> {
-        // Validate that the `PartialDate` is a valid, actionable `PartialDate`
-        if !(partial_datetime.day.is_some()
-            && (partial_datetime.month.is_some() || partial_datetime.month_code.is_some())
-            && (partial_datetime.year.is_some() || (partial_datetime.era.is_some() && partial_datetime.era_year.is_some())))
-        {
-            return Err(TemporalError::r#type()
-                .with_message("A partial date must have at least one defined field."));
-        }
-
         // Determine the Date from the provided fields.
         let fields = TemporalFields::from(self);
         let partial_fields = TemporalFields::from(PartialDate::from(partial_datetime));

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -8,7 +8,7 @@ use crate::{
         RoundingOptions, TemporalUnit,
     },
     parsers::parse_date_time,
-    temporal_assert, Sign, TemporalError, TemporalResult, TemporalUnwrap,
+    temporal_assert, Sign, TemporalError, TemporalFields, TemporalResult, TemporalUnwrap,
 };
 
 use num_traits::AsPrimitive;
@@ -16,12 +16,68 @@ use std::{cmp::Ordering, str::FromStr};
 use tinystr::TinyAsciiStr;
 
 use super::{
-    calendar::{CalendarDateLike, GetTemporalCalendar}, duration::normalized::{NormalizedTimeDuration, RelativeRoundResult}, Date, Duration, PartialDate, PartialTime, Time
+    calendar::{CalendarDateLike, GetTemporalCalendar},
+    duration::normalized::{NormalizedTimeDuration, RelativeRoundResult},
+    Date, Duration, MonthCode, PartialDate, PartialTime, Time,
 };
 
+/// A partial DateTime record
 pub struct PartialDateTime {
     date: PartialDate,
     time: PartialTime,
+}
+
+impl PartialDateTime {
+    /// Creates a `PartialDateTime` from its individual parts.
+    #[inline]
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_parts(
+        year: Option<i32>,
+        month: Option<i32>,
+        month_code: Option<MonthCode>,
+        day: Option<i32>,
+        era: Option<TinyAsciiStr<16>>,
+        era_year: Option<i32>,
+        hour: Option<i32>,
+        minute: Option<i32>,
+        second: Option<i32>,
+        millisecond: Option<i32>,
+        microsecond: Option<i32>,
+        nanosecond: Option<i32>,
+    ) -> Self {
+        Self {
+            date: PartialDate::from_parts(year, month, month_code, day, era, era_year),
+            time: PartialTime::from_parts(
+                hour,
+                minute,
+                second,
+                millisecond,
+                microsecond,
+                nanosecond,
+            ),
+        }
+    }
+
+    /// Creates a `PartialDateTime` from a `PartialDate`.
+    #[inline]
+    #[must_use]
+    pub fn from_partial_date(partial: PartialDate) -> Self {
+        Self {
+            date: partial,
+            time: PartialTime::default(),
+        }
+    }
+
+    /// Creates a `PartialDateTime` from a `PartialTime`.
+    #[inline]
+    #[must_use]
+    pub fn from_partial_time(partial: PartialTime) -> Self {
+        Self {
+            date: PartialDate::default(),
+            time: partial,
+        }
+    }
 }
 
 /// The native Rust implementation of `Temporal.PlainDateTime`
@@ -244,6 +300,33 @@ impl DateTime {
             IsoDateTime::new(iso_date, iso_time)?,
             calendar,
         ))
+    }
+
+    /// Creates a new `DateTime` with the fields of a `PartialDateTime`.
+    #[inline]
+    pub fn with(
+        &self,
+        partial_datetime: PartialDateTime,
+        overflow: Option<ArithmeticOverflow>,
+    ) -> TemporalResult<Self> {
+        let fields = TemporalFields::from(self);
+        let partial_fields = TemporalFields::from(partial_datetime.date);
+
+        let mut merge_result = fields.merge_fields(&partial_fields, self.calendar())?;
+
+        let result_date = self.calendar.date_from_fields(
+            &mut merge_result,
+            overflow.unwrap_or(ArithmeticOverflow::Constrain),
+        )?;
+
+        let time = self.iso.time.with(
+            partial_datetime.time,
+            overflow.unwrap_or(ArithmeticOverflow::Constrain),
+        )?;
+
+        let iso_datetime = IsoDateTime::new(result_date.iso, time)?;
+
+        Ok(Self::new_unchecked(iso_datetime, self.calendar().clone()))
     }
 
     /// Creates a new `DateTime` from the current `DateTime` and the provided `Time`.
@@ -543,9 +626,13 @@ impl FromStr for DateTime {
 mod tests {
     use std::str::FromStr;
 
+    use tinystr::{tinystr, TinyAsciiStr};
+
     use crate::{
-        components::{calendar::Calendar, duration::DateDuration, Duration},
-        iso::{IsoDate, IsoTime},
+        components::{
+            calendar::Calendar, duration::DateDuration, DateTime, Duration, MonthCode, PartialDate,
+            PartialDateTime, PartialTime,
+        },
         options::{
             DifferenceSettings, RoundingIncrement, RoundingOptions, TemporalRoundingMode,
             TemporalUnit,
@@ -553,7 +640,21 @@ mod tests {
         primitive::FiniteF64,
     };
 
-    use super::DateTime;
+    fn assert_datetime(
+        dt: DateTime,
+        fields: (i32, u8, TinyAsciiStr<4>, u8, u8, u8, u8, u16, u16, u16),
+    ) {
+        assert_eq!(dt.year().unwrap(), fields.0);
+        assert_eq!(dt.month().unwrap(), fields.1);
+        assert_eq!(dt.month_code().unwrap(), fields.2);
+        assert_eq!(dt.day().unwrap(), fields.3);
+        assert_eq!(dt.hour(), fields.4);
+        assert_eq!(dt.minute(), fields.5);
+        assert_eq!(dt.second(), fields.6);
+        assert_eq!(dt.millisecond(), fields.7);
+        assert_eq!(dt.microsecond(), fields.8);
+        assert_eq!(dt.nanosecond(), fields.9);
+    }
 
     #[test]
     #[allow(clippy::float_cmp)]
@@ -576,6 +677,152 @@ mod tests {
 
         assert!(negative_limit.is_err());
         assert!(positive_limit.is_err());
+    }
+
+    #[test]
+    fn basic_with_test() {
+        let pdt =
+            DateTime::new(1976, 11, 18, 15, 23, 30, 123, 456, 789, Calendar::default()).unwrap();
+
+        // Test year
+        let partial = PartialDateTime {
+            date: PartialDate {
+                year: Some(2019),
+                ..Default::default()
+            },
+            time: PartialTime::default(),
+        };
+        let result = pdt.with(partial, None).unwrap();
+        assert_datetime(
+            result,
+            (2019, 11, tinystr!(4, "M11"), 18, 15, 23, 30, 123, 456, 789),
+        );
+
+        // Test month
+        let partial = PartialDateTime {
+            date: PartialDate {
+                month: Some(5),
+                ..Default::default()
+            },
+            time: PartialTime::default(),
+        };
+        let result = pdt.with(partial, None).unwrap();
+        assert_datetime(
+            result,
+            (1976, 5, tinystr!(4, "M05"), 18, 15, 23, 30, 123, 456, 789),
+        );
+
+        // Test monthCode
+        let partial = PartialDateTime {
+            date: PartialDate {
+                month_code: Some(MonthCode::Five),
+                ..Default::default()
+            },
+            time: PartialTime::default(),
+        };
+        let result = pdt.with(partial, None).unwrap();
+        assert_datetime(
+            result,
+            (1976, 5, tinystr!(4, "M05"), 18, 15, 23, 30, 123, 456, 789),
+        );
+
+        // Test day
+        let partial = PartialDateTime {
+            date: PartialDate {
+                day: Some(5),
+                ..Default::default()
+            },
+            time: PartialTime::default(),
+        };
+        let result = pdt.with(partial, None).unwrap();
+        assert_datetime(
+            result,
+            (1976, 11, tinystr!(4, "M11"), 5, 15, 23, 30, 123, 456, 789),
+        );
+
+        // Test hour
+        let partial = PartialDateTime {
+            date: PartialDate::default(),
+            time: PartialTime {
+                hour: Some(5),
+                ..Default::default()
+            },
+        };
+        let result = pdt.with(partial, None).unwrap();
+        assert_datetime(
+            result,
+            (1976, 11, tinystr!(4, "M11"), 18, 5, 23, 30, 123, 456, 789),
+        );
+
+        // Test minute
+        let partial = PartialDateTime {
+            date: PartialDate::default(),
+            time: PartialTime {
+                minute: Some(5),
+                ..Default::default()
+            },
+        };
+        let result = pdt.with(partial, None).unwrap();
+        assert_datetime(
+            result,
+            (1976, 11, tinystr!(4, "M11"), 18, 15, 5, 30, 123, 456, 789),
+        );
+
+        // Test second
+        let partial = PartialDateTime {
+            date: PartialDate::default(),
+            time: PartialTime {
+                second: Some(5),
+                ..Default::default()
+            },
+        };
+        let result = pdt.with(partial, None).unwrap();
+        assert_datetime(
+            result,
+            (1976, 11, tinystr!(4, "M11"), 18, 15, 23, 5, 123, 456, 789),
+        );
+
+        // Test second
+        let partial = PartialDateTime {
+            date: PartialDate::default(),
+            time: PartialTime {
+                millisecond: Some(5),
+                ..Default::default()
+            },
+        };
+        let result = pdt.with(partial, None).unwrap();
+        assert_datetime(
+            result,
+            (1976, 11, tinystr!(4, "M11"), 18, 15, 23, 30, 5, 456, 789),
+        );
+
+        // Test second
+        let partial = PartialDateTime {
+            date: PartialDate::default(),
+            time: PartialTime {
+                microsecond: Some(5),
+                ..Default::default()
+            },
+        };
+        let result = pdt.with(partial, None).unwrap();
+        assert_datetime(
+            result,
+            (1976, 11, tinystr!(4, "M11"), 18, 15, 23, 30, 123, 5, 789),
+        );
+
+        // Test second
+        let partial = PartialDateTime {
+            date: PartialDate::default(),
+            time: PartialTime {
+                nanosecond: Some(5),
+                ..Default::default()
+            },
+        };
+        let result = pdt.with(partial, None).unwrap();
+        assert_datetime(
+            result,
+            (1976, 11, tinystr!(4, "M11"), 18, 15, 23, 30, 123, 456, 5),
+        );
     }
 
     // options-undefined.js
@@ -635,47 +882,15 @@ mod tests {
             DateTime::new(2019, 10, 29, 10, 46, 38, 271, 986, 102, Calendar::default()).unwrap();
 
         let result = dt.subtract(&Duration::hour(FiniteF64(12.0)), None).unwrap();
-
-        assert_eq!(
-            result.iso.date,
-            IsoDate {
-                year: 2019,
-                month: 10,
-                day: 28
-            }
-        );
-        assert_eq!(
-            result.iso.time,
-            IsoTime {
-                hour: 22,
-                minute: 46,
-                second: 38,
-                millisecond: 271,
-                microsecond: 986,
-                nanosecond: 102
-            }
+        assert_datetime(
+            result,
+            (2019, 10, tinystr!(4, "M10"), 28, 22, 46, 38, 271, 986, 102),
         );
 
         let result = dt.add(&Duration::hour(FiniteF64(-12.0)), None).unwrap();
-
-        assert_eq!(
-            result.iso.date,
-            IsoDate {
-                year: 2019,
-                month: 10,
-                day: 28
-            }
-        );
-        assert_eq!(
-            result.iso.time,
-            IsoTime {
-                hour: 22,
-                minute: 46,
-                second: 38,
-                millisecond: 271,
-                microsecond: 986,
-                nanosecond: 102
-            }
+        assert_datetime(
+            result,
+            (2019, 10, tinystr!(4, "M10"), 28, 22, 46, 38, 271, 986, 102),
         );
     }
 

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -18,66 +18,36 @@ use tinystr::TinyAsciiStr;
 use super::{
     calendar::{CalendarDateLike, GetTemporalCalendar},
     duration::normalized::{NormalizedTimeDuration, RelativeRoundResult},
-    Date, Duration, MonthCode, PartialDate, PartialTime, Time,
+    Date, Duration, MonthCode, PartialDate, Time,
 };
 
 /// A partial DateTime record
+#[derive(Debug, Default, Copy, Clone)]
 pub struct PartialDateTime {
-    date: PartialDate,
-    time: PartialTime,
-}
-
-impl PartialDateTime {
-    /// Creates a `PartialDateTime` from its individual parts.
-    #[inline]
-    #[must_use]
-    #[allow(clippy::too_many_arguments)]
-    pub fn from_parts(
-        year: Option<i32>,
-        month: Option<i32>,
-        month_code: Option<MonthCode>,
-        day: Option<i32>,
-        era: Option<TinyAsciiStr<16>>,
-        era_year: Option<i32>,
-        hour: Option<i32>,
-        minute: Option<i32>,
-        second: Option<i32>,
-        millisecond: Option<i32>,
-        microsecond: Option<i32>,
-        nanosecond: Option<i32>,
-    ) -> Self {
-        Self {
-            date: PartialDate::from_parts(year, month, month_code, day, era, era_year),
-            time: PartialTime::from_parts(
-                hour,
-                minute,
-                second,
-                millisecond,
-                microsecond,
-                nanosecond,
-            ),
-        }
-    }
-
-    /// Creates a `PartialDateTime` from a `PartialDate`.
-    #[inline]
-    #[must_use]
-    pub fn from_partial_date(partial: PartialDate) -> Self {
-        Self {
-            date: partial,
-            time: PartialTime::default(),
-        }
-    }
-
-    /// Creates a `PartialDateTime` from a `PartialTime`.
-    #[inline]
-    #[must_use]
-    pub fn from_partial_time(partial: PartialTime) -> Self {
-        Self {
-            date: PartialDate::default(),
-            time: partial,
-        }
-    }
+    // A potentially set `year` field.
+    pub year: Option<i32>,
+    // A potentially set `month` field.
+    pub month: Option<i32>,
+    // A potentially set `month_code` field.
+    pub month_code: Option<MonthCode>,
+    // A potentially set `day` field.
+    pub day: Option<i32>,
+    // A potentially set `era` field.
+    pub era: Option<TinyAsciiStr<16>>,
+    // A potentially set `era_year` field.
+    pub era_year: Option<i32>,
+    // A potentially set `hour` field.
+    pub hour: Option<i32>,
+    // A potentially set `minute` field.
+    pub minute: Option<i32>,
+    // A potentially set `second` field.
+    pub second: Option<i32>,
+    // A potentially set `millisecond` field.
+    pub millisecond: Option<i32>,
+    // A potentially set `microsecond` field.
+    pub microsecond: Option<i32>,
+    // A potentially set `nanosecond` field.
+    pub nanosecond: Option<i32>,
 }
 
 /// The native Rust implementation of `Temporal.PlainDateTime`
@@ -310,7 +280,7 @@ impl DateTime {
         overflow: Option<ArithmeticOverflow>,
     ) -> TemporalResult<Self> {
         let fields = TemporalFields::from(self);
-        let partial_fields = TemporalFields::from(partial_datetime.date);
+        let partial_fields = TemporalFields::from(PartialDate::from(partial_datetime));
 
         let mut merge_result = fields.merge_fields(&partial_fields, self.calendar())?;
 
@@ -320,7 +290,7 @@ impl DateTime {
         )?;
 
         let time = self.iso.time.with(
-            partial_datetime.time,
+            partial_datetime.into(),
             overflow.unwrap_or(ArithmeticOverflow::Constrain),
         )?;
 
@@ -630,8 +600,8 @@ mod tests {
 
     use crate::{
         components::{
-            calendar::Calendar, duration::DateDuration, DateTime, Duration, MonthCode, PartialDate,
-            PartialDateTime, PartialTime,
+            calendar::Calendar, duration::DateDuration, DateTime, Duration, MonthCode,
+            PartialDateTime,
         },
         options::{
             DifferenceSettings, RoundingIncrement, RoundingOptions, TemporalRoundingMode,
@@ -686,11 +656,8 @@ mod tests {
 
         // Test year
         let partial = PartialDateTime {
-            date: PartialDate {
-                year: Some(2019),
-                ..Default::default()
-            },
-            time: PartialTime::default(),
+            year: Some(2019),
+            ..Default::default()
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -700,11 +667,8 @@ mod tests {
 
         // Test month
         let partial = PartialDateTime {
-            date: PartialDate {
-                month: Some(5),
-                ..Default::default()
-            },
-            time: PartialTime::default(),
+            month: Some(5),
+            ..Default::default()
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -714,11 +678,8 @@ mod tests {
 
         // Test monthCode
         let partial = PartialDateTime {
-            date: PartialDate {
-                month_code: Some(MonthCode::Five),
-                ..Default::default()
-            },
-            time: PartialTime::default(),
+            month_code: Some(MonthCode::Five),
+            ..Default::default()
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -728,11 +689,8 @@ mod tests {
 
         // Test day
         let partial = PartialDateTime {
-            date: PartialDate {
-                day: Some(5),
-                ..Default::default()
-            },
-            time: PartialTime::default(),
+            day: Some(5),
+            ..Default::default()
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -742,11 +700,8 @@ mod tests {
 
         // Test hour
         let partial = PartialDateTime {
-            date: PartialDate::default(),
-            time: PartialTime {
-                hour: Some(5),
-                ..Default::default()
-            },
+            hour: Some(5),
+            ..Default::default()
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -756,11 +711,8 @@ mod tests {
 
         // Test minute
         let partial = PartialDateTime {
-            date: PartialDate::default(),
-            time: PartialTime {
-                minute: Some(5),
-                ..Default::default()
-            },
+            minute: Some(5),
+            ..Default::default()
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -770,11 +722,8 @@ mod tests {
 
         // Test second
         let partial = PartialDateTime {
-            date: PartialDate::default(),
-            time: PartialTime {
-                second: Some(5),
-                ..Default::default()
-            },
+            second: Some(5),
+            ..Default::default()
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -784,11 +733,8 @@ mod tests {
 
         // Test second
         let partial = PartialDateTime {
-            date: PartialDate::default(),
-            time: PartialTime {
-                millisecond: Some(5),
-                ..Default::default()
-            },
+            millisecond: Some(5),
+            ..Default::default()
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -798,11 +744,8 @@ mod tests {
 
         // Test second
         let partial = PartialDateTime {
-            date: PartialDate::default(),
-            time: PartialTime {
-                microsecond: Some(5),
-                ..Default::default()
-            },
+            microsecond: Some(5),
+            ..Default::default()
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(
@@ -812,11 +755,8 @@ mod tests {
 
         // Test second
         let partial = PartialDateTime {
-            date: PartialDate::default(),
-            time: PartialTime {
-                nanosecond: Some(5),
-                ..Default::default()
-            },
+            nanosecond: Some(5),
+            ..Default::default()
         };
         let result = pdt.with(partial, None).unwrap();
         assert_datetime(

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -16,10 +16,13 @@ use std::{cmp::Ordering, str::FromStr};
 use tinystr::TinyAsciiStr;
 
 use super::{
-    calendar::{CalendarDateLike, GetTemporalCalendar},
-    duration::normalized::{NormalizedTimeDuration, RelativeRoundResult},
-    Date, Duration, Time,
+    calendar::{CalendarDateLike, GetTemporalCalendar}, duration::normalized::{NormalizedTimeDuration, RelativeRoundResult}, Date, Duration, PartialDate, PartialTime, Time
 };
+
+pub struct PartialDateTime {
+    date: PartialDate,
+    time: PartialTime,
+}
 
 /// The native Rust implementation of `Temporal.PlainDateTime`
 #[non_exhaustive]

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -33,7 +33,7 @@ use std::str::FromStr;
 #[doc(inline)]
 pub use date::{Date, PartialDate};
 #[doc(inline)]
-pub use datetime::DateTime;
+pub use datetime::{DateTime, PartialDateTime};
 #[doc(inline)]
 pub use duration::Duration;
 #[doc(inline)]
@@ -41,7 +41,7 @@ pub use instant::Instant;
 #[doc(inline)]
 pub use month_day::MonthDay;
 #[doc(inline)]
-pub use time::{Time, PartialTime};
+pub use time::{PartialTime, Time};
 #[doc(inline)]
 pub use year_month::YearMonth;
 pub use year_month::YearMonthFields;

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -41,7 +41,7 @@ pub use instant::Instant;
 #[doc(inline)]
 pub use month_day::MonthDay;
 #[doc(inline)]
-pub use time::Time;
+pub use time::{Time, PartialTime};
 #[doc(inline)]
 pub use year_month::YearMonth;
 pub use year_month::YearMonthFields;

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -12,7 +12,7 @@ use crate::{
     Sign, TemporalError, TemporalResult,
 };
 
-use super::{duration::normalized::NormalizedTimeDuration, DateTime, PartialDateTime};
+use super::{duration::normalized::NormalizedTimeDuration, DateTime};
 
 use std::str::FromStr;
 
@@ -31,19 +31,6 @@ pub struct PartialTime {
     pub microsecond: Option<i32>,
     // A potentially set `nanosecond` field.
     pub nanosecond: Option<i32>,
-}
-
-impl From<PartialDateTime> for PartialTime {
-    fn from(value: PartialDateTime) -> Self {
-        Self {
-            hour: value.hour,
-            minute: value.minute,
-            second: value.second,
-            millisecond: value.millisecond,
-            microsecond: value.microsecond,
-            nanosecond: value.nanosecond,
-        }
-    }
 }
 
 /// The native Rust implementation of `Temporal.PlainTime`.

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -16,6 +16,7 @@ use super::{duration::normalized::NormalizedTimeDuration, DateTime};
 
 use std::str::FromStr;
 
+/// A `PartialTime` represents partially filled `Time` fields.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PartialTime {
     pub(crate) hour: Option<i32>,
@@ -27,6 +28,9 @@ pub struct PartialTime {
 }
 
 impl PartialTime {
+    /// Creates a `PartialTime` from its parts.
+    #[inline]
+    #[must_use]
     pub fn from_parts(
         hour: Option<i32>,
         minute: Option<i32>,
@@ -191,15 +195,12 @@ impl Time {
     pub fn with(
         &self,
         partial: PartialTime,
-        overflow: Option<ArithmeticOverflow>
+        overflow: Option<ArithmeticOverflow>,
     ) -> TemporalResult<Self> {
-        let hour = partial.hour.unwrap_or(self.hour().into());
-        let minute = partial.minute.unwrap_or(self.minute().into());
-        let second = partial.second.unwrap_or(self.second().into());
-        let millisecond = partial.millisecond.unwrap_or(self.millisecond().into());
-        let microsecond = partial.microsecond.unwrap_or(self.microsecond().into());
-        let nanosecond = partial.nanosecond.unwrap_or(self.nanosecond().into());
-        Self::new(hour, minute, second, millisecond, microsecond, nanosecond, overflow.unwrap_or(ArithmeticOverflow::Constrain))
+        let iso = self
+            .iso
+            .with(partial, overflow.unwrap_or(ArithmeticOverflow::Constrain))?;
+        Ok(Self::new_unchecked(iso))
     }
 
     /// Returns the internal `hour` field.

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -12,40 +12,36 @@ use crate::{
     Sign, TemporalError, TemporalResult,
 };
 
-use super::{duration::normalized::NormalizedTimeDuration, DateTime};
+use super::{duration::normalized::NormalizedTimeDuration, DateTime, PartialDateTime};
 
 use std::str::FromStr;
 
 /// A `PartialTime` represents partially filled `Time` fields.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PartialTime {
-    pub(crate) hour: Option<i32>,
-    pub(crate) minute: Option<i32>,
-    pub(crate) second: Option<i32>,
-    pub(crate) millisecond: Option<i32>,
-    pub(crate) microsecond: Option<i32>,
-    pub(crate) nanosecond: Option<i32>,
+    // A potentially set `hour` field.
+    pub hour: Option<i32>,
+    // A potentially set `minute` field.
+    pub minute: Option<i32>,
+    // A potentially set `second` field.
+    pub second: Option<i32>,
+    // A potentially set `millisecond` field.
+    pub millisecond: Option<i32>,
+    // A potentially set `microsecond` field.
+    pub microsecond: Option<i32>,
+    // A potentially set `nanosecond` field.
+    pub nanosecond: Option<i32>,
 }
 
-impl PartialTime {
-    /// Creates a `PartialTime` from its parts.
-    #[inline]
-    #[must_use]
-    pub fn from_parts(
-        hour: Option<i32>,
-        minute: Option<i32>,
-        second: Option<i32>,
-        millisecond: Option<i32>,
-        microsecond: Option<i32>,
-        nanosecond: Option<i32>,
-    ) -> Self {
+impl From<PartialDateTime> for PartialTime {
+    fn from(value: PartialDateTime) -> Self {
         Self {
-            hour,
-            minute,
-            second,
-            millisecond,
-            microsecond,
-            nanosecond,
+            hour: value.hour,
+            minute: value.minute,
+            second: value.second,
+            millisecond: value.millisecond,
+            microsecond: value.microsecond,
+            nanosecond: value.nanosecond,
         }
     }
 }

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -16,6 +16,36 @@ use super::{duration::normalized::NormalizedTimeDuration, DateTime};
 
 use std::str::FromStr;
 
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PartialTime {
+    pub(crate) hour: Option<i32>,
+    pub(crate) minute: Option<i32>,
+    pub(crate) second: Option<i32>,
+    pub(crate) millisecond: Option<i32>,
+    pub(crate) microsecond: Option<i32>,
+    pub(crate) nanosecond: Option<i32>,
+}
+
+impl PartialTime {
+    pub fn from_parts(
+        hour: Option<i32>,
+        minute: Option<i32>,
+        second: Option<i32>,
+        millisecond: Option<i32>,
+        microsecond: Option<i32>,
+        nanosecond: Option<i32>,
+    ) -> Self {
+        Self {
+            hour,
+            minute,
+            second,
+            millisecond,
+            microsecond,
+            nanosecond,
+        }
+    }
+}
+
 /// The native Rust implementation of `Temporal.PlainTime`.
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -156,6 +186,20 @@ impl Time {
             overflow,
         )?;
         Ok(Self::new_unchecked(time))
+    }
+
+    pub fn with(
+        &self,
+        partial: PartialTime,
+        overflow: Option<ArithmeticOverflow>
+    ) -> TemporalResult<Self> {
+        let hour = partial.hour.unwrap_or(self.hour().into());
+        let minute = partial.minute.unwrap_or(self.minute().into());
+        let second = partial.second.unwrap_or(self.second().into());
+        let millisecond = partial.millisecond.unwrap_or(self.millisecond().into());
+        let microsecond = partial.microsecond.unwrap_or(self.microsecond().into());
+        let nanosecond = partial.nanosecond.unwrap_or(self.nanosecond().into());
+        Self::new(hour, minute, second, millisecond, microsecond, nanosecond, overflow.unwrap_or(ArithmeticOverflow::Constrain))
     }
 
     /// Returns the internal `hour` field.

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use std::str::FromStr;
 
 use crate::{
-    components::{calendar::Calendar, Date, MonthCode, PartialDate, YearMonthFields},
+    components::{calendar::Calendar, Date, DateTime, MonthCode, PartialDate, YearMonthFields},
     error::TemporalError,
     TemporalResult,
 };
@@ -470,6 +470,22 @@ impl TemporalFields {
         }
 
         Ok(result)
+    }
+}
+
+impl From<&DateTime> for TemporalFields {
+    fn from(value: &DateTime) -> Self {
+        Self {
+            bit_map: FieldMap::YEAR | FieldMap::MONTH | FieldMap::MONTH_CODE | FieldMap::DAY,
+            year: Some(value.iso.date.year),
+            month: Some(value.iso.date.month.into()),
+            month_code: Some(
+                MonthCode::try_from(value.iso.date.month)
+                    .expect("Date must always have a valid month."),
+            ),
+            day: Some(value.iso.date.day.into()),
+            ..Default::default()
+        }
     }
 }
 

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -21,7 +21,7 @@ use crate::{
             normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
             DateDuration, TimeDuration,
         },
-        Date, Duration,
+        Date, Duration, PartialTime,
     },
     error::TemporalError,
     options::{ArithmeticOverflow, ResolvedRoundingOptions, TemporalUnit},
@@ -563,6 +563,30 @@ impl IsoTime {
                 ))
             }
         }
+    }
+
+    /// Creates a new `Time` with the fields provided from a `PartialTime`.
+    #[inline]
+    pub(crate) fn with(
+        &self,
+        partial: PartialTime,
+        overflow: ArithmeticOverflow,
+    ) -> TemporalResult<Self> {
+        let hour = partial.hour.unwrap_or(self.hour.into());
+        let minute = partial.minute.unwrap_or(self.minute.into());
+        let second = partial.second.unwrap_or(self.second.into());
+        let millisecond = partial.millisecond.unwrap_or(self.millisecond.into());
+        let microsecond = partial.microsecond.unwrap_or(self.microsecond.into());
+        let nanosecond = partial.nanosecond.unwrap_or(self.nanosecond.into());
+        Self::new(
+            hour,
+            minute,
+            second,
+            millisecond,
+            microsecond,
+            nanosecond,
+            overflow,
+        )
     }
 
     /// Returns an `IsoTime` set to 12:00:00


### PR DESCRIPTION
This continues the work on implementing `with` methods with the approach from #89 by adding the same type of records to `DateTime` and `Time`.