### PR TITLE
Remove num-bigint dependency and rely on primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,26 +156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,7 +244,6 @@ dependencies = [
  "icu_calendar",
  "ixdtf",
  "log",
- "num-bigint",
  "num-traits",
  "rustc-hash",
  "tinystr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ tinystr = "0.7.6"
 icu_calendar = { version = "1.5.2", default-features = false, features = ["compiled_data"] }
 rustc-hash = { version = "2.0.0", features = ["std"] }
 bitflags = "2.6.0"
-num-bigint = { version = "0.4.6", features = ["serde"] }
 num-traits = "0.2.19"
 ixdtf = { version = "0.2.0", features = ["duration"]}
 log = { version = "0.4.0", optional = true }

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -2,7 +2,6 @@
 
 use alloc::string::String;
 use alloc::vec::Vec;
-use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 
 use crate::{
@@ -30,13 +29,13 @@ impl TimeZone {
 
 impl TimeZone {
     /// Get the offset for this current `TimeZoneSlot`.
-    pub fn get_offset_nanos_for(&self) -> TemporalResult<BigInt> {
+    pub fn get_offset_nanos_for(&self) -> TemporalResult<i128> {
         // 1. Let timeZone be the this value.
         // 2. Perform ? RequireInternalSlot(timeZone, [[InitializedTemporalTimeZone]]).
         // 3. Set instant to ? ToTemporalInstant(instant).
         // 4. If timeZone.[[OffsetMinutes]] is not empty, return 𝔽(timeZone.[[OffsetMinutes]] × (60 × 10^9)).
         if let Some(offset) = &self.offset {
-            return Ok(BigInt::from(i64::from(*offset) * 60_000_000_000i64));
+            return Ok(i128::from(*offset) * 60_000_000_000);
         }
         // 5. Return 𝔽(GetNamedTimeZoneOffsetNanoseconds(timeZone.[[Identifier]], instant.[[Nanoseconds]])).
         Err(TemporalError::range().with_message("IANA TimeZone names not yet implemented."))

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -12,7 +12,9 @@ use crate::{
 /// A Temporal `TimeZone`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TimeZone {
+    /// The IANA identifier for this time zone.
     pub(crate) iana: Option<String>, // TODO: ICU4X IANA TimeZone support.
+    /// The offset minutes of a time zone.
     pub(crate) offset: Option<i16>,
 }
 

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -31,7 +31,6 @@ use crate::{
     temporal_assert, utils, TemporalResult, TemporalUnwrap, NS_PER_DAY,
 };
 use icu_calendar::{Date as IcuDate, Iso};
-use num_bigint::BigInt;
 use num_traits::{cast::FromPrimitive, AsPrimitive, ToPrimitive};
 
 /// `IsoDateTime` is the record of the `IsoDate` and `IsoTime` internal slots.
@@ -894,15 +893,15 @@ fn iso_dt_within_valid_limits(date: IsoDate, time: &IsoTime) -> bool {
         return false;
     };
 
-    let max = BigInt::from(crate::NS_MAX_INSTANT + i128::from(NS_PER_DAY));
-    let min = BigInt::from(crate::NS_MIN_INSTANT - i128::from(NS_PER_DAY));
+    let max = crate::NS_MAX_INSTANT + i128::from(NS_PER_DAY);
+    let min = crate::NS_MIN_INSTANT - i128::from(NS_PER_DAY);
 
     min <= ns && max >= ns
 }
 
 #[inline]
 /// Utility function to convert a `IsoDate` and `IsoTime` values into epoch nanoseconds
-fn utc_epoch_nanos(date: IsoDate, time: &IsoTime, offset: f64) -> Option<BigInt> {
+fn utc_epoch_nanos(date: IsoDate, time: &IsoTime, offset: f64) -> Option<i128> {
     let ms = time.to_epoch_ms();
     let epoch_ms = utils::epoch_days_to_epoch_ms(date.to_epoch_days(), ms);
 
@@ -911,7 +910,7 @@ fn utc_epoch_nanos(date: IsoDate, time: &IsoTime, offset: f64) -> Option<BigInt>
         f64::from(time.microsecond).mul_add(1_000f64, f64::from(time.nanosecond)),
     );
 
-    BigInt::from_f64(epoch_nanos - offset)
+    i128::from_f64(epoch_nanos - offset)
 }
 
 // ==== `IsoDate` specific utiltiy functions ====


### PR DESCRIPTION
This PR removes the `num_bigint` dependency from the project that was primarily technical debt from the earlier days of `temporal_rs`