### PR TITLE
Adds `into_message` to `TemporalError`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -109,6 +109,12 @@ impl TemporalError {
     pub fn message(&self) -> &str {
         &self.msg
     }
+
+    /// Extracts the error message.
+    #[must_use]
+    pub fn into_message(self) -> Box<str> {
+        self.msg
+    }
 }
 
 impl fmt::Display for TemporalError {


### PR DESCRIPTION
For efficient conversion in https://github.com/boa-dev/boa/blob/e9586b8d004220c20ed1391a3e12a9011260cadc/core/engine/src/builtins/temporal/error.rs#L8-L11.