### PR TITLE
Move to no_std

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,12 @@ jobs:
         uses: taiki-e/install-action@nextest
       - name: Test
         run: cargo test
-
+      - name: Cargo build --all-features
+        run: cargo build --quiet --all-features
+      - name: Install latest nextest
+        uses: taiki-e/install-action@nextest
+      - name: Test --all-features
+        run: cargo test --all-features
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +263,7 @@ dependencies = [
  "bitflags",
  "icu_calendar",
  "ixdtf",
+ "log",
  "num-bigint",
  "num-traits",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ bitflags = "2.6.0"
 num-bigint = { version = "0.4.6", features = ["serde"] }
 num-traits = "0.2.19"
 ixdtf = { version = "0.2.0", features = ["duration"]}
+log = { version = "0.4.0", optional = true }
+
+
+[features]
+log = ["dep:log"]

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -3,7 +3,10 @@
 //! The goal of the calendar module of `boa_temporal` is to provide
 //! Temporal compatible calendar implementations.
 
-use std::str::FromStr;
+use alloc::borrow::ToOwned;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::str::FromStr;
 
 use crate::{
     components::{

--- a/src/components/calendar/era.rs
+++ b/src/components/calendar/era.rs
@@ -9,7 +9,7 @@
 
 // TODO (0.1.0): Feature flag certain eras as experimental
 
-use std::ops::RangeInclusive;
+use core::ops::RangeInclusive;
 
 use tinystr::{tinystr, TinyAsciiStr};
 

--- a/src/components/calendar/types.rs
+++ b/src/components/calendar/types.rs
@@ -2,6 +2,8 @@
 
 use tinystr::{tinystr, TinyAsciiStr};
 
+use alloc::format;
+
 use crate::iso::{constrain_iso_day, is_valid_iso_day};
 use crate::options::ArithmeticOverflow;
 use crate::{TemporalError, TemporalResult};

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -17,7 +17,9 @@ use crate::{
     primitive::FiniteF64,
     Sign, TemporalError, TemporalResult, TemporalUnwrap,
 };
-use std::str::FromStr;
+
+use alloc::format;
+use core::str::FromStr;
 
 use super::{
     calendar::{ascii_four_to_integer, month_to_month_code},
@@ -131,13 +133,13 @@ pub struct PlainDate {
 }
 
 impl Ord for PlainDate {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.iso.cmp(&other.iso)
     }
 }
 
 impl PartialOrd for PlainDate {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -11,8 +11,8 @@ use crate::{
     temporal_assert, Sign, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
+use core::{cmp::Ordering, str::FromStr};
 use num_traits::AsPrimitive;
-use std::{cmp::Ordering, str::FromStr};
 use tinystr::TinyAsciiStr;
 
 use super::{
@@ -648,7 +648,7 @@ impl FromStr for PlainDateTime {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     use tinystr::{tinystr, TinyAsciiStr};
 

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -7,9 +7,12 @@ use crate::{
     primitive::FiniteF64,
     temporal_assert, Sign, TemporalError, TemporalResult,
 };
+use alloc::format;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::str::FromStr;
 use ixdtf::parsers::{records::TimeDurationRecord, IsoDurationParser};
 use num_traits::AsPrimitive;
-use std::str::FromStr;
 
 use self::normalized::NormalizedTimeDuration;
 
@@ -651,7 +654,7 @@ pub(crate) fn is_valid_duration(
     // 7. NOTE: The above step cannot be implemented directly using floating-point arithmetic.
     // Multiplying by 10**-3, 10**-6, and 10**-9 respectively may be imprecise when milliseconds,
     // microseconds, or nanoseconds is an unsafe integer. This multiplication can be implemented
-    // in C++ with an implementation of std::remquo() with sufficient bits in the quotient.
+    // in C++ with an implementation of core::remquo() with sufficient bits in the quotient.
     // String manipulation will also give an exact result, since the multiplication is by a power of 10.
     // Seconds part
     let normalized_seconds = days.0.mul_add(

--- a/src/components/duration/date.rs
+++ b/src/components/duration/date.rs
@@ -1,6 +1,7 @@
 //! Implementation of a `DateDuration`
 
 use crate::{primitive::FiniteF64, Sign, TemporalError, TemporalResult};
+use alloc::vec::Vec;
 
 /// `DateDuration` represents the [date duration record][spec] of the `Duration.`
 ///

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -1,6 +1,6 @@
 //! This module implements the normalized `Duration` records.
 
-use std::{num::NonZeroU128, ops::Add};
+use core::{num::NonZeroU128, ops::Add};
 
 use num_traits::{AsPrimitive, Euclid, FromPrimitive};
 

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -180,11 +180,11 @@ impl TimeDuration {
             _ => temporal_assert!(largest_unit == TemporalUnit::Nanosecond),
         }
 
-        // NOTE(nekevss): `mul_add` is essentially the Rust's implementation of `core::fma()`, so that's handy, but
+        // NOTE(nekevss): `mul_add` is essentially the Rust's implementation of `std::fma()`, so that's handy, but
         // this should be tested much further.
         // 11. NOTE: When largestUnit is "millisecond", "microsecond", or "nanosecond", milliseconds, microseconds, or
         // nanoseconds may be an unsafe integer. In this case, care must be taken when implementing the calculation
-        // using floating point arithmetic. It can be implemented in C++ using core::fma(). String manipulation will also
+        // using floating point arithmetic. It can be implemented in C++ using std::fma(). String manipulation will also
         // give an exact result, since the multiplication is by a power of 10.
 
         // NOTE: days may have the potentially to exceed i64

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -6,6 +6,7 @@ use crate::{
 
 use super::{is_valid_duration, normalized::NormalizedTimeDuration};
 
+use alloc::vec::Vec;
 use num_traits::Euclid;
 
 /// `TimeDuration` represents the [Time Duration record][spec] of the `Duration.`
@@ -179,11 +180,11 @@ impl TimeDuration {
             _ => temporal_assert!(largest_unit == TemporalUnit::Nanosecond),
         }
 
-        // NOTE(nekevss): `mul_add` is essentially the Rust's implementation of `std::fma()`, so that's handy, but
+        // NOTE(nekevss): `mul_add` is essentially the Rust's implementation of `core::fma()`, so that's handy, but
         // this should be tested much further.
         // 11. NOTE: When largestUnit is "millisecond", "microsecond", or "nanosecond", milliseconds, microseconds, or
         // nanoseconds may be an unsafe integer. In this case, care must be taken when implementing the calculation
-        // using floating point arithmetic. It can be implemented in C++ using std::fma(). String manipulation will also
+        // using floating point arithmetic. It can be implemented in C++ using core::fma(). String manipulation will also
         // give an exact result, since the multiplication is by a power of 10.
 
         // NOTE: days may have the potentially to exceed i64

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -1,6 +1,6 @@
 //! An implementation of the Temporal Instant.
 
-use std::{num::NonZeroU128, str::FromStr};
+use core::{num::NonZeroU128, str::FromStr};
 
 use crate::{
     components::{duration::TimeDuration, Duration},

--- a/src/components/month_day.rs
+++ b/src/components/month_day.rs
@@ -1,6 +1,6 @@
 //! This module implements `MonthDay` and any directly related algorithms.
 
-use std::str::FromStr;
+use core::str::FromStr;
 
 use tinystr::TinyAsciiStr;
 

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::{duration::normalized::NormalizedTimeDuration, PlainDateTime};
 
-use std::str::FromStr;
+use core::str::FromStr;
 
 /// A `PartialTime` represents partially filled `Time` fields.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -1,5 +1,7 @@
 //! This module implements the Temporal `TimeZone` and components.
 
+use alloc::string::String;
+use alloc::vec::Vec;
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 

--- a/src/components/year_month.rs
+++ b/src/components/year_month.rs
@@ -1,6 +1,7 @@
 //! This module implements `YearMonth` and any directly related algorithms.
 
-use std::str::FromStr;
+use alloc::string::String;
+use core::str::FromStr;
 
 use tinystr::TinyAsciiStr;
 

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -19,13 +19,13 @@ pub struct ZonedDateTime {
 }
 
 impl Ord for ZonedDateTime {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.instant.cmp(&other.instant)
     }
 }
 
 impl PartialOrd for ZonedDateTime {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
@@ -158,7 +158,7 @@ impl ZonedDateTime {
 #[cfg(test)]
 mod tests {
 
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     use crate::components::{calendar::Calendar, tz::TimeZone};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 //! This module implements `TemporalError`.
 
+use alloc::boxed::Box;
+use alloc::string::ToString;
 use core::fmt;
 
 use icu_calendar::CalendarError;

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -12,7 +12,8 @@
 //!
 //! An `IsoDateTime` has the internal slots of both an `IsoDate` and `IsoTime`.
 
-use std::num::NonZeroU128;
+use alloc::string::ToString;
+use core::num::NonZeroU128;
 
 use crate::{
     components::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
+#![no_std]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
 #![allow(
     // Currently throws a false positive regarding dependencies that are only used in benchmarks.
@@ -39,6 +40,9 @@
     clippy::missing_panics_doc,
 )]
 
+extern crate alloc;
+extern crate core;
+
 pub mod error;
 pub mod options;
 pub mod parsers;
@@ -52,7 +56,7 @@ pub(crate) mod rounding;
 #[doc(hidden)]
 pub(crate) mod utils;
 
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 // TODO: evaluate positives and negatives of using tinystr. Re-exporting
 // tinystr as a convenience, as it is currently tied into the API.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,8 @@ macro_rules! temporal_assert {
     };
     ($condition:expr, $($args:tt)+) => {
         if !$condition {
-            println!($($args)+);
+            #[cfg(feature = "log")]
+            log::error!($($args)+);
             return Err(TemporalError::assert());
         }
     };

--- a/src/options.rs
+++ b/src/options.rs
@@ -3,8 +3,8 @@
 //! Temporal has various instances where user's can define options for how an
 //! operation may be completed.
 
+use core::ops::Add;
 use core::{fmt, str::FromStr};
-use std::ops::Add;
 
 use crate::{
     components::{PlainDate, ZonedDateTime},
@@ -342,7 +342,7 @@ impl Add<usize> for TemporalUnit {
 pub struct ParseTemporalUnitError;
 
 impl fmt::Display for ParseTemporalUnitError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("provided string was not a valid TemporalUnit")
     }
 }
@@ -369,7 +369,7 @@ impl FromStr for TemporalUnit {
 }
 
 impl fmt::Display for TemporalUnit {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Auto => "auto",
             Self::Year => "year",
@@ -403,7 +403,7 @@ pub enum ArithmeticOverflow {
 pub struct ParseArithmeticOverflowError;
 
 impl fmt::Display for ParseArithmeticOverflowError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("provided string was not a valid overflow value")
     }
 }
@@ -421,7 +421,7 @@ impl FromStr for ArithmeticOverflow {
 }
 
 impl fmt::Display for ArithmeticOverflow {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Constrain => "constrain",
             Self::Reject => "reject",
@@ -444,7 +444,7 @@ pub enum DurationOverflow {
 pub struct ParseDurationOverflowError;
 
 impl fmt::Display for ParseDurationOverflowError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("provided string was not a valid duration overflow value")
     }
 }
@@ -462,7 +462,7 @@ impl FromStr for DurationOverflow {
 }
 
 impl fmt::Display for DurationOverflow {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Constrain => "constrain",
             Self::Balance => "balance",
@@ -489,7 +489,7 @@ pub enum InstantDisambiguation {
 pub struct ParseInstantDisambiguationError;
 
 impl fmt::Display for ParseInstantDisambiguationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("provided string was not a valid instant disambiguation value")
     }
 }
@@ -509,7 +509,7 @@ impl FromStr for InstantDisambiguation {
 }
 
 impl fmt::Display for InstantDisambiguation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Compatible => "compatible",
             Self::Earlier => "earlier",
@@ -538,7 +538,7 @@ pub enum OffsetDisambiguation {
 pub struct ParseOffsetDisambiguationError;
 
 impl fmt::Display for ParseOffsetDisambiguationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("provided string was not a valid offset disambiguation value")
     }
 }
@@ -558,7 +558,7 @@ impl FromStr for OffsetDisambiguation {
 }
 
 impl fmt::Display for OffsetDisambiguation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Use => "use",
             Self::Prefer => "prefer",
@@ -674,7 +674,7 @@ impl FromStr for TemporalRoundingMode {
 }
 
 impl fmt::Display for TemporalRoundingMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Ceil => "ceil",
             Self::Floor => "floor",
@@ -705,7 +705,7 @@ pub enum CalendarName {
 }
 
 impl fmt::Display for CalendarName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             CalendarName::Auto => "auto",
             CalendarName::Always => "always",

--- a/src/options/increment.rs
+++ b/src/options/increment.rs
@@ -1,4 +1,4 @@
-use std::num::{NonZeroU128, NonZeroU32};
+use core::num::{NonZeroU128, NonZeroU32};
 
 use crate::{TemporalError, TemporalResult};
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,5 +1,7 @@
 //! This module implements Temporal Date/Time parsing functionality.
 
+use alloc::format;
+
 use crate::{TemporalError, TemporalResult, TemporalUnwrap};
 
 use ixdtf::parsers::{

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -132,7 +132,7 @@ impl PartialEq<f64> for FiniteF64 {
 }
 
 impl PartialOrd<f64> for FiniteF64 {
-    fn partial_cmp(&self, other: &f64) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &f64) -> Option<core::cmp::Ordering> {
         self.0.partial_cmp(other)
     }
 }

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -5,7 +5,7 @@ use crate::{
     temporal_assert, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
-use std::{
+use core::{
     cmp::Ordering,
     num::NonZeroU128,
     ops::{Div, Neg},
@@ -199,7 +199,7 @@ fn apply_unsigned_rounding_mode<T: Roundable>(
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU128;
+    use core::num::NonZeroU128;
 
     use super::{IncrementRounder, Round, TemporalRoundingMode};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,8 @@
 //! Utility date and time equations for Temporal
 
+use alloc::format;
+use alloc::string::String;
+
 use crate::MS_PER_DAY;
 
 // NOTE: Review the below for optimizations and add ALOT of tests.


### PR DESCRIPTION
This moves the crate over to `no_std` so it can be used on more platforms and doesn't require linking in the rust standard library.

I wasn't sure what to do with `temporal_assert`. I think in general the printing functionality of `temporal_assert` should be behind some feature anyway? I'm not a huge fan of libraries choosing to output stuff to stdout. Perhaps the log crate can be used as an optional dep instead.