### PR TITLE
General API cleanup and adjustments

### DIFF
--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -232,9 +232,9 @@ impl From<&[String]> for CalendarFieldsType {
 /// The `DateLike` objects that can be provided to the `CalendarProtocol`.
 #[derive(Debug)]
 pub enum CalendarDateLike<'a> {
-    /// Represents a `DateTime`.
+    /// Represents a `PlainDateTime`.
     DateTime(&'a PlainDateTime),
-    /// Represents a `Date`.
+    /// Represents a `PlainDate`.
     Date(&'a PlainDate),
     /// Represents a `PlainYearMonth`.
     YearMonth(&'a PlainYearMonth),

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use crate::{
     components::{
         duration::{DateDuration, TimeDuration},
-        Date, DateTime, Duration, MonthDay, YearMonth,
+        PlainDate, PlainDateTime, Duration, PlainMonthDay, PlainYearMonth,
     },
     iso::{IsoDate, IsoDateSlots},
     options::{ArithmeticOverflow, TemporalUnit},
@@ -201,14 +201,15 @@ impl FromStr for Calendar {
     }
 }
 
+// TODO: Potentially dead code.
 /// Designate the type of `CalendarFields` needed
 #[derive(Debug, Clone, Copy)]
 pub enum CalendarFieldsType {
-    /// Whether the Fields should return for a Date.
+    /// Whether the Fields should return for a PlainDate.
     Date,
-    /// Whether the Fields should return for a YearMonth.
+    /// Whether the Fields should return for a PlainYearMonth.
     YearMonth,
-    /// Whether the Fields should return for a MonthDay.
+    /// Whether the Fields should return for a PlainMonthDay.
     MonthDay,
 }
 
@@ -232,13 +233,13 @@ impl From<&[String]> for CalendarFieldsType {
 #[derive(Debug)]
 pub enum CalendarDateLike<'a> {
     /// Represents a `DateTime`.
-    DateTime(&'a DateTime),
+    DateTime(&'a PlainDateTime),
     /// Represents a `Date`.
-    Date(&'a Date),
-    /// Represents a `YearMonth`.
-    YearMonth(&'a YearMonth),
-    /// Represents a `MonthDay`.
-    MonthDay(&'a MonthDay),
+    Date(&'a PlainDate),
+    /// Represents a `PlainYearMonth`.
+    YearMonth(&'a PlainYearMonth),
+    /// Represents a `PlainMonthDay`.
+    MonthDay(&'a PlainMonthDay),
 }
 
 impl CalendarDateLike<'_> {
@@ -275,12 +276,12 @@ impl Calendar {
         &self,
         partial: &PartialDate,
         overflow: ArithmeticOverflow,
-    ) -> TemporalResult<Date> {
+    ) -> TemporalResult<PlainDate> {
         let fields = self.resolve_partial_date_fields(partial, overflow)?;
 
         if self.is_iso() {
             // Resolve month and monthCode;
-            return Date::new(
+            return PlainDate::new_with_overflow(
                 fields.era_year.year,
                 fields.month_code.as_iso_month_integer()?.into(),
                 fields.day,
@@ -296,7 +297,7 @@ impl Calendar {
             fields.day as u8, // TODO: FIX
         )?;
         let iso = self.0.date_to_iso(&calendar_date);
-        Date::new(
+        PlainDate::new_with_overflow(
             iso.year().number,
             iso.month().ordinal as i32,
             iso.day_of_month().0 as i32,
@@ -305,15 +306,15 @@ impl Calendar {
         )
     }
 
-    /// `CalendarMonthDayFromFields`
+    /// `CalendarPlainMonthDayFromFields`
     pub fn month_day_from_partial(
         &self,
         partial: &PartialDate,
         overflow: ArithmeticOverflow,
-    ) -> TemporalResult<MonthDay> {
+    ) -> TemporalResult<PlainMonthDay> {
         let resolved_fields = self.resolve_partial_date_fields(partial, overflow)?;
         if self.is_iso() {
-            return MonthDay::new(
+            return PlainMonthDay::new_with_overflow(
                 resolved_fields.month_code.as_iso_month_integer()?.into(),
                 resolved_fields.day,
                 self.clone(),
@@ -326,15 +327,15 @@ impl Calendar {
         Err(TemporalError::range().with_message("Not yet implemented/supported."))
     }
 
-    /// `CalendarYearMonthFromFields`
+    /// `CalendarPlainYearMonthFromFields`
     pub fn year_month_from_partial(
         &self,
         partial: &PartialDate,
         overflow: ArithmeticOverflow,
-    ) -> TemporalResult<YearMonth> {
+    ) -> TemporalResult<PlainYearMonth> {
         let resolved_fields = self.resolve_partial_date_fields(partial, overflow)?;
         if self.is_iso() {
-            return YearMonth::new(
+            return PlainYearMonth::new_with_overflow(
                 resolved_fields.era_year.year,
                 resolved_fields.month_code.as_iso_month_integer()?.into(),
                 Some(resolved_fields.day),
@@ -351,7 +352,7 @@ impl Calendar {
             resolved_fields.day as u8, // NOTE: Not the best idea, probably action overflow behavior prior to this.
         )?;
         let iso = self.0.date_to_iso(&calendar_date);
-        YearMonth::new(
+        PlainYearMonth::new_with_overflow(
             iso.year().number,
             iso.month().ordinal as i32,
             Some(iso.day_of_month().0 as i32),
@@ -363,10 +364,10 @@ impl Calendar {
     /// `CalendarDateAdd`
     pub fn date_add(
         &self,
-        date: &Date,
+        date: &PlainDate,
         duration: &Duration,
         overflow: ArithmeticOverflow,
-    ) -> TemporalResult<Date> {
+    ) -> TemporalResult<PlainDate> {
         if self.is_iso() {
             // 8. Let norm be NormalizeTimeDuration(duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]],
             // duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]]).
@@ -386,12 +387,11 @@ impl Calendar {
                 overflow,
             )?;
             // 11. Return ? CreateTemporalDate(result.[[Year]], result.[[Month]], result.[[Day]], "iso8601").
-            return Date::new(
+            return PlainDate::try_new(
                 result.year,
                 result.month.into(),
                 result.day.into(),
                 date.calendar().clone(),
-                ArithmeticOverflow::Reject,
             );
         }
 
@@ -401,8 +401,8 @@ impl Calendar {
     /// `CalendarDateUntil`
     pub fn date_until(
         &self,
-        one: &Date,
-        two: &Date,
+        one: &PlainDate,
+        two: &PlainDate,
         largest_unit: TemporalUnit,
     ) -> TemporalResult<Duration> {
         if self.is_iso() {
@@ -712,14 +712,14 @@ impl Calendar {
     }
 }
 
-impl From<Date> for Calendar {
-    fn from(value: Date) -> Self {
+impl From<PlainDate> for Calendar {
+    fn from(value: PlainDate) -> Self {
         value.calendar().clone()
     }
 }
 
-impl From<DateTime> for Calendar {
-    fn from(value: DateTime) -> Self {
+impl From<PlainDateTime> for Calendar {
+    fn from(value: PlainDateTime) -> Self {
         value.calendar().clone()
     }
 }
@@ -730,27 +730,27 @@ impl From<ZonedDateTime> for Calendar {
     }
 }
 
-impl From<MonthDay> for Calendar {
-    fn from(value: MonthDay) -> Self {
+impl From<PlainMonthDay> for Calendar {
+    fn from(value: PlainMonthDay) -> Self {
         value.calendar().clone()
     }
 }
 
-impl From<YearMonth> for Calendar {
-    fn from(value: YearMonth) -> Self {
+impl From<PlainYearMonth> for Calendar {
+    fn from(value: PlainYearMonth) -> Self {
         value.calendar().clone()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{components::Date, iso::IsoDate, options::TemporalUnit};
+    use crate::{components::PlainDate, iso::IsoDate, options::TemporalUnit};
 
     use super::Calendar;
 
     #[test]
     fn date_until_largest_year() {
-        // tests format: (Date one, Date two, Duration result)
+        // tests format: (Date one, PlainDate two, Duration result)
         let tests = [
             ((2021, 7, 16), (2021, 7, 16), (0, 0, 0, 0, 0, 0, 0, 0, 0, 0)),
             ((2021, 7, 16), (2021, 7, 17), (0, 0, 0, 1, 0, 0, 0, 0, 0, 0)),
@@ -996,11 +996,11 @@ mod tests {
         let calendar = Calendar::default();
 
         for test in tests {
-            let first = Date::new_unchecked(
+            let first = PlainDate::new_unchecked(
                 IsoDate::new_unchecked(test.0 .0, test.0 .1, test.0 .2),
                 calendar.clone(),
             );
-            let second = Date::new_unchecked(
+            let second = PlainDate::new_unchecked(
                 IsoDate::new_unchecked(test.1 .0, test.1 .1, test.1 .2),
                 calendar.clone(),
             );

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use crate::{
     components::{
         duration::{DateDuration, TimeDuration},
-        PlainDate, PlainDateTime, Duration, PlainMonthDay, PlainYearMonth,
+        Duration, PlainDate, PlainDateTime, PlainMonthDay, PlainYearMonth,
     },
     iso::{IsoDate, IsoDateSlots},
     options::{ArithmeticOverflow, TemporalUnit},

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -176,8 +176,12 @@ impl PlainDate {
         }
 
         // 4. Let overflow be ? ToTemporalOverflow(options).
-        // 5. Let norm be NormalizeTimeDuration(duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]]).
-        // 6. Let days be duration.[[Days]] + BalanceTimeDuration(norm, "day").[[Days]].
+        // 5. Let norm be NormalizeTimeDuration(duration.[[Hours]],
+        //    duration.[[Minutes]], duration.[[Seconds]],
+        //    duration.[[Milliseconds]], duration.[[Microseconds]],
+        //    duration.[[Nanoseconds]]).
+        // 6. Let days be duration.[[Days]] + BalanceTimeDuration(norm,
+        //    "day").[[Days]].
         let days = duration.days().checked_add(
             &TimeDuration::from_normalized(duration.time().to_normalized(), TemporalUnit::Day)?.0,
         )?;
@@ -271,7 +275,7 @@ impl PlainDate {
         let date_duration = if !rounding_granularity_is_noop {
             // a. Let destEpochNs be GetUTCEpochNanoseconds(other.[[ISOYear]], other.[[ISOMonth]], other.[[ISODay]], 0, 0, 0, 0, 0, 0).
             let dest_epoch_ns = other.iso.as_nanoseconds().temporal_unwrap()?;
-            // b. Let dateTime be ISO PlainDate-Time Record { [[Year]]: temporalDate.[[ISOYear]], [[Month]]: temporalDate.[[ISOMonth]], [[Day]]: temporalDate.[[ISODay]], [[Hour]]: 0, [[Minute]]: 0, [[Second]]: 0, [[Millisecond]]: 0, [[Microsecond]]: 0, [[Nanosecond]]: 0 }.
+            // b. Let dateTime be ISO Date-Time Record { [[Year]]: temporalDate.[[ISOYear]], [[Month]]: temporalDate.[[ISOMonth]], [[Day]]: temporalDate.[[ISODay]], [[Hour]]: 0, [[Minute]]: 0, [[Second]]: 0, [[Millisecond]]: 0, [[Microsecond]]: 0, [[Nanosecond]]: 0 }.
             let dt = PlainDateTime::new_unchecked(
                 IsoDateTime::new_unchecked(self.iso, IsoTime::default()),
                 self.calendar.clone(),

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -6,7 +6,7 @@ use crate::{
     components::{
         calendar::{Calendar, CalendarDateLike, GetTemporalCalendar},
         duration::DateDuration,
-        PlainDateTime, Duration,
+        Duration, PlainDateTime,
     },
     iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime},
     options::{
@@ -297,31 +297,19 @@ impl PlainDate {
 
 impl PlainDate {
     /// Creates a new `PlainDate` automatically constraining any values that may be invalid.
-    pub fn new(
-        year: i32,
-        month: i32,
-        day: i32,
-        calendar: Calendar,
-    ) -> TemporalResult<Self> {
+    pub fn new(year: i32, month: i32, day: i32, calendar: Calendar) -> TemporalResult<Self> {
         Self::new_with_overflow(year, month, day, calendar, ArithmeticOverflow::Constrain)
     }
 
-
     /// Creates a new `PlainDate` rejecting any date that may be invalid.
-    pub fn try_new(
-        year: i32,
-        month: i32,
-        day: i32,
-        calendar: Calendar,
-    ) -> TemporalResult<Self> {
+    pub fn try_new(year: i32, month: i32, day: i32, calendar: Calendar) -> TemporalResult<Self> {
         Self::new_with_overflow(year, month, day, calendar, ArithmeticOverflow::Reject)
     }
 
     /// Creates a new `PlainDate` with the specified overflow.
-    /// 
+    ///
     /// This operation is the public facing API to Temporal's `RegulateIsoDate`
     #[inline]
-    #[must_use]
     pub fn new_with_overflow(
         year: i32,
         month: i32,
@@ -717,12 +705,7 @@ mod tests {
 
     #[test]
     fn date_with_empty_error() {
-        let base = PlainDate::new(
-            1976,
-            11,
-            18,
-            Calendar::default(),
-        ).unwrap();
+        let base = PlainDate::new(1976, 11, 18, Calendar::default()).unwrap();
 
         let err = base.with(PartialDate::default(), None);
         assert!(err.is_err());
@@ -730,12 +713,7 @@ mod tests {
 
     #[test]
     fn basic_date_with() {
-        let base = PlainDate::new(
-            1976,
-            11,
-            18,
-            Calendar::default(),
-        ).unwrap();
+        let base = PlainDate::new(1976, 11, 18, Calendar::default()).unwrap();
 
         // Year
         let partial = PartialDate {

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -18,7 +18,7 @@ use tinystr::TinyAsciiStr;
 use super::{
     calendar::{CalendarDateLike, GetTemporalCalendar},
     duration::normalized::{NormalizedTimeDuration, RelativeRoundResult},
-    PlainDate, Duration, PartialDate, PartialTime, PlainTime,
+    Duration, PartialDate, PartialTime, PlainDate, PlainTime,
 };
 
 /// A partial PlainDateTime record
@@ -222,6 +222,7 @@ impl PlainDateTime {
 
 impl PlainDateTime {
     /// Creates a new `DateTime`, constraining any arguments that into a valid range.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         year: i32,
         month: i32,
@@ -234,10 +235,23 @@ impl PlainDateTime {
         nanosecond: i32,
         calendar: Calendar,
     ) -> TemporalResult<Self> {
-        Self::new_with_overflow(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar, ArithmeticOverflow::Constrain)
+        Self::new_with_overflow(
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            millisecond,
+            microsecond,
+            nanosecond,
+            calendar,
+            ArithmeticOverflow::Constrain,
+        )
     }
 
     /// Creates a new `DateTime`, rejecting any arguments that are not in a valid range.
+    #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         year: i32,
         month: i32,
@@ -250,7 +264,19 @@ impl PlainDateTime {
         nanosecond: i32,
         calendar: Calendar,
     ) -> TemporalResult<Self> {
-        Self::new_with_overflow(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar, ArithmeticOverflow::Reject)
+        Self::new_with_overflow(
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            millisecond,
+            microsecond,
+            nanosecond,
+            calendar,
+            ArithmeticOverflow::Reject,
+        )
     }
 
     /// Creates a new `DateTime` with the provided [`ArithmeticOverflow`] option.
@@ -267,7 +293,7 @@ impl PlainDateTime {
         microsecond: i32,
         nanosecond: i32,
         calendar: Calendar,
-        overflow: ArithmeticOverflow
+        overflow: ArithmeticOverflow,
     ) -> TemporalResult<Self> {
         let iso_date = IsoDate::new_with_overflow(year, month, day, overflow)?;
         let iso_time = IsoTime::new(
@@ -628,8 +654,8 @@ mod tests {
 
     use crate::{
         components::{
-            calendar::Calendar, duration::DateDuration, PlainDateTime, Duration, PartialDate,
-            PartialDateTime, PartialTime,
+            calendar::Calendar, duration::DateDuration, Duration, PartialDate, PartialDateTime,
+            PartialTime, PlainDateTime,
         },
         options::{
             DifferenceSettings, RoundingIncrement, RoundingOptions, TemporalRoundingMode,
@@ -671,7 +697,8 @@ mod tests {
             0,
             Calendar::from_str("iso8601").unwrap(),
         );
-        let positive_limit = PlainDateTime::try_new(275_760, 9, 14, 0, 0, 0, 0, 0, 0, Calendar::default());
+        let positive_limit =
+            PlainDateTime::try_new(275_760, 9, 14, 0, 0, 0, 0, 0, 0, Calendar::default());
 
         assert!(negative_limit.is_err());
         assert!(positive_limit.is_err());
@@ -680,7 +707,8 @@ mod tests {
     #[test]
     fn basic_with_test() {
         let pdt =
-            PlainDateTime::try_new(1976, 11, 18, 15, 23, 30, 123, 456, 789, Calendar::default()).unwrap();
+            PlainDateTime::try_new(1976, 11, 18, 15, 23, 30, 123, 456, 789, Calendar::default())
+                .unwrap();
 
         // Test year
         let partial = PartialDateTime {
@@ -826,7 +854,8 @@ mod tests {
     #[test]
     fn datetime_with_empty_partial() {
         let pdt =
-            PlainDateTime::try_new(2020, 1, 31, 12, 34, 56, 987, 654, 321, Calendar::default()).unwrap();
+            PlainDateTime::try_new(2020, 1, 31, 12, 34, 56, 987, 654, 321, Calendar::default())
+                .unwrap();
 
         let err = pdt.with(PartialDateTime::default(), None);
         assert!(err.is_err());
@@ -836,7 +865,8 @@ mod tests {
     #[test]
     fn datetime_add_test() {
         let pdt =
-            PlainDateTime::try_new(2020, 1, 31, 12, 34, 56, 987, 654, 321, Calendar::default()).unwrap();
+            PlainDateTime::try_new(2020, 1, 31, 12, 34, 56, 987, 654, 321, Calendar::default())
+                .unwrap();
 
         let result = pdt
             .add(
@@ -861,7 +891,8 @@ mod tests {
     #[test]
     fn datetime_subtract_test() {
         let pdt =
-            PlainDateTime::try_new(2000, 3, 31, 12, 34, 56, 987, 654, 321, Calendar::default()).unwrap();
+            PlainDateTime::try_new(2000, 3, 31, 12, 34, 56, 987, 654, 321, Calendar::default())
+                .unwrap();
 
         let result = pdt
             .subtract(
@@ -886,7 +917,8 @@ mod tests {
     #[test]
     fn datetime_subtract_hour_overflows() {
         let dt =
-            PlainDateTime::try_new(2019, 10, 29, 10, 46, 38, 271, 986, 102, Calendar::default()).unwrap();
+            PlainDateTime::try_new(2019, 10, 29, 10, 46, 38, 271, 986, 102, Calendar::default())
+                .unwrap();
 
         let result = dt.subtract(&Duration::hour(FiniteF64(12.0)), None).unwrap();
         assert_datetime(
@@ -917,9 +949,11 @@ mod tests {
     #[test]
     fn dt_until_basic() {
         let earlier =
-            PlainDateTime::try_new(2019, 1, 8, 8, 22, 36, 123, 456, 789, Calendar::default()).unwrap();
+            PlainDateTime::try_new(2019, 1, 8, 8, 22, 36, 123, 456, 789, Calendar::default())
+                .unwrap();
         let later =
-            PlainDateTime::try_new(2021, 9, 7, 12, 39, 40, 987, 654, 321, Calendar::default()).unwrap();
+            PlainDateTime::try_new(2021, 9, 7, 12, 39, 40, 987, 654, 321, Calendar::default())
+                .unwrap();
 
         let settings = create_diff_setting(TemporalUnit::Hour, 3, TemporalRoundingMode::HalfExpand);
         let result = earlier.until(&later, settings).unwrap();
@@ -939,9 +973,11 @@ mod tests {
     #[test]
     fn dt_since_basic() {
         let earlier =
-            PlainDateTime::try_new(2019, 1, 8, 8, 22, 36, 123, 456, 789, Calendar::default()).unwrap();
+            PlainDateTime::try_new(2019, 1, 8, 8, 22, 36, 123, 456, 789, Calendar::default())
+                .unwrap();
         let later =
-            PlainDateTime::try_new(2021, 9, 7, 12, 39, 40, 987, 654, 321, Calendar::default()).unwrap();
+            PlainDateTime::try_new(2021, 9, 7, 12, 39, 40, 987, 654, 321, Calendar::default())
+                .unwrap();
 
         let settings = create_diff_setting(TemporalUnit::Hour, 3, TemporalRoundingMode::HalfExpand);
         let result = later.since(&earlier, settings).unwrap();
@@ -960,17 +996,18 @@ mod tests {
 
     #[test]
     fn dt_round_basic() {
-        let assert_datetime = |dt: PlainDateTime, expected: (i32, u8, u8, u8, u8, u8, u16, u16, u16)| {
-            assert_eq!(dt.iso_year(), expected.0);
-            assert_eq!(dt.iso_month(), expected.1);
-            assert_eq!(dt.iso_day(), expected.2);
-            assert_eq!(dt.hour(), expected.3);
-            assert_eq!(dt.minute(), expected.4);
-            assert_eq!(dt.second(), expected.5);
-            assert_eq!(dt.millisecond(), expected.6);
-            assert_eq!(dt.microsecond(), expected.7);
-            assert_eq!(dt.nanosecond(), expected.8);
-        };
+        let assert_datetime =
+            |dt: PlainDateTime, expected: (i32, u8, u8, u8, u8, u8, u16, u16, u16)| {
+                assert_eq!(dt.iso_year(), expected.0);
+                assert_eq!(dt.iso_month(), expected.1);
+                assert_eq!(dt.iso_day(), expected.2);
+                assert_eq!(dt.hour(), expected.3);
+                assert_eq!(dt.minute(), expected.4);
+                assert_eq!(dt.second(), expected.5);
+                assert_eq!(dt.millisecond(), expected.6);
+                assert_eq!(dt.microsecond(), expected.7);
+                assert_eq!(dt.nanosecond(), expected.8);
+            };
 
         let gen_rounding_options = |smallest: TemporalUnit, increment: u32| -> RoundingOptions {
             RoundingOptions {
@@ -981,7 +1018,8 @@ mod tests {
             }
         };
         let dt =
-            PlainDateTime::try_new(1976, 11, 18, 14, 23, 30, 123, 456, 789, Calendar::default()).unwrap();
+            PlainDateTime::try_new(1976, 11, 18, 14, 23, 30, 123, 456, 789, Calendar::default())
+                .unwrap();
 
         let result = dt
             .round(gen_rounding_options(TemporalUnit::Hour, 4))

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -1,7 +1,7 @@
 //! This module implements `Duration` along with it's methods and components.
 
 use crate::{
-    components::{DateTime, Time},
+    components::{PlainDateTime, PlainTime},
     iso::{IsoDateTime, IsoTime},
     options::{RelativeTo, ResolvedRoundingOptions, RoundingOptions, TemporalUnit},
     primitive::FiniteF64,
@@ -20,6 +20,7 @@ mod time;
 #[cfg(test)]
 mod tests;
 
+// TODO: Determine visibility.
 #[doc(inline)]
 pub use date::DateDuration;
 #[doc(inline)]
@@ -490,7 +491,7 @@ impl Duration {
             || self.days() == 0.0;
 
         // 34. If zonedRelativeTo is not undefined and plainDateTimeOrRelativeToWillBeUsed is true, then
-        let _precalculated: Option<DateTime> = if relative_to.zdt.is_some() && pdtr_will_be_used {
+        let _precalculated: Option<PlainDateTime> = if relative_to.zdt.is_some() && pdtr_will_be_used {
             return Err(TemporalError::general("Not yet implemented."));
             // a. NOTE: The above conditions mean that the corresponding Temporal.PlainDateTime or
             // Temporal.PlainDate for zonedRelativeTo will be used in one of the operations below.
@@ -519,7 +520,7 @@ impl Duration {
         // 39. Else if plainRelativeTo is not undefined, then
         } else if let Some(plain_date) = relative_to.date {
             // a. Let targetTime be AddTime(0, 0, 0, 0, 0, 0, norm).
-            let (balanced_days, time) = Time::default().add_normalized_time_duration(norm);
+            let (balanced_days, time) = PlainTime::default().add_normalized_time_duration(norm);
             // b. Let dateDuration be ? CreateTemporalDuration(duration.[[Years]], duration.[[Months]], duration.[[Weeks]],
             // duration.[[Days]] + targetTime.[[Days]], 0, 0, 0, 0, 0, 0).
             let date_duration = DateDuration::new(
@@ -532,12 +533,12 @@ impl Duration {
             // c. Let targetDate be ? AddDate(calendarRec, plainRelativeTo, dateDuration).
             let target_date = plain_date.add_date(&Duration::from(date_duration), None)?;
 
-            let plain_dt = DateTime::new_unchecked(
+            let plain_dt = PlainDateTime::new_unchecked(
                 IsoDateTime::new(plain_date.iso, IsoTime::default())?,
                 plain_date.calendar().clone(),
             );
 
-            let target_dt = DateTime::new_unchecked(
+            let target_dt = PlainDateTime::new_unchecked(
                 IsoDateTime::new(target_date.iso, time.iso)?,
                 target_date.calendar().clone(),
             );
@@ -565,7 +566,7 @@ impl Duration {
             );
 
             // c. Let roundRecord be ? RoundTimeDuration(duration.[[Days]], norm, roundingIncrement, smallestUnit, roundingMode).
-            let (round_record, _) = TimeDuration::round(self.days(), &norm, resolved_options)?;
+            let (round_record, _) = norm.round(self.days(), resolved_options)?;
             // d. Let normWithDays be ? Add24HourDaysToNormalizedTimeDuration(roundRecord.[[NormalizedDuration]].[[NormalizedTime]],
             // roundRecord.[[NormalizedDuration]].[[Days]]).
             let norm_with_days = round_record

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -491,17 +491,18 @@ impl Duration {
             || self.days() == 0.0;
 
         // 34. If zonedRelativeTo is not undefined and plainDateTimeOrRelativeToWillBeUsed is true, then
-        let _precalculated: Option<PlainDateTime> = if relative_to.zdt.is_some() && pdtr_will_be_used {
-            return Err(TemporalError::general("Not yet implemented."));
-            // a. NOTE: The above conditions mean that the corresponding Temporal.PlainDateTime or
-            // Temporal.PlainDate for zonedRelativeTo will be used in one of the operations below.
-            // b. Let instant be ! CreateTemporalInstant(zonedRelativeTo.[[Nanoseconds]]).
-            // c. Set precalculatedPlainDateTime to ? GetPlainDateTimeFor(timeZoneRec, instant, zonedRelativeTo.[[Calendar]]).
-            // d. Set plainRelativeTo to ! CreateTemporalDate(precalculatedPlainDateTime.[[ISOYear]],
-            // precalculatedPlainDateTime.[[ISOMonth]], precalculatedPlainDateTime.[[ISODay]], zonedRelativeTo.[[Calendar]]).
-        } else {
-            None
-        };
+        let _precalculated: Option<PlainDateTime> =
+            if relative_to.zdt.is_some() && pdtr_will_be_used {
+                return Err(TemporalError::general("Not yet implemented."));
+                // a. NOTE: The above conditions mean that the corresponding Temporal.PlainDateTime or
+                // Temporal.PlainDate for zonedRelativeTo will be used in one of the operations below.
+                // b. Let instant be ! CreateTemporalInstant(zonedRelativeTo.[[Nanoseconds]]).
+                // c. Set precalculatedPlainDateTime to ? GetPlainDateTimeFor(timeZoneRec, instant, zonedRelativeTo.[[Calendar]]).
+                // d. Set plainRelativeTo to ! CreateTemporalDate(precalculatedPlainDateTime.[[ISOYear]],
+                // precalculatedPlainDateTime.[[ISOMonth]], precalculatedPlainDateTime.[[ISODay]], zonedRelativeTo.[[Calendar]]).
+            } else {
+                None
+            };
         // 35. Let calendarRec be ? CreateCalendarMethodsRecordFromRelativeTo(plainRelativeTo, zonedRelativeTo, « DATE-ADD, DATE-UNTIL »).
 
         // 36. Let norm be NormalizeTimeDuration(duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]],

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -2,12 +2,12 @@
 
 use std::{num::NonZeroU128, ops::Add};
 
-use num_traits::{AsPrimitive, Euclid};
+use num_traits::{AsPrimitive, FromPrimitive, Euclid};
 
 use crate::{
-    components::{tz::TimeZone, Date, DateTime},
+    components::{tz::TimeZone, PlainDate, PlainDateTime},
     iso::IsoDate,
-    options::{ArithmeticOverflow, ResolvedRoundingOptions, TemporalRoundingMode, TemporalUnit},
+    options::{ResolvedRoundingOptions, TemporalRoundingMode, TemporalUnit},
     primitive::FiniteF64,
     rounding::{IncrementRounder, Round},
     TemporalError, TemporalResult, TemporalUnwrap, NS_PER_DAY,
@@ -124,8 +124,74 @@ impl NormalizedTimeDuration {
         Ok(Self(result))
     }
 
+    /// The equivalent of `RoundTimeDuration` abstract operation.
+    pub(crate) fn round(
+        &self,
+        days: FiniteF64,
+        options: ResolvedRoundingOptions,
+    ) -> TemporalResult<(NormalizedDurationRecord, Option<i128>)> {
+        // 1. Assert: IsCalendarUnit(unit) is false.
+        let (days, norm, total) = match options.smallest_unit {
+            // 2. If unit is "day", then
+            TemporalUnit::Day => {
+                // a. Let fractionalDays be days + DivideNormalizedTimeDuration(norm, nsPerDay).
+                let fractional_days = days.checked_add(&FiniteF64(self.as_fractional_days()))?;
+                // b. Set days to RoundNumberToIncrement(fractionalDays, increment, roundingMode).
+                let days = IncrementRounder::from_potentially_negative_parts(
+                    fractional_days.0,
+                    options.increment.as_extended_increment(),
+                )?
+                .round(options.rounding_mode);
+                // c. Let total be fractionalDays.
+                // d. Set norm to ZeroTimeDuration().
+                (
+                    FiniteF64::try_from(days)?,
+                    NormalizedTimeDuration::default(),
+                    i128::from_f64(fractional_days.0),
+                )
+            }
+            // 3. Else,
+            TemporalUnit::Hour
+            | TemporalUnit::Minute
+            | TemporalUnit::Second
+            | TemporalUnit::Millisecond
+            | TemporalUnit::Microsecond
+            | TemporalUnit::Nanosecond => {
+                // a. Assert: The value in the "Category" column of the row of Table 22 whose "Singular" column contains unit, is time.
+                // b. Let divisor be the value in the "Length in Nanoseconds" column of the row of Table 22 whose "Singular" column contains unit.
+                let divisor = options.smallest_unit.as_nanoseconds().temporal_unwrap()?;
+                // c. Let total be DivideNormalizedTimeDuration(norm, divisor).
+                let total = self.divide(divisor as i64);
+                let non_zero_divisor = unsafe { NonZeroU128::new_unchecked(divisor.into()) };
+                // d. Set norm to ? RoundNormalizedTimeDurationToIncrement(norm, divisor × increment, roundingMode).
+                let norm = self.round_inner(
+                    non_zero_divisor
+                        .checked_mul(options.increment.as_extended_increment())
+                        .temporal_unwrap()?,
+                    options.rounding_mode,
+                )?;
+                (days, norm, Some(total))
+            }
+            _ => return Err(TemporalError::assert()),
+        };
+
+        // 4. Return the Record { [[NormalizedDuration]]: ? CreateNormalizedDurationRecord(0, 0, 0, days, norm), [[Total]]: total  }.
+        Ok((
+            NormalizedDurationRecord::new(
+                DateDuration::new(
+                    FiniteF64::default(),
+                    FiniteF64::default(),
+                    FiniteF64::default(),
+                    days,
+                )?,
+                norm,
+            )?,
+            total,
+        ))
+    }
+
     /// Round the current `NormalizedTimeDuration`.
-    pub(super) fn round(
+    pub(super) fn round_inner(
         &self,
         increment: NonZeroU128,
         mode: TemporalRoundingMode,
@@ -221,7 +287,7 @@ impl NormalizedDurationRecord {
         &self,
         sign: Sign,
         dest_epoch_ns: i128,
-        dt: &DateTime,
+        dt: &PlainDateTime,
         tz: Option<TimeZone>, // ???
         options: ResolvedRoundingOptions,
     ) -> TemporalResult<NudgeRecord> {
@@ -312,22 +378,20 @@ impl NormalizedDurationRecord {
 
                 // c. Let weeksStart be ! CreateTemporalDate(isoResult1.[[Year]], isoResult1.[[Month]], isoResult1.[[Day]],
                 // calendarRec.[[Receiver]]).
-                let weeks_start = Date::new(
+                let weeks_start = PlainDate::try_new(
                     iso_one.year,
                     iso_one.month.into(),
                     iso_one.day.into(),
                     dt.calendar().clone(),
-                    ArithmeticOverflow::Reject,
                 )?;
 
                 // d. Let weeksEnd be ! CreateTemporalDate(isoResult2.[[Year]], isoResult2.[[Month]], isoResult2.[[Day]],
                 // calendarRec.[[Receiver]]).
-                let weeks_end = Date::new(
+                let weeks_end = PlainDate::try_new(
                     iso_two.year,
                     iso_two.month.into(),
                     iso_two.day.into(),
                     dt.calendar().clone(),
-                    ArithmeticOverflow::Reject,
                 )?;
 
                 // e. Let untilOptions be OrdinaryObjectCreate(null).
@@ -541,7 +605,7 @@ impl NormalizedDurationRecord {
         let total = norm.divide(unit_length as i64);
 
         // 5. Let roundedNorm be ? RoundNormalizedTimeDurationToIncrement(norm, unitLength × increment, roundingMode).
-        let rounded_norm = norm.round(
+        let rounded_norm = norm.round_inner(
             unsafe {
                 NonZeroU128::new_unchecked(unit_length.into())
                     .checked_mul(options.increment.as_extended_increment())
@@ -607,7 +671,7 @@ impl NormalizedDurationRecord {
         &self,
         sign: Sign,
         nudge_epoch_ns: i128,
-        date_time: &DateTime,
+        date_time: &PlainDateTime,
         tz: Option<TimeZone>,
         largest_unit: TemporalUnit,
         smallest_unit: TemporalUnit,
@@ -744,7 +808,7 @@ impl NormalizedDurationRecord {
     pub(crate) fn round_relative_duration(
         &self,
         dest_epoch_ns: i128,
-        dt: &DateTime,
+        dt: &PlainDateTime,
         tz: Option<TimeZone>,
         options: ResolvedRoundingOptions,
     ) -> TemporalResult<RelativeRoundResult> {

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -2,7 +2,7 @@
 
 use std::{num::NonZeroU128, ops::Add};
 
-use num_traits::{AsPrimitive, FromPrimitive, Euclid};
+use num_traits::{AsPrimitive, Euclid, FromPrimitive};
 
 use crate::{
     components::{tz::TimeZone, PlainDate, PlainDateTime},

--- a/src/components/duration/tests.rs
+++ b/src/components/duration/tests.rs
@@ -35,12 +35,7 @@ fn basic_positive_floor_rounding_v2() {
         FiniteF64(500.0),
     )
     .unwrap();
-    let forward_date = PlainDate::new(
-        2020,
-        4,
-        1,
-        Calendar::from_str("iso8601").unwrap(),
-    ).unwrap();
+    let forward_date = PlainDate::new(2020, 4, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
     let relative_forward = RelativeTo {
         date: Some(&forward_date),
@@ -111,12 +106,8 @@ fn basic_negative_floor_rounding_v2() {
         FiniteF64(500.0),
     )
     .unwrap();
-    let backward_date = PlainDate::new(
-        2020,
-        12,
-        1,
-        Calendar::from_str("iso8601").unwrap(),
-    ).unwrap();
+    let backward_date =
+        PlainDate::new(2020, 12, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
     let relative_backward = RelativeTo {
         date: Some(&backward_date),
@@ -187,12 +178,7 @@ fn basic_positive_ceil_rounding() {
         FiniteF64(500.0),
     )
     .unwrap();
-    let forward_date = PlainDate::new(
-        2020,
-        4,
-        1,
-        Calendar::from_str("iso8601").unwrap(),
-    ).unwrap();
+    let forward_date = PlainDate::new(2020, 4, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
     let relative_forward = RelativeTo {
         date: Some(&forward_date),
@@ -262,12 +248,8 @@ fn basic_negative_ceil_rounding() {
         FiniteF64(500.0),
     )
     .unwrap();
-    let backward_date = PlainDate::new(
-        2020,
-        12,
-        1,
-        Calendar::from_str("iso8601").unwrap(),
-    ).unwrap();
+    let backward_date =
+        PlainDate::new(2020, 12, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
     let relative_backward = RelativeTo {
         date: Some(&backward_date),
         zdt: None,
@@ -337,12 +319,7 @@ fn basic_positive_expand_rounding() {
         FiniteF64(500.0),
     )
     .unwrap();
-    let forward_date = PlainDate::new(
-        2020,
-        4,
-        1,
-        Calendar::from_str("iso8601").unwrap(),
-    ).unwrap();
+    let forward_date = PlainDate::new(2020, 4, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
     let relative_forward = RelativeTo {
         date: Some(&forward_date),
@@ -413,12 +390,8 @@ fn basic_negative_expand_rounding() {
     )
     .unwrap();
 
-    let backward_date = PlainDate::new(
-        2020,
-        12,
-        1,
-        Calendar::from_str("iso8601").unwrap(),
-    ).unwrap();
+    let backward_date =
+        PlainDate::new(2020, 12, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
     let relative_backward = RelativeTo {
         date: Some(&backward_date),
@@ -485,12 +458,7 @@ fn rounding_increment_non_integer() {
         )
         .unwrap(),
     );
-    let binding = PlainDate::new(
-        2000,
-        1,
-        1,
-        Calendar::from_str("iso8601").unwrap(),
-    ).unwrap();
+    let binding = PlainDate::new(2000, 1, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
     let relative_to = RelativeTo {
         date: Some(&binding),
         zdt: None,

--- a/src/components/duration/tests.rs
+++ b/src/components/duration/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    components::{calendar::Calendar, Date},
-    options::{ArithmeticOverflow, RoundingIncrement, TemporalRoundingMode},
+    components::{calendar::Calendar, PlainDate},
+    options::{RoundingIncrement, TemporalRoundingMode},
 };
 
 use super::*;
@@ -35,14 +35,12 @@ fn basic_positive_floor_rounding_v2() {
         FiniteF64(500.0),
     )
     .unwrap();
-    let forward_date = Date::new(
+    let forward_date = PlainDate::new(
         2020,
         4,
         1,
         Calendar::from_str("iso8601").unwrap(),
-        ArithmeticOverflow::Reject,
-    )
-    .unwrap();
+    ).unwrap();
 
     let relative_forward = RelativeTo {
         date: Some(&forward_date),
@@ -113,14 +111,12 @@ fn basic_negative_floor_rounding_v2() {
         FiniteF64(500.0),
     )
     .unwrap();
-    let backward_date = Date::new(
+    let backward_date = PlainDate::new(
         2020,
         12,
         1,
         Calendar::from_str("iso8601").unwrap(),
-        ArithmeticOverflow::Reject,
-    )
-    .unwrap();
+    ).unwrap();
 
     let relative_backward = RelativeTo {
         date: Some(&backward_date),
@@ -191,14 +187,12 @@ fn basic_positive_ceil_rounding() {
         FiniteF64(500.0),
     )
     .unwrap();
-    let forward_date = Date::new(
+    let forward_date = PlainDate::new(
         2020,
         4,
         1,
         Calendar::from_str("iso8601").unwrap(),
-        ArithmeticOverflow::Reject,
-    )
-    .unwrap();
+    ).unwrap();
 
     let relative_forward = RelativeTo {
         date: Some(&forward_date),
@@ -268,14 +262,12 @@ fn basic_negative_ceil_rounding() {
         FiniteF64(500.0),
     )
     .unwrap();
-    let backward_date = Date::new(
+    let backward_date = PlainDate::new(
         2020,
         12,
         1,
         Calendar::from_str("iso8601").unwrap(),
-        ArithmeticOverflow::Reject,
-    )
-    .unwrap();
+    ).unwrap();
     let relative_backward = RelativeTo {
         date: Some(&backward_date),
         zdt: None,
@@ -345,14 +337,12 @@ fn basic_positive_expand_rounding() {
         FiniteF64(500.0),
     )
     .unwrap();
-    let forward_date = Date::new(
+    let forward_date = PlainDate::new(
         2020,
         4,
         1,
         Calendar::from_str("iso8601").unwrap(),
-        ArithmeticOverflow::Reject,
-    )
-    .unwrap();
+    ).unwrap();
 
     let relative_forward = RelativeTo {
         date: Some(&forward_date),
@@ -423,14 +413,12 @@ fn basic_negative_expand_rounding() {
     )
     .unwrap();
 
-    let backward_date = Date::new(
+    let backward_date = PlainDate::new(
         2020,
         12,
         1,
         Calendar::from_str("iso8601").unwrap(),
-        ArithmeticOverflow::Reject,
-    )
-    .unwrap();
+    ).unwrap();
 
     let relative_backward = RelativeTo {
         date: Some(&backward_date),
@@ -497,14 +485,12 @@ fn rounding_increment_non_integer() {
         )
         .unwrap(),
     );
-    let binding = Date::new(
+    let binding = PlainDate::new(
         2000,
         1,
         1,
         Calendar::from_str("iso8601").unwrap(),
-        ArithmeticOverflow::Reject,
-    )
-    .unwrap();
+    ).unwrap();
     let relative_to = RelativeTo {
         date: Some(&binding),
         zdt: None,

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -1,15 +1,10 @@
 //! An implementation of `TimeDuration` and it's methods.
 
 use crate::{
-    options::TemporalUnit,
-    primitive::FiniteF64,
-    temporal_assert, TemporalError, TemporalResult
+    options::TemporalUnit, primitive::FiniteF64, temporal_assert, TemporalError, TemporalResult,
 };
 
-use super::{
-    is_valid_duration,
-    normalized::NormalizedTimeDuration,
-};
+use super::{is_valid_duration, normalized::NormalizedTimeDuration};
 
 use num_traits::Euclid;
 

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -1,21 +1,17 @@
 //! An implementation of `TimeDuration` and it's methods.
 
-use std::num::NonZeroU128;
-
 use crate::{
-    options::{ResolvedRoundingOptions, TemporalUnit},
+    options::TemporalUnit,
     primitive::FiniteF64,
-    rounding::{IncrementRounder, Round},
-    temporal_assert, TemporalError, TemporalResult, TemporalUnwrap,
+    temporal_assert, TemporalError, TemporalResult
 };
 
 use super::{
     is_valid_duration,
-    normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
-    DateDuration,
+    normalized::NormalizedTimeDuration,
 };
 
-use num_traits::{Euclid, FromPrimitive};
+use num_traits::Euclid;
 
 /// `TimeDuration` represents the [Time Duration record][spec] of the `Duration.`
 ///
@@ -324,75 +320,5 @@ impl TimeDuration {
             && self.milliseconds.abs() < 1000f64
             && self.milliseconds.abs() < 1000f64
             && self.milliseconds.abs() < 1000f64
-    }
-}
-
-// ==== TimeDuration method impls ====
-
-impl TimeDuration {
-    // TODO: Maybe move to `NormalizedTimeDuration`
-    pub(crate) fn round(
-        days: FiniteF64,
-        norm: &NormalizedTimeDuration,
-        options: ResolvedRoundingOptions,
-    ) -> TemporalResult<(NormalizedDurationRecord, Option<i128>)> {
-        // 1. Assert: IsCalendarUnit(unit) is false.
-        let (days, norm, total) = match options.smallest_unit {
-            // 2. If unit is "day", then
-            TemporalUnit::Day => {
-                // a. Let fractionalDays be days + DivideNormalizedTimeDuration(norm, nsPerDay).
-                let fractional_days = days.checked_add(&FiniteF64(norm.as_fractional_days()))?;
-                // b. Set days to RoundNumberToIncrement(fractionalDays, increment, roundingMode).
-                let days = IncrementRounder::from_potentially_negative_parts(
-                    fractional_days.0,
-                    options.increment.as_extended_increment(),
-                )?
-                .round(options.rounding_mode);
-                // c. Let total be fractionalDays.
-                // d. Set norm to ZeroTimeDuration().
-                (
-                    FiniteF64::try_from(days)?,
-                    NormalizedTimeDuration::default(),
-                    i128::from_f64(fractional_days.0),
-                )
-            }
-            // 3. Else,
-            TemporalUnit::Hour
-            | TemporalUnit::Minute
-            | TemporalUnit::Second
-            | TemporalUnit::Millisecond
-            | TemporalUnit::Microsecond
-            | TemporalUnit::Nanosecond => {
-                // a. Assert: The value in the "Category" column of the row of Table 22 whose "Singular" column contains unit, is time.
-                // b. Let divisor be the value in the "Length in Nanoseconds" column of the row of Table 22 whose "Singular" column contains unit.
-                let divisor = options.smallest_unit.as_nanoseconds().temporal_unwrap()?;
-                // c. Let total be DivideNormalizedTimeDuration(norm, divisor).
-                let total = norm.divide(divisor as i64);
-                let non_zero_divisor = unsafe { NonZeroU128::new_unchecked(divisor.into()) };
-                // d. Set norm to ? RoundNormalizedTimeDurationToIncrement(norm, divisor × increment, roundingMode).
-                let norm = norm.round(
-                    non_zero_divisor
-                        .checked_mul(options.increment.as_extended_increment())
-                        .temporal_unwrap()?,
-                    options.rounding_mode,
-                )?;
-                (days, norm, Some(total))
-            }
-            _ => return Err(TemporalError::assert()),
-        };
-
-        // 4. Return the Record { [[NormalizedDuration]]: ? CreateNormalizedDurationRecord(0, 0, 0, days, norm), [[Total]]: total  }.
-        Ok((
-            NormalizedDurationRecord::new(
-                DateDuration::new(
-                    FiniteF64::default(),
-                    FiniteF64::default(),
-                    FiniteF64::default(),
-                    days,
-                )?,
-                norm,
-            )?,
-            total,
-        ))
     }
 }

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -80,7 +80,7 @@ impl Instant {
             other.epoch_nanos,
             self.epoch_nanos,
         )?;
-        let (round_record, _) = TimeDuration::round(FiniteF64::default(), &diff, resolved_options)?;
+        let (round_record, _) = diff.round(FiniteF64::default(), resolved_options)?;
 
         // 6. Let norm be diffRecord.[[NormalizedTimeDuration]].
         // 7. Let result be ! BalanceTimeDuration(norm, settings.[[LargestUnit]]).
@@ -282,7 +282,7 @@ impl FromStr for Instant {
         let ixdtf_record = parse_instant(s)?;
 
         // Find the IsoDate
-        let iso_date = IsoDate::new(
+        let iso_date = IsoDate::new_with_overflow(
             ixdtf_record.date.year,
             ixdtf_record.date.month.into(),
             ixdtf_record.date.day.into(),

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,18 +1,8 @@
 //! The primary date-time components provided by Temporal.
 //!
-//! The below components are the main primitives of the `Temporal` specification:
-//!   - `Date` -> `PlainDate`
-//!   - `DateTime` -> `PlainDateTime`
-//!   - `Time` -> `PlainTime`
-//!   - `Duration` -> `Duration`
-//!   - `Instant` -> `Instant`
-//!   - `MonthDay` -> `PlainMonthDay`
-//!   - `YearMonth` -> `PlainYearMonth`
-//!   - `ZonedDateTime` -> `ZonedDateTime`
-//!
-//! The Temporal specification, along with this implementation aims to provide
-//! full support for time zones and non-gregorian calendars that are compliant
-//! with standards like ISO 8601, RFC 3339, and RFC 5545.
+//! The Temporal specification, along with this implementation aims to
+//! provide full support for time zones and non-gregorian calendars that
+//! are compliant with standards like ISO 8601, RFC 3339, and RFC 5545.
 
 // TODO: Expand upon above introduction.
 
@@ -29,18 +19,18 @@ mod year_month;
 mod zoneddatetime;
 
 #[doc(inline)]
-pub use date::{Date, PartialDate};
+pub use date::{PlainDate, PartialDate};
 #[doc(inline)]
-pub use datetime::{DateTime, PartialDateTime};
+pub use datetime::{PlainDateTime, PartialDateTime};
 #[doc(inline)]
 pub use duration::Duration;
 #[doc(inline)]
 pub use instant::Instant;
 #[doc(inline)]
-pub use month_day::MonthDay;
+pub use month_day::PlainMonthDay;
 #[doc(inline)]
-pub use time::{PartialTime, Time};
+pub use time::{PartialTime, PlainTime};
 #[doc(inline)]
-pub use year_month::YearMonth;
+pub use year_month::PlainYearMonth;
 #[doc(inline)]
 pub use zoneddatetime::ZonedDateTime;

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -19,9 +19,9 @@ mod year_month;
 mod zoneddatetime;
 
 #[doc(inline)]
-pub use date::{PlainDate, PartialDate};
+pub use date::{PartialDate, PlainDate};
 #[doc(inline)]
-pub use datetime::{PlainDateTime, PartialDateTime};
+pub use datetime::{PartialDateTime, PlainDateTime};
 #[doc(inline)]
 pub use duration::Duration;
 #[doc(inline)]

--- a/src/components/month_day.rs
+++ b/src/components/month_day.rs
@@ -16,12 +16,12 @@ use super::calendar::{CalendarDateLike, GetTemporalCalendar};
 /// The native Rust implementation of `Temporal.PlainMonthDay`
 #[non_exhaustive]
 #[derive(Debug, Default, Clone)]
-pub struct MonthDay {
+pub struct PlainMonthDay {
     iso: IsoDate,
     calendar: Calendar,
 }
 
-impl MonthDay {
+impl PlainMonthDay {
     /// Creates a new unchecked `MonthDay`
     #[inline]
     #[must_use]
@@ -31,14 +31,14 @@ impl MonthDay {
 
     /// Creates a new valid `MonthDay`.
     #[inline]
-    pub fn new(
+    pub fn new_with_overflow(
         month: i32,
         day: i32,
         calendar: Calendar,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<Self> {
         // 1972 is the first leap year in the Unix epoch (needed to cover all dates)
-        let iso = IsoDate::new(1972, month, day, overflow)?;
+        let iso = IsoDate::new_with_overflow(1972, month, day, overflow)?;
         Ok(Self::new_unchecked(iso, calendar))
     }
 
@@ -77,13 +77,13 @@ impl MonthDay {
     }
 }
 
-impl GetTemporalCalendar for MonthDay {
+impl GetTemporalCalendar for PlainMonthDay {
     fn get_calendar(&self) -> Calendar {
         self.calendar.clone()
     }
 }
 
-impl IsoDateSlots for MonthDay {
+impl IsoDateSlots for PlainMonthDay {
     #[inline]
     /// Returns this structs `IsoDate`.
     fn iso_date(&self) -> IsoDate {
@@ -91,7 +91,7 @@ impl IsoDateSlots for MonthDay {
     }
 }
 
-impl FromStr for MonthDay {
+impl FromStr for PlainMonthDay {
     type Err = TemporalError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -103,7 +103,7 @@ impl FromStr for MonthDay {
 
         let date = date.temporal_unwrap()?;
 
-        Self::new(
+        Self::new_with_overflow(
             date.month.into(),
             date.day.into(),
             Calendar::from_str(calendar)?,

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -139,8 +139,7 @@ impl PlainTime {
             || resolved.increment != RoundingIncrement::ONE
         {
             // a. Let roundRecord be ! RoundDuration(0, 0, 0, 0, norm, settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
-            let (round_record, _) =
-                normalized_time.round(FiniteF64::default(), resolved)?;
+            let (round_record, _) = normalized_time.round(FiniteF64::default(), resolved)?;
             // b. Set norm to roundRecord.[[NormalizedDuration]].[[NormalizedTime]].
             normalized_time = round_record.normalized_time_duration()
         };
@@ -168,7 +167,15 @@ impl PlainTime {
         microsecond: i32,
         nanosecond: i32,
     ) -> TemporalResult<Self> {
-        Self::new_with_overflow(hour, minute, second, millisecond, microsecond, nanosecond, ArithmeticOverflow::Constrain)
+        Self::new_with_overflow(
+            hour,
+            minute,
+            second,
+            millisecond,
+            microsecond,
+            nanosecond,
+            ArithmeticOverflow::Constrain,
+        )
     }
 
     /// Creates a new `PlainTime`, rejecting any field that is not in a valid range.
@@ -180,9 +187,16 @@ impl PlainTime {
         microsecond: i32,
         nanosecond: i32,
     ) -> TemporalResult<Self> {
-        Self::new_with_overflow(hour, minute, second, millisecond, microsecond, nanosecond, ArithmeticOverflow::Reject)
+        Self::new_with_overflow(
+            hour,
+            minute,
+            second,
+            millisecond,
+            microsecond,
+            nanosecond,
+            ArithmeticOverflow::Reject,
+        )
     }
-
 
     /// Creates a new `PlainTime` with the provided [`ArithmeticOverflow`] option.
     #[inline]
@@ -510,9 +524,15 @@ mod tests {
 
     #[test]
     fn since_basic() {
-        let one = PlainTime::new_with_overflow(15, 23, 30, 123, 456, 789, ArithmeticOverflow::Constrain).unwrap();
-        let two = PlainTime::new_with_overflow(14, 23, 30, 123, 456, 789, ArithmeticOverflow::Constrain).unwrap();
-        let three = PlainTime::new_with_overflow(13, 30, 30, 123, 456, 789, ArithmeticOverflow::Constrain).unwrap();
+        let one =
+            PlainTime::new_with_overflow(15, 23, 30, 123, 456, 789, ArithmeticOverflow::Constrain)
+                .unwrap();
+        let two =
+            PlainTime::new_with_overflow(14, 23, 30, 123, 456, 789, ArithmeticOverflow::Constrain)
+                .unwrap();
+        let three =
+            PlainTime::new_with_overflow(13, 30, 30, 123, 456, 789, ArithmeticOverflow::Constrain)
+                .unwrap();
 
         let result = one.since(&two, DifferenceSettings::default()).unwrap();
         assert_eq!(result.hours(), 1.0);
@@ -531,9 +551,15 @@ mod tests {
 
     #[test]
     fn until_basic() {
-        let one = PlainTime::new_with_overflow(15, 23, 30, 123, 456, 789, ArithmeticOverflow::Constrain).unwrap();
-        let two = PlainTime::new_with_overflow(16, 23, 30, 123, 456, 789, ArithmeticOverflow::Constrain).unwrap();
-        let three = PlainTime::new_with_overflow(17, 0, 30, 123, 456, 789, ArithmeticOverflow::Constrain).unwrap();
+        let one =
+            PlainTime::new_with_overflow(15, 23, 30, 123, 456, 789, ArithmeticOverflow::Constrain)
+                .unwrap();
+        let two =
+            PlainTime::new_with_overflow(16, 23, 30, 123, 456, 789, ArithmeticOverflow::Constrain)
+                .unwrap();
+        let three =
+            PlainTime::new_with_overflow(17, 0, 30, 123, 456, 789, ArithmeticOverflow::Constrain)
+                .unwrap();
 
         let result = one.until(&two, DifferenceSettings::default()).unwrap();
         assert_eq!(result.hours(), 1.0);
@@ -553,82 +579,99 @@ mod tests {
     #[test]
     // test262/test/built-ins/Temporal/PlainTime/prototype/round/roundingincrement-nanoseconds.js
     fn rounding_increment_nanos() {
-        let time = PlainTime::new_with_overflow(3, 34, 56, 987, 654, 321, ArithmeticOverflow::Constrain).unwrap();
+        let time =
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 321, ArithmeticOverflow::Constrain)
+                .unwrap();
 
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(1.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 321, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 321, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(2.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 322, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 322, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(4.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 320, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 320, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(5.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 320, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 320, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(8.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 320, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 320, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(10.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 320, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 320, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(20.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 320, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 320, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(25.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 325, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 325, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(40.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 320, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 320, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(50.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 300, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 300, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(100.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 300, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 300, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(125.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 375, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 375, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(200.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 400, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 400, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(250.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 250, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 250, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
         assert_eq!(
             time.round(TemporalUnit::Nanosecond, Some(500.0), None)
                 .unwrap(),
-            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 500, ArithmeticOverflow::Constrain).unwrap()
+            PlainTime::new_with_overflow(3, 34, 56, 987, 654, 500, ArithmeticOverflow::Constrain)
+                .unwrap()
         );
     }
 }

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -4,7 +4,7 @@ use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 
 use crate::{
-    components::{calendar::Calendar, PlainDateTime, Instant},
+    components::{calendar::Calendar, Instant, PlainDateTime},
     TemporalError, TemporalResult,
 };
 

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -4,13 +4,9 @@ use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 
 use crate::{
-    components::{calendar::Calendar, DateTime, Instant},
+    components::{calendar::Calendar, PlainDateTime, Instant},
     TemporalError, TemporalResult,
 };
-
-/// Any object that implements the `TzProtocol` must implement the below methods/properties.
-pub const TIME_ZONE_PROPERTIES: [&str; 3] =
-    ["getOffsetNanosecondsFor", "getPossibleInstantsFor", "id"];
 
 /// A Temporal `TimeZone`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -24,9 +20,9 @@ impl TimeZone {
         &self,
         instant: &Instant,
         calendar: &Calendar,
-    ) -> TemporalResult<DateTime> {
+    ) -> TemporalResult<PlainDateTime> {
         let nanos = self.get_offset_nanos_for()?;
-        DateTime::from_instant(instant, nanos.to_f64().unwrap_or(0.0), calendar.clone())
+        PlainDateTime::from_instant(instant, nanos.to_f64().unwrap_or(0.0), calendar.clone())
     }
 }
 

--- a/src/components/year_month.rs
+++ b/src/components/year_month.rs
@@ -20,12 +20,12 @@ use super::{
 /// The native Rust implementation of `Temporal.YearMonth`.
 #[non_exhaustive]
 #[derive(Debug, Default, Clone)]
-pub struct YearMonth {
+pub struct PlainYearMonth {
     iso: IsoDate,
     calendar: Calendar,
 }
 
-impl YearMonth {
+impl PlainYearMonth {
     /// Creates an unvalidated `YearMonth`.
     #[inline]
     #[must_use]
@@ -35,7 +35,7 @@ impl YearMonth {
 
     /// Creates a new valid `YearMonth`.
     #[inline]
-    pub fn new(
+    pub fn new_with_overflow(
         year: i32,
         month: i32,
         reference_day: Option<i32>,
@@ -43,7 +43,7 @@ impl YearMonth {
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<Self> {
         let day = reference_day.unwrap_or(1);
-        let iso = IsoDate::new(year, month, day, overflow)?;
+        let iso = IsoDate::new_with_overflow(year, month, day, overflow)?;
         Ok(Self::new_unchecked(iso, calendar))
     }
 
@@ -113,7 +113,7 @@ impl YearMonth {
     }
 }
 
-impl YearMonth {
+impl PlainYearMonth {
     /// Returns the Calendar value.
     #[inline]
     #[must_use]
@@ -132,7 +132,7 @@ impl YearMonth {
         &self,
         duration: &Duration,
         overflow: ArithmeticOverflow,
-    ) -> TemporalResult<YearMonth> {
+    ) -> TemporalResult<Self> {
         self.add_or_subtract_duration(duration, overflow)
     }
 
@@ -140,7 +140,7 @@ impl YearMonth {
         &self,
         duration: &Duration,
         overflow: ArithmeticOverflow,
-    ) -> TemporalResult<YearMonth> {
+    ) -> TemporalResult<Self> {
         self.add_or_subtract_duration(&duration.negated(), overflow)
     }
 
@@ -148,7 +148,7 @@ impl YearMonth {
         &self,
         duration: &Duration,
         overflow: ArithmeticOverflow,
-    ) -> TemporalResult<YearMonth> {
+    ) -> TemporalResult<Self> {
         let partial = PartialDate::try_from_year_month(self)?;
 
         let mut intermediate_date = self.get_calendar().date_from_partial(&partial, overflow)?;
@@ -162,14 +162,14 @@ impl YearMonth {
     }
 }
 
-impl GetTemporalCalendar for YearMonth {
+impl GetTemporalCalendar for PlainYearMonth {
     /// Returns a reference to `YearMonth`'s `CalendarSlot`
     fn get_calendar(&self) -> Calendar {
         self.calendar.clone()
     }
 }
 
-impl IsoDateSlots for YearMonth {
+impl IsoDateSlots for PlainYearMonth {
     #[inline]
     /// Returns this `YearMonth`'s `IsoDate`
     fn iso_date(&self) -> IsoDate {
@@ -177,7 +177,7 @@ impl IsoDateSlots for YearMonth {
     }
 }
 
-impl FromStr for YearMonth {
+impl FromStr for PlainYearMonth {
     type Err = TemporalError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -187,7 +187,7 @@ impl FromStr for YearMonth {
 
         let date = record.date.temporal_unwrap()?;
 
-        Self::new(
+        Self::new_with_overflow(
             date.year,
             date.month.into(),
             None,

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -21,7 +21,7 @@ use crate::{
             normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
             DateDuration, TimeDuration,
         },
-        PlainDate, Duration, PartialTime,
+        Duration, PartialTime, PlainDate,
     },
     error::TemporalError,
     options::{ArithmeticOverflow, ResolvedRoundingOptions, TemporalUnit},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,15 @@
-//! The `Temporal` crate is an implementation of ECMAScript's Temporal buitl-in.
+//! The `Temporal` crate is an implementation of ECMAScript's Temporal
+//! buitl-in.
 //!
-//! The crate is being designed with both engine and general use in mind.
+//! The crate is being designed with both engine and general use in
+//! mind.
 //!
-//! IMPORTANT NOTE: Please note that this library is actively being developed and is very
-//! much experimental and NOT STABLE.
+//! [`Temporal`][proposal] is the Stage 3 proposal for ECMAScript that
+//! provides new JS objects and functions for working with dates and
+//! times that fully supports time zones and non-gregorian calendars.
 //!
-//! [`Temporal`][proposal] is the Stage 3 proposal for ECMAScript that provides new JS objects and functions
-//! for working with dates and times that fully supports time zones and non-gregorian calendars.
-//!
-//! This library's primary source is the Temporal Proposal [specification][spec].
+//! This library's primary source is the Temporal Proposal
+//! [specification][spec].
 //!
 //! [proposal]: https://github.com/tc39/proposal-temporal
 //! [spec]: https://tc39.es/proposal-temporal/
@@ -38,12 +39,13 @@
     clippy::missing_panics_doc,
 )]
 
-pub mod components;
 pub mod error;
-pub mod iso;
 pub mod options;
 pub mod parsers;
 pub mod primitive;
+
+pub(crate) mod components;
+pub(crate) mod iso;
 
 #[doc(hidden)]
 pub(crate) mod rounding;
@@ -52,8 +54,9 @@ pub(crate) mod utils;
 
 use std::cmp::Ordering;
 
-// TODO: evaluate positives and negatives of using tinystr.
-// Re-exporting tinystr as a convenience, as it is currently tied into the API.
+// TODO: evaluate positives and negatives of using tinystr. Re-exporting
+// tinystr as a convenience, as it is currently tied into the API.
+/// Re-export of `TinyAsciiStr` from `tinystr`.
 pub use tinystr::TinyAsciiStr;
 
 #[doc(inline)]
@@ -62,12 +65,22 @@ pub use error::TemporalError;
 /// The `Temporal` result type
 pub type TemporalResult<T> = Result<T, TemporalError>;
 
+pub mod partial {
+    //! Partial Date/Time component records.
+    //! 
+    //! The partial records are `temporal_rs`'s method of addressing
+    //! `TemporalFields` in the specification.
+    pub use crate::components::{PartialDate, PartialDateTime, PartialTime, duration::PartialDuration};
+}
+
+pub use crate::components::{calendar::Calendar, PlainDate, PlainDateTime, PlainTime, PlainMonthDay, PlainYearMonth, Instant, Duration, ZonedDateTime};
+
 /// A library specific trait for unwrapping assertions.
 pub(crate) trait TemporalUnwrap {
     type Output;
 
-    /// `temporal_rs` based assertion for unwrapping. This will panic in debug
-    /// builds, but throws error during runtime.
+    /// `temporal_rs` based assertion for unwrapping. This will panic in
+    /// debug builds, but throws error during runtime.
     fn temporal_unwrap(self) -> TemporalResult<Self::Output>;
 }
 
@@ -80,6 +93,7 @@ impl<T> TemporalUnwrap for Option<T> {
     }
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! temporal_assert {
     ($condition:expr $(,)*) => {
@@ -95,6 +109,9 @@ macro_rules! temporal_assert {
     };
 }
 
+// TODO: Determine final home or leave in the top level? ops::Sign,
+// types::Sign, etc.
+/// A general Sign type.
 #[repr(i8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Sign {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! The `Temporal` crate is an implementation of ECMAScript's Temporal
-//! buitl-in.
+//! built-in objects.
 //!
 //! The crate is being designed with both engine and general use in
 //! mind.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,13 +67,18 @@ pub type TemporalResult<T> = Result<T, TemporalError>;
 
 pub mod partial {
     //! Partial Date/Time component records.
-    //! 
+    //!
     //! The partial records are `temporal_rs`'s method of addressing
     //! `TemporalFields` in the specification.
-    pub use crate::components::{PartialDate, PartialDateTime, PartialTime, duration::PartialDuration};
+    pub use crate::components::{
+        duration::PartialDuration, PartialDate, PartialDateTime, PartialTime,
+    };
 }
 
-pub use crate::components::{calendar::Calendar, PlainDate, PlainDateTime, PlainTime, PlainMonthDay, PlainYearMonth, Instant, Duration, ZonedDateTime};
+pub use crate::components::{
+    calendar::Calendar, Duration, Instant, PlainDate, PlainDateTime, PlainMonthDay, PlainTime,
+    PlainYearMonth, ZonedDateTime,
+};
 
 /// A library specific trait for unwrapping assertions.
 pub(crate) trait TemporalUnwrap {

--- a/src/options.rs
+++ b/src/options.rs
@@ -7,7 +7,7 @@ use core::{fmt, str::FromStr};
 use std::ops::Add;
 
 use crate::{
-    components::{Date, ZonedDateTime},
+    components::{PlainDate, ZonedDateTime},
     Sign, TemporalError, TemporalResult, MS_PER_DAY, NS_PER_DAY,
 };
 
@@ -222,7 +222,7 @@ impl ResolvedRoundingOptions {
 // ==== RelativeTo Object ====
 
 pub struct RelativeTo<'a> {
-    pub date: Option<&'a Date>,
+    pub date: Option<&'a PlainDate>,
     pub zdt: Option<&'a ZonedDateTime>,
 }
 

--- a/src/options/increment.rs
+++ b/src/options/increment.rs
@@ -3,10 +3,12 @@ use std::num::{NonZeroU128, NonZeroU32};
 use crate::{TemporalError, TemporalResult};
 
 // ==== RoundingIncrement option ====
+
 // Invariants:
 // RoundingIncrement(n): 1 <= n < 10^9
-/// A numeric rounding increment.
 // TODO: Add explanation on what exactly are rounding increments.
+
+/// A numeric rounding increment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RoundingIncrement(pub(crate) NonZeroU32);
 


### PR DESCRIPTION
In general, this completes some various API housekeeping that was needed. Updates the built-ins to align with specification names, changes the exports, implements some of the general API changes to be more Rust-like.

Below are a full list of changes:

  - Updates all component names to align with the Temporal spec (Adds the `Plain` prefix where needed)
  - Initial implementation of the API suggestions from #93
  - Exports each component in the libraries root and adds the partial records to a `partial` mod.

Ideally, now working with the library should look something like the below.

```rust
// previously would have been: 
// use temporal_rs::{components::{calendar::Calendar, Date, PartialDate}, options::ArithmeticOverflow};
use temporal_rs::{Date, Calendar, partial::PartialDate, options::ArithmeticOverflow};

let iso_calendar = Calendar::from_str("iso8601")?;
// Previously would have been Date::new(2020, 10, 19, iso_calendar.clone(), ArithmeticOverflow::Reject)?;
let constructed_date = Date::try_new(2020, 10, 19, iso_calendar.clone())?;
let today = PartialDate {
    year: Some(2020),
    month: Some(10),
    day: Some(19),
    ..Default::default()
};
let date_from_partial = iso_calendar.date_from_partial(&today, ArithmeticOverflow::Reject)?;

assert_eq!(constructed_date, from_partial);
```
