### PR TITLE
Stub out tzdb support to unblock `Now` and `ZonedDateTime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,6 +24,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytes"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+
+[[package]]
 name = "calendrical_calculations"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,6 +44,37 @@ dependencies = [
  "core_maths",
  "displaydoc",
 ]
+
+[[package]]
+name = "cc"
+version = "1.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core_maths"
@@ -42,6 +94,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -138,6 +213,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.161"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +259,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "proc-macro2"
@@ -209,6 +311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,12 +349,14 @@ name = "temporal_rs"
 version = "0.0.3"
 dependencies = [
  "bitflags",
+ "iana-time-zone",
  "icu_calendar",
  "ixdtf",
  "log",
  "num-traits",
  "rustc-hash",
  "tinystr",
+ "tzif",
 ]
 
 [[package]]
@@ -260,10 +370,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "tzif"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b8eb18929606c6f3eea7ef096a91dd5c26dbbde2a20a343c4a409b851666fd"
+dependencies = [
+ "combine",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 authors = ["boa-dev"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/boa-dev/temporal"
-rust-version = "1.79"
+rust-version = "1.80"
 exclude = [
     "docs/*",
     ".github/*",
@@ -26,6 +26,11 @@ num-traits = "0.2.19"
 ixdtf = { version = "0.2.0", features = ["duration"]}
 log = { version = "0.4.0", optional = true }
 
+tzif = { version = "0.2.3", optional = true }
+iana-time-zone = "0.1.61"
 
 [features]
 log = ["dep:log"]
+experimental = ["tzdb"]
+tzdb = ["dep:tzif", "std"]
+std = []

--- a/docs/TZDB.md
+++ b/docs/TZDB.md
@@ -1,0 +1,69 @@
+# General TZDB implementation notes
+
+Below are some logs of the logic currently at play to find the local
+time records based off user provided nanoseconds (seconds).
+
+Important to note, that currently the logs only exist for notably +/-
+time zones that observe DST.
+
+Further testing still needs to be done for time zones without any DST
+transition / potentially historically abnormal edge cases.
+
+## Empty case (AKA Spring forward)
+
+// New York STD -> DST transition (2017-3-12)
+// Record direction: DST -> STD
+Search time: Seconds(1489285800)
+Unresolved under LocalTimeTypeRecord { utoff: Seconds(-18000), is_dst: false, idx: 8 }
+Unresolved over LocalTimeTypeRecord { utoff: Seconds(-14400), is_dst: true, idx: 4 }
+previous over Seconds(10873800)
+current diff Seconds(-16200)
+Resolved under LocalTimeTypeRecord { utoff: Seconds(-18000), is_dst: false, idx: 8 }
+Resolved over LocalTimeTypeRecord { utoff: Seconds(-14400), is_dst: true, idx: 4 }
+Range: Seconds(-18000)..Seconds(-14400)
+Diff value: Seconds(-16200)
+Contains Result: true
+Result: []
+
+// Sydney STD -> DST transition (2017-10-1)
+// Record direction: STD -> DST
+Search time: Seconds(1506825000)
+Unresolved under LocalTimeTypeRecord { utoff: Seconds(39600), is_dst: true, idx: 4 }
+Unresolved over LocalTimeTypeRecord { utoff: Seconds(36000), is_dst: false, idx: 9 }
+previous over Seconds(15762600)
+current diff Seconds(37800)
+Resolved under LocalTimeTypeRecord { utoff: Seconds(36000), is_dst: false, idx: 9 }
+Resolved over LocalTimeTypeRecord { utoff: Seconds(39600), is_dst: true, idx: 4 }
+Range: Seconds(36000)..Seconds(39600)
+Diff value: Seconds(37800)
+Contains Result: true
+Result: []
+
+
+## Duplicate case (AKA Spring backward)
+
+// New York DST -> STD transition (2017-11-5)
+Search time: Seconds(1509845400)
+Unresolved under LocalTimeTypeRecord { utoff: Seconds(-14400), is_dst: true, idx: 4 }
+Unresolved over LocalTimeTypeRecord { utoff: Seconds(-18000), is_dst: false, idx: 8 }
+previous over Seconds(20543400)
+current diff Seconds(-16200)
+Resolved under LocalTimeTypeRecord { utoff: Seconds(-14400), is_dst: true, idx: 4 }
+Resolved over LocalTimeTypeRecord { utoff: Seconds(-18000), is_dst: false, idx: 8 }
+Range: Seconds(-18000)..Seconds(-14400)
+Diff value: Seconds(-16200)
+Contains Result: true
+Result: [LocalTimeTypeRecord { utoff: Seconds(-14400), is_dst: true, idx: 4 }, LocalTimeTypeRecord { utoff: Seconds(-18000), is_dst: false, idx: 8 }]
+
+// Sydney DST -> STD transition (2017-4-2)
+Search time: Seconds(1491100200)
+Unresolved under LocalTimeTypeRecord { utoff: Seconds(36000), is_dst: false, idx: 9 }
+Unresolved over LocalTimeTypeRecord { utoff: Seconds(39600), is_dst: true, idx: 4 }
+previous over Seconds(15762600)
+current diff Seconds(37800)
+Resolved under LocalTimeTypeRecord { utoff: Seconds(39600), is_dst: true, idx: 4 }
+Resolved over LocalTimeTypeRecord { utoff: Seconds(36000), is_dst: false, idx: 9 }
+Range: Seconds(36000)..Seconds(39600)
+Diff value: Seconds(37800)
+Contains Result: true
+Result: [LocalTimeTypeRecord { utoff: Seconds(39600), is_dst: true, idx: 4 }, LocalTimeTypeRecord { utoff: Seconds(36000), is_dst: false, idx: 9 }]

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -67,8 +67,10 @@ impl PlainDateTime {
         IsoDateTime::new_unchecked(iso, IsoTime::noon()).is_within_limits()
     }
 
+    // TODO: Potentially deprecate and remove.
     /// Create a new `DateTime` from an `Instant`.
     #[inline]
+    #[allow(unused)]
     pub(crate) fn from_instant(
         instant: &Instant,
         offset: f64,
@@ -210,7 +212,7 @@ impl PlainDateTime {
         // [[Day]]: d1, [[Hour]]: h1, [[Minute]]: min1, [[Second]]: s1, [[Millisecond]]:
         // ms1, [[Microsecond]]: mus1, [[Nanosecond]]: ns1 }.
         // 7. Let destEpochNs be GetUTCEpochNanoseconds(y2, mon2, d2, h2, min2, s2, ms2, mus2, ns2).
-        let dest_epoch_ns = other.iso.as_nanoseconds(0.0).temporal_unwrap()?;
+        let dest_epoch_ns = other.iso.as_nanoseconds().temporal_unwrap()?;
 
         // 8. Return ? RoundRelativeDuration(diff, destEpochNs, dateTime, calendarRec, unset, largestUnit,
         // roundingIncrement, smallestUnit, roundingMode).

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -494,8 +494,8 @@ impl NormalizedDurationRecord {
             // a. Let startEpochNs be GetUTCEpochNanoseconds(start.[[Year]], start.[[Month]], start.[[Day]], start.[[Hour]], start.[[Minute]], start.[[Second]], start.[[Millisecond]], start.[[Microsecond]], start.[[Nanosecond]]).
             // b. Let endEpochNs be GetUTCEpochNanoseconds(end.[[Year]], end.[[Month]], end.[[Day]], end.[[Hour]], end.[[Minute]], end.[[Second]], end.[[Millisecond]], end.[[Microsecond]], end.[[Nanosecond]]).
             (
-                start.as_nanoseconds(0.0).unwrap_or(0),
-                end.as_nanoseconds(0.0).unwrap_or(0),
+                start.as_nanoseconds().unwrap_or(0),
+                end.as_nanoseconds().unwrap_or(0),
             )
         // 8. Else,
         } else {
@@ -782,7 +782,7 @@ impl NormalizedDurationRecord {
             } else {
                 // 1. Let endEpochNs be GetUTCEpochNanoseconds(end.[[Year]], end.[[Month]], end.[[Day]], end.[[Hour]],
                 // end.[[Minute]], end.[[Second]], end.[[Millisecond]], end.[[Microsecond]], end.[[Nanosecond]]).
-                end.as_nanoseconds(0.0).temporal_unwrap()?
+                end.as_nanoseconds().temporal_unwrap()?
             };
             // viii. Let beyondEnd be nudgedEpochNs - endEpochNs.
             let beyond_end = nudge_epoch_ns - end_epoch_ns;

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -308,7 +308,9 @@ impl FromStr for Instant {
             + f64::from(ixdtf_record.offset.second) * NANOSECONDS_PER_SECOND
             + f64::from(ixdtf_record.offset.nanosecond);
 
-        let nanoseconds = IsoDateTime::new_unchecked(iso_date, iso_time).as_nanoseconds(offset);
+        let nanoseconds = IsoDateTime::new_unchecked(iso_date, iso_time)
+            .as_nanoseconds()
+            .map(|v| v + offset as i128);
 
         Self::from_epoch_milliseconds(nanoseconds.unwrap_or(i128::MAX))
     }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -18,6 +18,13 @@ mod time;
 mod year_month;
 mod zoneddatetime;
 
+#[cfg(feature = "std")]
+mod now;
+
+#[cfg(feature = "std")]
+#[doc(inline)]
+pub use now::Now;
+
 #[doc(inline)]
 pub use date::{PartialDate, PlainDate};
 #[doc(inline)]

--- a/src/components/now.rs
+++ b/src/components/now.rs
@@ -1,0 +1,61 @@
+//! The Temporal Now component
+
+use alloc::string::String;
+use num_traits::FromPrimitive;
+
+use crate::{iso::IsoDateTime, sys, TemporalResult, TemporalUnwrap};
+
+use super::{
+    calendar::Calendar,
+    tz::{TimeZone, TzProvider},
+    Instant, PlainDateTime,
+};
+
+/// The Temporal Now object.
+pub struct Now;
+
+impl Now {
+    /// Returns the current time zone.
+    pub fn time_zone_id() -> TemporalResult<String> {
+        sys::get_system_tz_identifier()
+    }
+
+    /// Returns the current instant
+    pub fn instant() -> TemporalResult<Instant> {
+        system_instant()
+    }
+
+    pub fn plain_date_time_with_provider(
+        tz: Option<TimeZone>,
+        provider: &mut impl TzProvider,
+    ) -> TemporalResult<PlainDateTime> {
+        let iso = system_date_time(tz, provider)?;
+        Ok(PlainDateTime::new_unchecked(iso, Calendar::default()))
+    }
+}
+
+fn system_date_time(
+    tz: Option<TimeZone>,
+    provider: &mut impl TzProvider,
+) -> TemporalResult<IsoDateTime> {
+    // 1. If temporalTimeZoneLike is undefined, then
+    // a. Let timeZone be SystemTimeZoneIdentifier().
+    // 2. Else,
+    // a. Let timeZone be ? ToTemporalTimeZoneIdentifier(temporalTimeZoneLike).
+    let tz = tz.unwrap_or(sys::get_system_tz_identifier()?.into());
+    // 3. Let epochNs be SystemUTCEpochNanoseconds().
+    // TODO: Handle u128 -> i128 better for system nanoseconds
+    let epoch_ns = sys::get_system_nanoseconds()?;
+    // 4. Return GetISODateTimeFor(timeZone, epochNs).
+    tz.get_iso_datetime_for(
+        &Instant {
+            epoch_nanos: epoch_ns as i128,
+        },
+        provider,
+    )
+}
+
+fn system_instant() -> TemporalResult<Instant> {
+    let nanos = sys::get_system_nanoseconds()?;
+    Instant::new(i128::from_u128(nanos).temporal_unwrap()?)
+}

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -9,7 +9,7 @@ use num_traits::ToPrimitive;
 
 use crate::{components::Instant, iso::IsoDateTime, TemporalError, TemporalResult};
 
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "tzdb", not(target_os = "windows")))]
 use crate::tzdb::FsTzdbProvider;
 #[cfg(feature = "experimental")]
 use std::sync::{LazyLock, Mutex};
@@ -21,16 +21,16 @@ pub static TZ_PROVIDER: LazyLock<Mutex<FsTzdbProvider>> =
 use super::ZonedDateTime;
 
 pub trait TzProvider {
-    fn check_identifier(&mut self, identifier: &str) -> bool;
+    fn check_identifier(&self, identifier: &str) -> bool;
 
     fn get_named_tz_epoch_nanoseconds(
-        &mut self,
+        &self,
         identifier: &str,
         iso_datetime: IsoDateTime,
     ) -> TemporalResult<Vec<i128>>;
 
     fn get_named_tz_offset_nanoseconds(
-        &mut self,
+        &self,
         identifier: &str,
         epoch_nanoseconds: i128,
     ) -> TemporalResult<i128>;

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -11,10 +11,10 @@ use crate::{components::Instant, iso::IsoDateTime, TemporalError, TemporalResult
 
 #[cfg(all(feature = "tzdb", not(target_os = "windows")))]
 use crate::tzdb::FsTzdbProvider;
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "experimental", not(target_os = "windows")))]
 use std::sync::{LazyLock, Mutex};
 
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "experimental", not(target_os = "windows")))]
 pub static TZ_PROVIDER: LazyLock<Mutex<FsTzdbProvider>> =
     LazyLock::new(|| Mutex::new(FsTzdbProvider::default()));
 

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -1,46 +1,112 @@
 //! This module implements the Temporal `TimeZone` and components.
 
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::{iter::Peekable, str::Chars};
+
 use num_traits::ToPrimitive;
 
-use crate::{
-    components::{calendar::Calendar, Instant, PlainDateTime},
-    TemporalError, TemporalResult,
-};
+use crate::{components::Instant, iso::IsoDateTime, TemporalError, TemporalResult};
+
+#[cfg(feature = "experimental")]
+use crate::tzdb::FsTzdbProvider;
+#[cfg(feature = "experimental")]
+use std::sync::{LazyLock, Mutex};
+
+#[cfg(feature = "experimental")]
+pub static TZ_PROVIDER: LazyLock<Mutex<FsTzdbProvider>> =
+    LazyLock::new(|| Mutex::new(FsTzdbProvider::default()));
+
+use super::ZonedDateTime;
+
+pub trait TzProvider {
+    fn check_identifier(&mut self, identifier: &str) -> bool;
+
+    fn get_named_tz_epoch_nanoseconds(
+        &mut self,
+        identifier: &str,
+        iso_datetime: IsoDateTime,
+    ) -> TemporalResult<Vec<i128>>;
+
+    fn get_named_tz_offset_nanoseconds(
+        &mut self,
+        identifier: &str,
+        epoch_nanoseconds: i128,
+    ) -> TemporalResult<i128>;
+}
 
 /// A Temporal `TimeZone`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TimeZone {
-    /// The IANA identifier for this time zone.
-    pub(crate) iana: Option<String>, // TODO: ICU4X IANA TimeZone support.
-    /// The offset minutes of a time zone.
-    pub(crate) offset: Option<i16>,
+pub enum ParsedTimeZone<'a> {
+    IanaIdentifier { identifier: &'a str },
+    Offset { minutes: i16 },
+}
+
+impl<'a> ParsedTimeZone<'a> {
+    pub fn from_str(s: &'a str, provider: &mut impl TzProvider) -> TemporalResult<Self> {
+        if s == "Z" {
+            return Ok(Self::Offset { minutes: 0 });
+        }
+        let mut cursor = s.chars().peekable();
+        if cursor.peek().map_or(false, is_ascii_sign) {
+            return parse_offset(&mut cursor);
+        } else if provider.check_identifier(s) {
+            return Ok(Self::IanaIdentifier { identifier: s });
+        }
+        Err(TemporalError::range().with_message("Valid time zone was not provided."))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimeZone(pub String);
+
+impl From<&ZonedDateTime> for TimeZone {
+    fn from(value: &ZonedDateTime) -> Self {
+        value.tz().clone()
+    }
+}
+
+impl From<String> for TimeZone {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for TimeZone {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
 }
 
 impl TimeZone {
-    pub(crate) fn get_datetime_for(
+    pub(crate) fn get_iso_datetime_for(
         &self,
         instant: &Instant,
-        calendar: &Calendar,
-    ) -> TemporalResult<PlainDateTime> {
-        let nanos = self.get_offset_nanos_for()?;
-        PlainDateTime::from_instant(instant, nanos.to_f64().unwrap_or(0.0), calendar.clone())
+        provider: &mut impl TzProvider,
+    ) -> TemporalResult<IsoDateTime> {
+        let nanos = self.get_offset_nanos_for(instant.epoch_nanos, provider)?;
+        IsoDateTime::from_epoch_nanos(&instant.epoch_nanos, nanos.to_f64().unwrap_or(0.0))
     }
 }
 
 impl TimeZone {
     /// Get the offset for this current `TimeZoneSlot`.
-    pub fn get_offset_nanos_for(&self) -> TemporalResult<i128> {
-        // 1. Let timeZone be the this value.
-        // 2. Perform ? RequireInternalSlot(timeZone, [[InitializedTemporalTimeZone]]).
-        // 3. Set instant to ? ToTemporalInstant(instant).
-        // 4. If timeZone.[[OffsetMinutes]] is not empty, return 𝔽(timeZone.[[OffsetMinutes]] × (60 × 10^9)).
-        if let Some(offset) = &self.offset {
-            return Ok(i128::from(*offset) * 60_000_000_000);
+    pub fn get_offset_nanos_for(
+        &self,
+        epoch_ns: i128,
+        provider: &mut impl TzProvider,
+    ) -> TemporalResult<i128> {
+        // 1. Let parseResult be ! ParseTimeZoneIdentifier(timeZone).
+        let parsed = ParsedTimeZone::from_str(&self.0, provider)?;
+        match parsed {
+            // 2. If parseResult.[[OffsetMinutes]] is not empty, return parseResult.[[OffsetMinutes]] × (60 × 10**9).
+            ParsedTimeZone::Offset { minutes } => Ok(i128::from(minutes) * 60_000_000_000i128),
+            // 3. Return GetNamedTimeZoneOffsetNanoseconds(parseResult.[[Name]], epochNs).
+            ParsedTimeZone::IanaIdentifier { identifier } => {
+                provider.get_named_tz_offset_nanoseconds(identifier, epoch_ns)
+            }
         }
-        // 5. Return 𝔽(GetNamedTimeZoneOffsetNanoseconds(timeZone.[[Identifier]], instant.[[Nanoseconds]])).
-        Err(TemporalError::range().with_message("IANA TimeZone names not yet implemented."))
     }
 
     /// Get the possible `Instant`s for this `TimeZoneSlot`.
@@ -52,4 +118,66 @@ impl TimeZone {
     pub fn id(&self) -> TemporalResult<String> {
         Err(TemporalError::range().with_message("Not yet implemented."))
     }
+}
+
+#[inline]
+fn parse_offset<'a>(chars: &mut Peekable<Chars<'_>>) -> TemporalResult<ParsedTimeZone<'a>> {
+    let sign = chars.next().map_or(1, |c| if c == '+' { 1 } else { -1 });
+    // First offset portion
+    let hours = parse_digit_pair(chars)?;
+
+    let sep = chars.peek().map_or(false, |ch| *ch == ':');
+    if sep {
+        let _ = chars.next();
+    }
+
+    let digit_peek = chars.peek().map(|ch| ch.is_ascii_digit());
+
+    let minutes = match digit_peek {
+        Some(true) => parse_digit_pair(chars)?,
+        Some(false) => return Err(non_ascii_digit()),
+        None => 0,
+    };
+
+    Ok(ParsedTimeZone::Offset {
+        minutes: (hours * 60 + minutes) * sign,
+    })
+}
+
+fn parse_digit_pair(chars: &mut Peekable<Chars<'_>>) -> TemporalResult<i16> {
+    let valid = chars
+        .peek()
+        .map_or(Err(abrupt_end()), |ch| Ok(ch.is_ascii_digit()))?;
+    let first = if valid {
+        chars.next().expect("validated.")
+    } else {
+        return Err(non_ascii_digit());
+    };
+    let valid = chars
+        .peek()
+        .map_or(Err(abrupt_end()), |ch| Ok(ch.is_ascii_digit()))?;
+    let second = if valid {
+        chars.next().expect("validated.")
+    } else {
+        return Err(non_ascii_digit());
+    };
+
+    let tens = (first.to_digit(10).expect("validated") * 10) as i16;
+    let ones = second.to_digit(10).expect("validated") as i16;
+
+    Ok(tens + ones)
+}
+
+// NOTE: Spec calls for throwing a RangeError when parse node is a list of errors for timezone.
+
+fn abrupt_end() -> TemporalError {
+    TemporalError::range().with_message("Abrupt end while parsing offset string")
+}
+
+fn non_ascii_digit() -> TemporalError {
+    TemporalError::range().with_message("Non ascii digit found while parsing offset string")
+}
+
+fn is_ascii_sign(ch: &char) -> bool {
+    *ch == '+' || *ch == '-'
 }

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -1,13 +1,18 @@
 //! This module implements `ZonedDateTime` and any directly related algorithms.
 
-use tinystr::TinyStr4;
+use tinystr::TinyAsciiStr;
 
 use crate::{
     components::{calendar::Calendar, tz::TimeZone, Instant},
     TemporalResult,
 };
 
-use super::calendar::CalendarDateLike;
+use super::{calendar::CalendarDateLike, tz::TzProvider, PlainDateTime};
+
+#[cfg(all(feature = "experimental", not(target_os = "windows")))]
+use crate::{components::tz::TZ_PROVIDER, TemporalError};
+#[cfg(all(feature = "experimental", not(target_os = "windows")))]
+use std::ops::DerefMut;
 
 /// The native Rust implementation of `Temporal.ZonedDateTime`.
 #[non_exhaustive]
@@ -92,89 +97,199 @@ impl ZonedDateTime {
     pub fn epoch_nanoseconds(&self) -> f64 {
         self.instant.epoch_nanoseconds()
     }
+}
 
+// ===== TzProvider APIs for ZonedDateTime =====
+
+#[cfg(all(feature = "experimental", not(target_os = "windows")))]
+impl ZonedDateTime {
+    pub fn year(&self) -> TemporalResult<i32> {
+        let mut provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.year_with_provider(provider.deref_mut())
+    }
+
+    pub fn month(&self) -> TemporalResult<u8> {
+        let mut provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.month_with_provider(provider.deref_mut())
+    }
+
+    pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
+        let mut provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.month_code_with_provider(provider.deref_mut())
+    }
+
+    pub fn day(&self) -> TemporalResult<u8> {
+        let mut provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.day_with_provider(provider.deref_mut())
+    }
+
+    pub fn hour(&self) -> TemporalResult<u8> {
+        let mut provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.hour_with_provider(provider.deref_mut())
+    }
+
+    pub fn minute(&self) -> TemporalResult<u8> {
+        let mut provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.minute_with_provider(provider.deref_mut())
+    }
+
+    pub fn second(&self) -> TemporalResult<u8> {
+        let mut provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.second_with_provider(provider.deref_mut())
+    }
+}
+
+impl ZonedDateTime {
     /// Returns the `year` value for this `ZonedDateTime`.
     #[inline]
-    pub fn year(&self) -> TemporalResult<i32> {
-        let dt = self.tz.get_datetime_for(&self.instant, &self.calendar)?;
+    pub fn year_with_provider(&self, provider: &mut impl TzProvider) -> TemporalResult<i32> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar.year(&CalendarDateLike::DateTime(&dt))
     }
 
     /// Returns the `month` value for this `ZonedDateTime`.
-    pub fn month(&self) -> TemporalResult<u8> {
-        let dt = self.tz.get_datetime_for(&self.instant, &self.calendar)?;
+    pub fn month_with_provider(&self, provider: &mut impl TzProvider) -> TemporalResult<u8> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar.month(&CalendarDateLike::DateTime(&dt))
     }
 
     /// Returns the `monthCode` value for this `ZonedDateTime`.
-    pub fn month_code(&self) -> TemporalResult<TinyStr4> {
-        let dt = self.tz.get_datetime_for(&self.instant, &self.calendar)?;
+    pub fn month_code_with_provider(
+        &self,
+        provider: &mut impl TzProvider,
+    ) -> TemporalResult<TinyAsciiStr<4>> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar.month_code(&CalendarDateLike::DateTime(&dt))
     }
 
     /// Returns the `day` value for this `ZonedDateTime`.
-    pub fn day(&self) -> TemporalResult<u8> {
-        let dt = self.tz.get_datetime_for(&self.instant, &self.calendar)?;
+    pub fn day_with_provider(&self, provider: &mut impl TzProvider) -> TemporalResult<u8> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar.day(&CalendarDateLike::DateTime(&dt))
     }
 
     /// Returns the `hour` value for this `ZonedDateTime`.
-    pub fn hour(&self) -> TemporalResult<u8> {
-        let dt = self.tz.get_datetime_for(&self.instant, &self.calendar)?;
-        Ok(dt.hour())
+    pub fn hour_with_provider(&self, provider: &mut impl TzProvider) -> TemporalResult<u8> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        Ok(iso.time.hour)
     }
 
     /// Returns the `minute` value for this `ZonedDateTime`.
-    pub fn minute(&self) -> TemporalResult<u8> {
-        let dt = self.tz.get_datetime_for(&self.instant, &self.calendar)?;
-        Ok(dt.minute())
+    pub fn minute_with_provider(&self, provider: &mut impl TzProvider) -> TemporalResult<u8> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        Ok(iso.time.minute)
     }
 
     /// Returns the `second` value for this `ZonedDateTime`.
-    pub fn second(&self) -> TemporalResult<u8> {
-        let dt = self.tz.get_datetime_for(&self.instant, &self.calendar)?;
-        Ok(dt.second())
+    pub fn second_with_provider(&self, provider: &mut impl TzProvider) -> TemporalResult<u8> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        Ok(iso.time.second)
     }
 
     /// Returns the `millisecond` value for this `ZonedDateTime`.
-    pub fn millisecond(&self) -> TemporalResult<u16> {
-        let dt = self.tz.get_datetime_for(&self.instant, &self.calendar)?;
-        Ok(dt.millisecond())
+    pub fn millisecond_with_provider(&self, provider: &mut impl TzProvider) -> TemporalResult<u16> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        Ok(iso.time.millisecond)
     }
 
     /// Returns the `microsecond` value for this `ZonedDateTime`.
-    pub fn microsecond(&self) -> TemporalResult<u16> {
-        let dt = self.tz.get_datetime_for(&self.instant, &self.calendar)?;
-        Ok(dt.millisecond())
+    pub fn microsecond_with_provider(&self, provider: &mut impl TzProvider) -> TemporalResult<u16> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        Ok(iso.time.millisecond)
     }
 
     /// Returns the `nanosecond` value for this `ZonedDateTime`.
-    pub fn nanosecond(&self) -> TemporalResult<u16> {
-        let dt = self.tz.get_datetime_for(&self.instant, &self.calendar)?;
-        Ok(dt.nanosecond())
+    pub fn nanosecond_with_provider(&self, provider: &mut impl TzProvider) -> TemporalResult<u16> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        Ok(iso.time.nanosecond)
     }
 }
 
+#[cfg(all(feature = "tzdb", not(target_os = "windows")))]
 #[cfg(test)]
 mod tests {
 
     use core::str::FromStr;
 
-    use crate::components::{calendar::Calendar, tz::TimeZone};
+    use crate::{components::calendar::Calendar, tzdb::FsTzdbProvider};
 
     use super::ZonedDateTime;
 
     #[test]
     fn basic_zdt_test() {
+        let provider = &mut FsTzdbProvider::default();
         let nov_30_2023_utc = 1_701_308_952_000_000_000i128;
 
         let zdt = ZonedDateTime::new(
             nov_30_2023_utc,
             Calendar::from_str("iso8601").unwrap(),
-            TimeZone {
-                iana: None,
-                offset: Some(0),
-            },
+            "Z".into(),
+        )
+        .unwrap();
+
+        assert_eq!(zdt.year_with_provider(provider).unwrap(), 2023);
+        assert_eq!(zdt.month_with_provider(provider).unwrap(), 11);
+        assert_eq!(zdt.day_with_provider(provider).unwrap(), 30);
+        assert_eq!(zdt.hour_with_provider(provider).unwrap(), 1);
+        assert_eq!(zdt.minute_with_provider(provider).unwrap(), 49);
+        assert_eq!(zdt.second_with_provider(provider).unwrap(), 12);
+
+        let zdt_minus_five = ZonedDateTime::new(
+            nov_30_2023_utc,
+            Calendar::from_str("iso8601").unwrap(),
+            "America/New_York".into(),
+        )
+        .unwrap();
+
+        assert_eq!(zdt_minus_five.year_with_provider(provider).unwrap(), 2023);
+        assert_eq!(zdt_minus_five.month_with_provider(provider).unwrap(), 11);
+        assert_eq!(zdt_minus_five.day_with_provider(provider).unwrap(), 29);
+        assert_eq!(zdt_minus_five.hour_with_provider(provider).unwrap(), 20);
+        assert_eq!(zdt_minus_five.minute_with_provider(provider).unwrap(), 49);
+        assert_eq!(zdt_minus_five.second_with_provider(provider).unwrap(), 12);
+
+        let zdt_plus_eleven = ZonedDateTime::new(
+            nov_30_2023_utc,
+            Calendar::from_str("iso8601").unwrap(),
+            "Australia/Sydney".into(),
+        )
+        .unwrap();
+
+        assert_eq!(zdt_plus_eleven.year_with_provider(provider).unwrap(), 2023);
+        assert_eq!(zdt_plus_eleven.month_with_provider(provider).unwrap(), 11);
+        assert_eq!(zdt_plus_eleven.day_with_provider(provider).unwrap(), 30);
+        assert_eq!(zdt_plus_eleven.hour_with_provider(provider).unwrap(), 12);
+        assert_eq!(zdt_plus_eleven.minute_with_provider(provider).unwrap(), 49);
+        assert_eq!(zdt_plus_eleven.second_with_provider(provider).unwrap(), 12);
+    }
+
+    #[cfg(all(feature = "experimental", not(target_os = "windows")))]
+    #[test]
+    fn static_tzdb_zdt_test() {
+        let nov_30_2023_utc = 1_701_308_952_000_000_000i128;
+
+        let zdt = ZonedDateTime::new(
+            nov_30_2023_utc,
+            Calendar::from_str("iso8601").unwrap(),
+            "Z".into(),
         )
         .unwrap();
 
@@ -188,10 +303,7 @@ mod tests {
         let zdt_minus_five = ZonedDateTime::new(
             nov_30_2023_utc,
             Calendar::from_str("iso8601").unwrap(),
-            TimeZone {
-                iana: None,
-                offset: Some(-300),
-            },
+            "America/New_York".into(),
         )
         .unwrap();
 
@@ -201,5 +313,19 @@ mod tests {
         assert_eq!(zdt_minus_five.hour().unwrap(), 20);
         assert_eq!(zdt_minus_five.minute().unwrap(), 49);
         assert_eq!(zdt_minus_five.second().unwrap(), 12);
+
+        let zdt_plus_eleven = ZonedDateTime::new(
+            nov_30_2023_utc,
+            Calendar::from_str("iso8601").unwrap(),
+            "Australia/Sydney".into(),
+        )
+        .unwrap();
+
+        assert_eq!(zdt_plus_eleven.year().unwrap(), 2023);
+        assert_eq!(zdt_plus_eleven.month().unwrap(), 11);
+        assert_eq!(zdt_plus_eleven.day().unwrap(), 30);
+        assert_eq!(zdt_plus_eleven.hour().unwrap(), 12);
+        assert_eq!(zdt_plus_eleven.minute().unwrap(), 49);
+        assert_eq!(zdt_plus_eleven.second().unwrap(), 12);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,10 @@
 extern crate alloc;
 extern crate core;
 
+// TODO: Support SystemTime directly / pull in OS code from std::time?
+#[cfg(feature = "std")]
+extern crate std;
+
 pub mod error;
 pub mod options;
 pub mod parsers;
@@ -50,6 +54,12 @@ pub mod primitive;
 
 pub(crate) mod components;
 pub(crate) mod iso;
+
+#[cfg(feature = "std")]
+mod sys;
+
+#[cfg(all(feature = "tzdb", not(target_os = "windows")))]
+pub mod tzdb;
 
 #[doc(hidden)]
 pub(crate) mod rounding;
@@ -83,6 +93,9 @@ pub use crate::components::{
     calendar::Calendar, Duration, Instant, PlainDate, PlainDateTime, PlainMonthDay, PlainTime,
     PlainYearMonth, ZonedDateTime,
 };
+
+#[cfg(feature = "std")]
+pub use crate::components::Now;
 
 /// A library specific trait for unwrapping assertions.
 pub(crate) trait TemporalUnwrap {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{TemporalError, TemporalResult};

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,0 +1,18 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::{TemporalError, TemporalResult};
+
+// TODO: Need to implement system handling for non_std.
+
+/// Returns the system time in nanoseconds.
+pub(crate) fn get_system_nanoseconds() -> TemporalResult<u128> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| TemporalError::general(e.to_string()))
+        .map(|d| d.as_nanos())
+}
+
+/// Returns the system tz identifier
+pub(crate) fn get_system_tz_identifier() -> TemporalResult<String> {
+    iana_time_zone::get_timezone().map_err(|e| TemporalError::general(e.to_string()))
+}

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -32,6 +32,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use alloc::string::{String, ToString};
+use alloc::{vec, vec::Vec};
+
 use tzif::{
     self,
     data::{

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -1,0 +1,364 @@
+// Relevant operations:
+//
+//  - Time Zone Identifiers
+//  - AvailableNamedTimeZoneIdentifiers
+//  - SystemTimeZoneIdentifier
+//  - IsTimeZoneOffsetString
+//  - GetNamedTimeZoneEpochNanoseconds
+//     - fn(id, isoDateTimeRecord) -> [epochNanoseconds]
+//  - GetNamedTimeZoneOffsetNanoseconds
+//     - fn(id, epochNanoseconds) -> [offset]
+
+// TODO: Potentially implement a IsoDateTimeRecord type to decouple
+// public facing APIs from IsoDateTime
+
+// Could return type be something like [Option<i128>; 2]
+
+// NOTE: tzif data is computed in glibc's `__tzfile_compute` in `tzfile.c`.
+//
+// Handling the logic here may be incredibly important for full tzif support.
+
+// NOTES:
+//
+// Transitions to DST (in march) + 1. Empty list between 2:00-3:00.
+// Transitions to Std (in nov) -1. Two elements 1:00-2:00 is repeated twice.
+
+// Transition Seconds + (offset diff)
+// where
+// offset diff = is_dst { dst_off - std_off } else { std_off - dst_off }, i.e. to_offset - from_offset
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use tzif::{
+    self,
+    data::{
+        time::Seconds,
+        tzif::{DataBlock, LocalTimeTypeRecord, TzifData},
+    },
+};
+
+use crate::{components::tz::TzProvider, iso::IsoDateTime, TemporalError, TemporalResult};
+
+const ZONEINFO_DIR: &str = "/usr/share/zoneinfo/";
+
+pub type TransitionInfo = [Option<LocalTimeTypeRecord>; 2];
+
+#[derive(Debug)]
+pub struct Tzif(TzifData);
+
+impl Tzif {
+    fn read_tzif(identifier: &str) -> TemporalResult<Self> {
+        let mut path = PathBuf::from(ZONEINFO_DIR);
+        path.push(identifier);
+        Self::from_path(&path)
+    }
+
+    pub fn from_path<P: AsRef<Path>>(path: P) -> TemporalResult<Self> {
+        tzif::parse_tzif_file(path)
+            .map(Self)
+            .map_err(|e| TemporalError::general(e.to_string()))
+    }
+
+    // There are ultimately
+    pub fn get(&self, epoch_seconds: &Seconds) -> TemporalResult<LocalTimeTypeRecord> {
+        self.binary_search(epoch_seconds)
+            .map(|idx| {
+                let db = self
+                    .0
+                    .data_block2
+                    .as_ref()
+                    .expect("binary search throws error if datablock doesn't exist.");
+                get_local_record(db, idx - 1)
+            })
+            .ok_or(TemporalError::general("No transition time found."))
+    }
+
+    // There are various other ways to search rather than binary_search. See glibc
+    pub fn binary_search(&self, epoch_seconds: &Seconds) -> Option<usize> {
+        self.0
+            .data_block2
+            .as_ref()
+            .map(|b| match b.transition_times.binary_search(epoch_seconds) {
+                Ok(idx) | Err(idx) => idx,
+            })
+    }
+
+    pub fn v2_estimate_tz_pair(
+        &self,
+        seconds: &Seconds,
+    ) -> TemporalResult<Vec<LocalTimeTypeRecord>> {
+        // We need to estimate a tz pair.
+        // First search the ambiguous seconds.
+        // TODO: it would be nice to resolve the Posix str into a local time type record.
+        let estimated_idx = self.binary_search(seconds).expect("values to exist. Although that won't always be the case, so handling via POSIX proleptic tz string.");
+
+        // The estimated index will be off based on the amount missing
+        // from the lack of offset.
+        //
+        // This means that we may need (idx, idx - 1) or (idx - 1, idx - 2)
+        let Some(ref data_block) = self.0.data_block2 else {
+            return Err(TemporalError::general("tbd"));
+        };
+
+        let record = get_local_record(data_block, estimated_idx);
+        let record_minus_one = get_local_record(data_block, estimated_idx - 1);
+
+        // Potential shift bugs with odd historical transitions?
+        let shift_window = usize::from((record.utoff + record_minus_one.utoff).0.signum() >= 0);
+
+        let new_idx = estimated_idx - shift_window;
+
+        let current_transition = data_block.transition_times[new_idx];
+        let current_diff = *seconds - current_transition;
+
+        let initial_record = get_local_record(data_block, new_idx - 1);
+        let next_record = get_local_record(data_block, new_idx);
+
+        let offset_range = if initial_record.utoff < next_record.utoff {
+            initial_record.utoff..next_record.utoff
+        } else {
+            next_record.utoff..initial_record.utoff
+        };
+        match offset_range.contains(&current_diff) {
+            true if next_record.is_dst => Ok(Vec::default()),
+            true => Ok(vec![initial_record, next_record]),
+            false => Ok(vec![initial_record]),
+        }
+    }
+}
+
+#[inline]
+fn get_local_record(db: &DataBlock, idx: usize) -> LocalTimeTypeRecord {
+    db.local_time_type_records[db.transition_types[idx]]
+}
+
+#[derive(Debug, Default)]
+pub struct FsTzdbProvider {
+    cache: HashMap<String, Tzif>,
+}
+
+impl FsTzdbProvider {
+    pub fn get(&mut self, identifier: &str) -> TemporalResult<&Tzif> {
+        if !self.cache.contains_key(identifier) {
+            let tzif = Tzif::read_tzif(identifier)?;
+            self.cache.insert(identifier.into(), tzif);
+            self.cache.get(identifier).ok_or(TemporalError::assert())
+        } else {
+            self.cache.get(identifier).ok_or(TemporalError::assert())
+        }
+    }
+}
+
+impl TzProvider for FsTzdbProvider {
+    fn check_identifier(&mut self, identifier: &str) -> bool {
+        self.get(identifier).is_ok()
+    }
+
+    fn get_named_tz_epoch_nanoseconds(
+        &mut self,
+        identifier: &str,
+        iso_datetime: IsoDateTime,
+    ) -> TemporalResult<Vec<i128>> {
+        let seconds = (iso_datetime
+            .as_nanoseconds()
+            .expect("IsoDateTime to be valid")
+            / 1_000_000_000) as i64;
+        let tzif = self.get(identifier)?;
+        let local_time_record_result = tzif.v2_estimate_tz_pair(&Seconds(seconds))?;
+        Ok(local_time_record_result
+            .iter()
+            .map(|r| r.utoff.0 as i128 * 1_000_000_000)
+            .collect())
+    }
+
+    fn get_named_tz_offset_nanoseconds(
+        &mut self,
+        identifier: &str,
+        epoch_nanoseconds: i128,
+    ) -> TemporalResult<i128> {
+        let tzif = self.get(identifier)?;
+        let seconds = (epoch_nanoseconds / 1_000_000_000) as i64;
+        let local_time_record_result = tzif.get(&Seconds(seconds))?;
+        Ok(local_time_record_result.utoff.0 as i128 * 1_000_000_000)
+    }
+}
+//
+
+#[cfg(test)]
+mod tests {
+    use tzif::data::time::Seconds;
+
+    use crate::{iso::IsoDateTime, tzdb::TzProvider};
+
+    use super::{FsTzdbProvider, Tzif};
+
+    #[test]
+    fn one_second_after_empty_edge_case() {
+        let mut provider = FsTzdbProvider::default();
+        let date = crate::iso::IsoDate {
+            year: 2017,
+            month: 3,
+            day: 12,
+        };
+        let time = crate::iso::IsoTime {
+            hour: 3,
+            minute: 0,
+            second: 0,
+            millisecond: 0,
+            microsecond: 0,
+            nanosecond: 0,
+        };
+        let today = IsoDateTime::new(date, time).unwrap();
+
+        let local = provider
+            .get_named_tz_epoch_nanoseconds("America/New_York", today)
+            .unwrap();
+        assert_eq!(local.len(), 1);
+    }
+
+    #[test]
+    fn one_second_before_empty_edge_case() {
+        let mut provider = FsTzdbProvider::default();
+        let date = crate::iso::IsoDate {
+            year: 2017,
+            month: 3,
+            day: 12,
+        };
+        let time = crate::iso::IsoTime {
+            hour: 2,
+            minute: 59,
+            second: 59,
+            millisecond: 0,
+            microsecond: 0,
+            nanosecond: 0,
+        };
+        let today = IsoDateTime::new(date, time).unwrap();
+
+        let local = provider
+            .get_named_tz_epoch_nanoseconds("America/New_York", today)
+            .unwrap();
+        assert!(local.is_empty());
+    }
+
+    #[test]
+    fn new_york_empty_test_case() {
+        let date = crate::iso::IsoDate {
+            year: 2017,
+            month: 3,
+            day: 12,
+        };
+        let time = crate::iso::IsoTime {
+            hour: 2,
+            minute: 30,
+            second: 0,
+            millisecond: 0,
+            microsecond: 0,
+            nanosecond: 0,
+        };
+        let edge_case = IsoDateTime::new(date, time).unwrap();
+        let edge_case_seconds = edge_case
+            .as_nanoseconds()
+            .map_or(0, |nanos| (nanos / 1_000_000_000) as i64);
+
+        let new_york = Tzif::read_tzif("America/New_York");
+        assert!(new_york.is_ok());
+        let new_york = new_york.unwrap();
+
+        let locals = new_york
+            .v2_estimate_tz_pair(&Seconds(edge_case_seconds))
+            .unwrap();
+        assert!(locals.is_empty());
+    }
+
+    #[test]
+    fn sydney_empty_test_case() {
+        // Australia Daylight savings day
+        let date = crate::iso::IsoDate {
+            year: 2017,
+            month: 10,
+            day: 1,
+        };
+        let time = crate::iso::IsoTime {
+            hour: 2,
+            minute: 30,
+            second: 0,
+            millisecond: 0,
+            microsecond: 0,
+            nanosecond: 0,
+        };
+        let today = IsoDateTime::new(date, time).unwrap();
+        let seconds = today
+            .as_nanoseconds()
+            .map_or(0, |nanos| (nanos / 1_000_000_000) as i64);
+
+        let sydney = Tzif::read_tzif("Australia/Sydney");
+        assert!(sydney.is_ok());
+        let sydney = sydney.unwrap();
+
+        let locals = sydney.v2_estimate_tz_pair(&Seconds(seconds)).unwrap();
+        assert!(locals.is_empty());
+    }
+
+    #[test]
+    fn new_york_duplicate_case() {
+        let date = crate::iso::IsoDate {
+            year: 2017,
+            month: 11,
+            day: 5,
+        };
+        let time = crate::iso::IsoTime {
+            hour: 1,
+            minute: 30,
+            second: 0,
+            millisecond: 0,
+            microsecond: 0,
+            nanosecond: 0,
+        };
+        let edge_case = IsoDateTime::new(date, time).unwrap();
+        let edge_case_seconds = edge_case
+            .as_nanoseconds()
+            .map_or(0, |nanos| (nanos / 1_000_000_000) as i64);
+
+        let new_york = Tzif::read_tzif("America/New_York");
+        assert!(new_york.is_ok());
+        let new_york = new_york.unwrap();
+
+        let locals = new_york
+            .v2_estimate_tz_pair(&Seconds(edge_case_seconds))
+            .unwrap();
+
+        assert_eq!(locals.len(), 2);
+    }
+
+    #[test]
+    fn sydney_duplicate_case() {
+        // Australia Daylight savings day
+        let date = crate::iso::IsoDate {
+            year: 2017,
+            month: 4,
+            day: 2,
+        };
+        let time = crate::iso::IsoTime {
+            hour: 2,
+            minute: 30,
+            second: 0,
+            millisecond: 0,
+            microsecond: 0,
+            nanosecond: 0,
+        };
+        let today = IsoDateTime::new(date, time).unwrap();
+        let seconds = today
+            .as_nanoseconds()
+            .map_or(0, |nanos| (nanos / 1_000_000_000) as i64);
+
+        let sydney = Tzif::read_tzif("Australia/Sydney");
+        assert!(sydney.is_ok());
+        let sydney = sydney.unwrap();
+
+        let locals = sydney.v2_estimate_tz_pair(&Seconds(seconds)).unwrap();
+        assert_eq!(locals.len(), 2);
+    }
+}

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -97,7 +97,6 @@ impl Tzif {
             .ok_or(TemporalError::general("Only Tzif V2+ is supported."))
     }
 
-    // There are ultimately
     pub fn get(&self, epoch_seconds: &Seconds) -> TemporalResult<LocalTimeTypeRecord> {
         let result = self.binary_search(epoch_seconds)?;
 

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -101,7 +101,6 @@ impl Tzif {
         // We need to estimate a tz pair.
         // First search the ambiguous seconds.
         // TODO: it would be nice to resolve the Posix str into a local time type record.
-        println!("Searching for{:?}", seconds);
         let Some(b_search_result) = self.binary_search(seconds) else {
             return Err(TemporalError::general("Only Tzif v2+ is supported."));
         };
@@ -111,8 +110,6 @@ impl Tzif {
             .data_block2
             .as_ref()
             .expect("binary_search validates that data_block2 exists.");
-
-        println!("Data block: {:?}", data_block);
 
         let estimated_idx = match b_search_result {
             Ok(idx) => idx,

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -147,7 +147,7 @@ impl Tzif {
         };
         match offset_range.contains(&current_diff) {
             true if next_record.is_dst => Ok(Vec::default()),
-            true => Ok(vec![initial_record, next_record]),
+            true => Ok(vec![next_record, initial_record]),
             false => Ok(vec![initial_record]),
         }
     }

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -116,7 +116,7 @@ impl Tzif {
     // For more information, see /docs/TZDB.md
     /// This function determines the Time Zone output for a local epoch
     /// nanoseconds value without an offset.
-    /// 
+    ///
     /// Basically, if someone provides a DateTime 2017-11-05T01:30:00,
     /// we have no way of knowing if this value is in DST or STD.
     /// Furthermore, for the above example, this should return 2 time


### PR DESCRIPTION
And thus begins the Great Time Zone / `ZonedDateTime` implementation. :sweat_smile: 

This stubs out `tzdb` support by relying solely on the user's zoneinfo files, and should allow us to move forward with implementing and testing `ZonedDateTime` without being blocked by a proper tzdb provider for Boa.

This PR implements:

  - `Now` builtin
  - `FsTzdbProvider` stub
  - Some `ZonedDateTime` APIs along with experimental, non-engine focused APIs.
  
Things of note that are not in this PR:
  
  - Handling POSIX's [proleptic tz format](https://snapshots.sourceware.org/glibc/trunk/2024-06-27_16-55_1719507301/manual/html_node/Proleptic-TZ.html) and non-fat version of the TZDB.
  - Any thing zoneinfo / `zic` related.
  - Tests for more time zone edge cases
  - Many `ZonedDateTime` methods and abstract ops
  - **Windows Support**
  
Let me know what you think :) 