### PR TITLE
Implement `date` macro

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -29,7 +29,7 @@ mod year_month;
 mod zoneddatetime;
 
 #[doc(inline)]
-pub use date::{Date, PartialDate};
+pub use date::{partial_to_date, Date, PartialDate};
 #[doc(inline)]
 pub use datetime::{DateTime, PartialDateTime};
 #[doc(inline)]


### PR DESCRIPTION
This PR implements a `date` macro that would make working with `PartialDate`s ideally a tad more ergonomic. Let me know what you think!