### PR TITLE
Implement  `PartialZonedDateTime` and `from_partial` and `from_str` for `ZonedDateTime`

### DIFF
--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -276,7 +276,7 @@ impl PlainDate {
         // 12. If roundingGranularityIsNoop is false, then
         let date_duration = if !rounding_granularity_is_noop {
             // a. Let destEpochNs be GetUTCEpochNanoseconds(other.[[ISOYear]], other.[[ISOMonth]], other.[[ISODay]], 0, 0, 0, 0, 0, 0).
-            let dest_epoch_ns = other.iso.as_nanoseconds().temporal_unwrap()?;
+            let dest_epoch_ns = other.iso.as_nanoseconds()?;
             // b. Let dateTime be ISO Date-Time Record { [[Year]]: temporalDate.[[ISOYear]], [[Month]]: temporalDate.[[ISOMonth]], [[Day]]: temporalDate.[[ISODay]], [[Hour]]: 0, [[Minute]]: 0, [[Second]]: 0, [[Millisecond]]: 0, [[Microsecond]]: 0, [[Nanosecond]]: 0 }.
             let dt = PlainDateTime::new_unchecked(
                 IsoDateTime::new_unchecked(self.iso, IsoTime::default()),
@@ -284,7 +284,7 @@ impl PlainDate {
             );
             // c. Set duration to ? RoundRelativeDuration(duration, destEpochNs, dateTime, calendarRec, unset, settings.[[LargestUnit]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
             *duration
-                .round_relative_duration(dest_epoch_ns, &dt, None, resolved)?
+                .round_relative_duration(dest_epoch_ns.0, &dt, None, resolved)?
                 .0
                 .date()
         } else {

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -74,7 +74,7 @@ impl PlainDateTime {
     #[allow(unused)]
     pub(crate) fn from_instant(
         instant: &Instant,
-        offset: f64,
+        offset: i64,
         calendar: Calendar,
     ) -> TemporalResult<Self> {
         let iso = IsoDateTime::from_epoch_nanos(&instant.as_i128(), offset)?;
@@ -213,11 +213,11 @@ impl PlainDateTime {
         // [[Day]]: d1, [[Hour]]: h1, [[Minute]]: min1, [[Second]]: s1, [[Millisecond]]:
         // ms1, [[Microsecond]]: mus1, [[Nanosecond]]: ns1 }.
         // 7. Let destEpochNs be GetUTCEpochNanoseconds(y2, mon2, d2, h2, min2, s2, ms2, mus2, ns2).
-        let dest_epoch_ns = other.iso.as_nanoseconds().temporal_unwrap()?;
+        let dest_epoch_ns = other.iso.as_nanoseconds()?;
 
         // 8. Return ? RoundRelativeDuration(diff, destEpochNs, dateTime, calendarRec, unset, largestUnit,
         // roundingIncrement, smallestUnit, roundingMode).
-        diff.round_relative_duration(dest_epoch_ns, self, None, options)
+        diff.round_relative_duration(dest_epoch_ns.0, self, None, options)
     }
 }
 

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -493,10 +493,7 @@ impl NormalizedDurationRecord {
             // TODO: Test valid range of EpochNanoseconds in order to add `expect` over `unwrap_or`
             // a. Let startEpochNs be GetUTCEpochNanoseconds(start.[[Year]], start.[[Month]], start.[[Day]], start.[[Hour]], start.[[Minute]], start.[[Second]], start.[[Millisecond]], start.[[Microsecond]], start.[[Nanosecond]]).
             // b. Let endEpochNs be GetUTCEpochNanoseconds(end.[[Year]], end.[[Month]], end.[[Day]], end.[[Hour]], end.[[Minute]], end.[[Second]], end.[[Millisecond]], end.[[Microsecond]], end.[[Nanosecond]]).
-            (
-                start.as_nanoseconds()?,
-                end.as_nanoseconds()?,
-            )
+            (start.as_nanoseconds()?, end.as_nanoseconds()?)
         // 8. Else,
         } else {
             // a. Let startDateTime be ! CreateTemporalDateTime(start.[[Year]], start.[[Month]], start.[[Day]],

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -494,8 +494,8 @@ impl NormalizedDurationRecord {
             // a. Let startEpochNs be GetUTCEpochNanoseconds(start.[[Year]], start.[[Month]], start.[[Day]], start.[[Hour]], start.[[Minute]], start.[[Second]], start.[[Millisecond]], start.[[Microsecond]], start.[[Nanosecond]]).
             // b. Let endEpochNs be GetUTCEpochNanoseconds(end.[[Year]], end.[[Month]], end.[[Day]], end.[[Hour]], end.[[Minute]], end.[[Second]], end.[[Millisecond]], end.[[Microsecond]], end.[[Nanosecond]]).
             (
-                start.as_nanoseconds().unwrap_or(0),
-                end.as_nanoseconds().unwrap_or(0),
+                start.as_nanoseconds()?,
+                end.as_nanoseconds()?,
             )
         // 8. Else,
         } else {
@@ -531,7 +531,7 @@ impl NormalizedDurationRecord {
         // 12. Let progress be (destEpochNs - startEpochNs) / (endEpochNs - startEpochNs).
         // 13. Let total be r1 + progress × increment × sign.
         let progress =
-            (dest_epoch_ns - start_epoch_ns) as f64 / (end_epoch_ns - start_epoch_ns) as f64;
+            (dest_epoch_ns - start_epoch_ns.0) as f64 / (end_epoch_ns.0 - start_epoch_ns.0) as f64;
         let total = r1 as f64
             + progress * options.increment.get() as f64 * f64::from(sign.as_sign_multiplier());
 
@@ -561,7 +561,7 @@ impl NormalizedDurationRecord {
                     NormalizedTimeDuration::default(),
                 )?,
                 total: Some(total as i128),
-                nudge_epoch_ns: end_epoch_ns,
+                nudge_epoch_ns: end_epoch_ns.0,
                 expanded: true,
             })
         // 18. Else,
@@ -575,7 +575,7 @@ impl NormalizedDurationRecord {
                     NormalizedTimeDuration::default(),
                 )?,
                 total: Some(total as i128),
-                nudge_epoch_ns: start_epoch_ns,
+                nudge_epoch_ns: start_epoch_ns.0,
                 expanded: false,
             })
         }
@@ -782,10 +782,10 @@ impl NormalizedDurationRecord {
             } else {
                 // 1. Let endEpochNs be GetUTCEpochNanoseconds(end.[[Year]], end.[[Month]], end.[[Day]], end.[[Hour]],
                 // end.[[Minute]], end.[[Second]], end.[[Millisecond]], end.[[Microsecond]], end.[[Nanosecond]]).
-                end.as_nanoseconds().temporal_unwrap()?
+                end.as_nanoseconds()?
             };
             // viii. Let beyondEnd be nudgedEpochNs - endEpochNs.
-            let beyond_end = nudge_epoch_ns - end_epoch_ns;
+            let beyond_end = nudge_epoch_ns - end_epoch_ns.0;
             // ix. If beyondEnd < 0, let beyondEndSign be -1; else if beyondEnd > 0, let beyondEndSign be 1; else let beyondEndSign be 0.
             // x. If beyondEndSign ≠ -sign, then
             if beyond_end.signum() != -i128::from(sign.as_sign_multiplier()) {

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -24,7 +24,7 @@ const NANOSECONDS_PER_MINUTE: f64 = 60f64 * NANOSECONDS_PER_SECOND;
 const NANOSECONDS_PER_HOUR: f64 = 60f64 * NANOSECONDS_PER_MINUTE;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct EpochNanoseconds(i128);
+pub struct EpochNanoseconds(pub(crate) i128);
 
 impl TryFrom<i128> for EpochNanoseconds {
     type Error = TemporalError;
@@ -321,9 +321,9 @@ impl FromStr for Instant {
 
         let nanoseconds = IsoDateTime::new_unchecked(iso_date, iso_time)
             .as_nanoseconds()
-            .map(|v| v + offset as i128);
+            .map(|v| v.0 + offset as i128);
 
-        Self::from_epoch_milliseconds(nanoseconds.unwrap_or(i128::MAX))
+        Self::try_new(nanoseconds.unwrap_or(i128::MAX))
     }
 }
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -40,4 +40,4 @@ pub use time::{PartialTime, PlainTime};
 #[doc(inline)]
 pub use year_month::PlainYearMonth;
 #[doc(inline)]
-pub use zoneddatetime::ZonedDateTime;
+pub use zoneddatetime::{PartialZonedDateTime, ZonedDateTime};

--- a/src/components/now.rs
+++ b/src/components/now.rs
@@ -51,7 +51,7 @@ fn system_date_time(
     // a. Let timeZone be SystemTimeZoneIdentifier().
     // 2. Else,
     // a. Let timeZone be ? ToTemporalTimeZoneIdentifier(temporalTimeZoneLike).
-    let tz = tz.unwrap_or(sys::get_system_tz_identifier()?.into());
+    let tz = tz.unwrap_or(TimeZone::IanaIdentifier(sys::get_system_tz_identifier()?));
     // 3. Let epochNs be SystemUTCEpochNanoseconds().
     // TODO: Handle u128 -> i128 better for system nanoseconds
     let epoch_ns = EpochNanoseconds::try_from(sys::get_system_nanoseconds()?)?;

--- a/src/components/now.rs
+++ b/src/components/now.rs
@@ -3,13 +3,10 @@
 use crate::{sys, TemporalResult};
 use alloc::string::String;
 
-#[cfg(feature = "std")]
 use num_traits::FromPrimitive;
 
-#[cfg(feature = "std")]
 use crate::{iso::IsoDateTime, TemporalUnwrap};
 
-#[cfg(feature = "std")]
 use super::{
     calendar::Calendar,
     tz::{TimeZone, TzProvider},
@@ -26,7 +23,6 @@ impl Now {
     }
 }
 
-#[cfg(feature = "std")]
 impl Now {
     /// Returns the current instant
     pub fn instant() -> TemporalResult<Instant> {
@@ -42,7 +38,6 @@ impl Now {
     }
 }
 
-#[cfg(feature = "std")]
 fn system_date_time(
     tz: Option<TimeZone>,
     provider: &impl TzProvider,
@@ -59,7 +54,6 @@ fn system_date_time(
     tz.get_iso_datetime_for(&Instant::from(epoch_ns), provider)
 }
 
-#[cfg(feature = "std")]
 fn system_instant() -> TemporalResult<Instant> {
     let nanos = sys::get_system_nanoseconds()?;
     Instant::try_new(i128::from_u128(nanos).temporal_unwrap()?)

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -1,5 +1,7 @@
 //! This module implements `Time` and any directly related algorithms.
 
+use num_traits::AsPrimitive;
+
 use crate::{
     components::{duration::TimeDuration, Duration},
     iso::IsoTime,
@@ -70,12 +72,12 @@ impl PlainTime {
         let nanosecond = i32::from(self.nanosecond()) + norm.subseconds();
         // 3. Return BalanceTime(hour, minute, second, millisecond, microsecond, nanosecond).
         let (day, balance_result) = IsoTime::balance(
-            f64::from(self.hour()),
-            f64::from(self.minute()),
-            second as f64,
-            f64::from(self.millisecond()),
-            f64::from(self.microsecond()),
-            f64::from(nanosecond),
+            self.hour().into(),
+            self.minute().into(),
+            second,
+            self.millisecond().into(),
+            self.microsecond().into(),
+            nanosecond.into(),
         );
 
         (day, Self::new_unchecked(balance_result))
@@ -86,22 +88,24 @@ impl PlainTime {
     /// Spec Equivalent: `AddDurationToOrSubtractDurationFromPlainTime`.
     pub(crate) fn add_to_time(&self, duration: &TimeDuration) -> TemporalResult<Self> {
         let (_, result) = IsoTime::balance(
-            FiniteF64::from(self.hour()).checked_add(&duration.hours)?.0,
+            FiniteF64::from(self.hour())
+                .checked_add(&duration.hours)?
+                .as_(),
             FiniteF64::from(self.minute())
                 .checked_add(&duration.minutes)?
-                .0,
+                .as_(),
             FiniteF64::from(self.second())
                 .checked_add(&duration.seconds)?
-                .0,
+                .as_(),
             FiniteF64::from(self.millisecond())
                 .checked_add(&duration.milliseconds)?
-                .0,
+                .as_(),
             FiniteF64::from(self.microsecond())
                 .checked_add(&duration.microseconds)?
-                .0,
+                .as_(),
             FiniteF64::from(self.nanosecond())
                 .checked_add(&duration.nanoseconds)?
-                .0,
+                .as_(),
         );
 
         // NOTE (nekevss): IsoTime::balance should never return an invalid `IsoTime`

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -9,7 +9,7 @@ use num_traits::ToPrimitive;
 
 use crate::{
     components::{duration::normalized::NormalizedTimeDuration, EpochNanoseconds, Instant},
-    iso::{IsoDate, IsoTime, IsoDateTime},
+    iso::{IsoDate, IsoDateTime, IsoTime},
     options::Disambiguation,
     TemporalError, TemporalResult,
 };
@@ -165,8 +165,7 @@ impl TimeZone {
                 // b. Perform ? CheckISODaysRange(balanced.[[ISODate]]).
                 balanced.date.is_valid_day_range()?;
                 // c. Let epochNanoseconds be GetUTCEpochNanoseconds(balanced).
-                let epoch_ns = balanced
-                    .as_nanoseconds()?;
+                let epoch_ns = balanced.as_nanoseconds()?;
                 // d. Let possibleEpochNanoseconds be « epochNanoseconds ».
                 vec![epoch_ns.0]
             }

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -75,7 +75,7 @@ impl Default for TimeZone {
 
 impl From<&ZonedDateTime> for TimeZone {
     fn from(value: &ZonedDateTime) -> Self {
-        value.tz().clone()
+        value.timezone().clone()
     }
 }
 

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -7,10 +7,9 @@ use core::{iter::Peekable, str::Chars};
 
 use num_traits::ToPrimitive;
 
-use crate::components::instant::EpochNanoseconds;
 use crate::{
-    components::{duration::normalized::NormalizedTimeDuration, Instant},
-    iso::{IsoDate, IsoDateTime},
+    components::{duration::normalized::NormalizedTimeDuration, EpochNanoseconds, Instant},
+    iso::{IsoDate, IsoTime, IsoDateTime},
     options::Disambiguation,
     TemporalError, TemporalResult,
 };
@@ -42,52 +41,37 @@ pub trait TzProvider {
     ) -> TemporalResult<i128>;
 }
 
-/// A Temporal `TimeZone`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum ParsedTimeZone<'a> {
-    IanaIdentifier { identifier: &'a str },
-    Offset { minutes: i16 },
+pub enum TimeZone {
+    IanaIdentifier(String),
+    OffsetMinutes(i16),
 }
 
-impl<'a> ParsedTimeZone<'a> {
-    pub fn from_str(s: &'a str, provider: &impl TzProvider) -> TemporalResult<Self> {
+impl TimeZone {
+    /// Parses a `TimeZone` from a provided `&str`.
+    pub fn try_from_str(s: &str, provider: &impl TzProvider) -> TemporalResult<Self> {
         if s == "Z" {
-            return Ok(Self::Offset { minutes: 0 });
+            return Ok(Self::OffsetMinutes(0));
         }
         let mut cursor = s.chars().peekable();
         if cursor.peek().map_or(false, is_ascii_sign) {
             return parse_offset(&mut cursor);
         } else if provider.check_identifier(s) {
-            return Ok(Self::IanaIdentifier { identifier: s });
+            return Ok(Self::IanaIdentifier(s.to_owned()));
         }
         Err(TemporalError::range().with_message("Valid time zone was not provided."))
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TimeZone(pub String);
-
 impl Default for TimeZone {
     fn default() -> Self {
-        Self("UTC".into())
+        Self::IanaIdentifier("UTC".into())
     }
 }
 
 impl From<&ZonedDateTime> for TimeZone {
     fn from(value: &ZonedDateTime) -> Self {
         value.timezone().clone()
-    }
-}
-
-impl From<String> for TimeZone {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&str> for TimeZone {
-    fn from(value: &str) -> Self {
-        Self(value.to_owned())
     }
 }
 
@@ -98,7 +82,7 @@ impl TimeZone {
         provider: &impl TzProvider,
     ) -> TemporalResult<IsoDateTime> {
         let nanos = self.get_offset_nanos_for(instant.as_i128(), provider)?;
-        IsoDateTime::from_epoch_nanos(&instant.as_i128(), nanos.to_f64().unwrap_or(0.0))
+        IsoDateTime::from_epoch_nanos(&instant.as_i128(), nanos.to_i64().unwrap_or(0))
     }
 }
 
@@ -110,12 +94,11 @@ impl TimeZone {
         provider: &impl TzProvider,
     ) -> TemporalResult<i128> {
         // 1. Let parseResult be ! ParseTimeZoneIdentifier(timeZone).
-        let parsed = ParsedTimeZone::from_str(&self.0, provider)?;
-        match parsed {
+        match self {
             // 2. If parseResult.[[OffsetMinutes]] is not empty, return parseResult.[[OffsetMinutes]] × (60 × 10**9).
-            ParsedTimeZone::Offset { minutes } => Ok(i128::from(minutes) * 60_000_000_000i128),
+            Self::OffsetMinutes(minutes) => Ok(i128::from(*minutes) * 60_000_000_000i128),
             // 3. Return GetNamedTimeZoneOffsetNanoseconds(parseResult.[[Name]], epochNs).
-            ParsedTimeZone::IanaIdentifier { identifier } => {
+            Self::IanaIdentifier(identifier) => {
                 provider.get_named_tz_offset_nanoseconds(identifier, epoch_ns)
             }
         }
@@ -140,9 +123,9 @@ impl TimeZone {
         provider: &impl TzProvider,
     ) -> TemporalResult<Vec<i128>> {
         // 1.Let parseResult be ! ParseTimeZoneIdentifier(timeZone).
-        let possible_nanoseconds = match ParsedTimeZone::from_str(&self.0, provider)? {
+        let possible_nanoseconds = match self {
             // 2. If parseResult.[[OffsetMinutes]] is not empty, then
-            ParsedTimeZone::Offset { minutes } => {
+            Self::OffsetMinutes(minutes) => {
                 // a. Let balanced be
                 // BalanceISODateTime(isoDateTime.[[ISODate]].[[Year]],
                 // isoDateTime.[[ISODate]].[[Month]],
@@ -169,13 +152,12 @@ impl TimeZone {
                 balanced.date.is_valid_day_range()?;
                 // c. Let epochNanoseconds be GetUTCEpochNanoseconds(balanced).
                 let epoch_ns = balanced
-                    .as_nanoseconds()
-                    .expect("conversion should be in a valid range. Option is result of BigInt");
+                    .as_nanoseconds()?;
                 // d. Let possibleEpochNanoseconds be « epochNanoseconds ».
-                vec![epoch_ns]
+                vec![epoch_ns.0]
             }
             // 3. Else,
-            ParsedTimeZone::IanaIdentifier { identifier } => {
+            Self::IanaIdentifier(identifier) => {
                 // a. Perform ? CheckISODaysRange(isoDateTime.[[ISODate]]).
                 iso.date.is_valid_day_range()?;
                 // b. Let possibleEpochNanoseconds be
@@ -327,10 +309,37 @@ impl TimeZone {
         // 25. Return possibleEpochNs[n - 1].
         EpochNanoseconds::try_from(possible[n - 1])
     }
+
+    pub(crate) fn get_start_of_day(
+        &self,
+        iso_date: &IsoDate,
+        provider: &impl TzProvider,
+    ) -> TemporalResult<EpochNanoseconds> {
+        // 1. Let isoDateTime be CombineISODateAndTimeRecord(isoDate, MidnightTimeRecord()).
+        let iso = IsoDateTime::new_unchecked(*iso_date, IsoTime::default());
+        // 2. Let possibleEpochNs be ? GetPossibleEpochNanoseconds(timeZone, isoDateTime).
+        let possible_nanos = self.get_possible_epoch_ns_for(iso, provider)?;
+        // 3. If possibleEpochNs is not empty, return possibleEpochNs[0].
+        if !possible_nanos.is_empty() {
+            return EpochNanoseconds::try_from(possible_nanos[0]);
+        }
+        // 4. Assert: IsOffsetTimeZoneIdentifier(timeZone) is false.
+        // 5. Let possibleEpochNsAfter be GetNamedTimeZoneEpochNanoseconds(timeZone, isoDateTimeAfter), where
+        // isoDateTimeAfter is the ISO Date-Time Record for which ! DifferenceISODateTime(isoDateTime,
+        // isoDateTimeAfter, "iso8601", hour).[[Time]] is the smallest possible value > 0 for which
+        // possibleEpochNsAfter is not empty (i.e., isoDateTimeAfter represents the first local time
+        // after the transition).
+        // NOTE (nekevss): The polyfill subtracts time from the epoch nanoseconds, but the specification
+        // appears to be talking about the possible nanoseconds after ... tbd.
+        let epoch_ns = iso.as_nanoseconds()?.0 + 7_200_000_000_000;
+        // 6. Assert: possibleEpochNsAfter's length = 1.
+        // 7. Return possibleEpochNsAfter[0].
+        EpochNanoseconds::try_from(self.get_offset_nanos_for(epoch_ns, provider)?)
+    }
 }
 
 #[inline]
-fn parse_offset<'a>(chars: &mut Peekable<Chars<'_>>) -> TemporalResult<ParsedTimeZone<'a>> {
+pub(crate) fn parse_offset(chars: &mut Peekable<Chars<'_>>) -> TemporalResult<TimeZone> {
     let sign = chars.next().map_or(1, |c| if c == '+' { 1 } else { -1 });
     // First offset portion
     let hours = parse_digit_pair(chars)?;
@@ -348,9 +357,7 @@ fn parse_offset<'a>(chars: &mut Peekable<Chars<'_>>) -> TemporalResult<ParsedTim
         None => 0,
     };
 
-    Ok(ParsedTimeZone::Offset {
-        minutes: (hours * 60 + minutes) * sign,
-    })
+    Ok(TimeZone::OffsetMinutes((hours * 60 + minutes) * sign))
 }
 
 fn parse_digit_pair(chars: &mut Peekable<Chars<'_>>) -> TemporalResult<i16> {

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -7,9 +7,9 @@ use tinystr::TinyAsciiStr;
 
 use crate::{
     components::{
-        EpochNanoseconds,
         calendar::CalendarDateLike,
         tz::{parse_offset, TzProvider},
+        EpochNanoseconds,
     },
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::{ArithmeticOverflow, Disambiguation, OffsetDisambiguation, TemporalRoundingMode},
@@ -208,7 +208,11 @@ impl ZonedDateTime {
             provider,
         )?;
 
-        Ok(Self::new_unchecked(Instant::from(epoch_nanos), calendar, partial.timezone))
+        Ok(Self::new_unchecked(
+            Instant::from(epoch_nanos),
+            calendar,
+            partial.timezone,
+        ))
     }
 
     /// Returns the `epochSeconds` value of this `ZonedDateTime`.

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -644,13 +644,13 @@ mod tests {
         options::{Disambiguation, OffsetDisambiguation},
         partial::{PartialDate, PartialTime, PartialZonedDateTime},
         tzdb::FsTzdbProvider,
-        Calendar, ZonedDateTime,
+        Calendar, TimeZone, ZonedDateTime,
     };
     use core::str::FromStr;
     use tinystr::tinystr;
 
     #[cfg(not(target_os = "windows"))]
-    use crate::{Duration, TimeZone};
+    use crate::Duration;
 
     #[test]
     fn basic_zdt_test() {

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -596,11 +596,11 @@ pub fn interpret_isodatetime_offset(
             // 10. For each element candidate of possibleEpochNs, do
             for candidate in &possible_nanos {
                 // a. Let candidateOffset be utcEpochNanoseconds - candidate.
-                let candidate_offset = utc_epochs.0 - candidate;
+                let candidate_offset = utc_epochs.0 - candidate.0;
                 // b. If candidateOffset = offsetNanoseconds, then
                 if candidate_offset == offset.into() {
                     // i. Return candidate.
-                    return EpochNanoseconds::try_from(*candidate);
+                    return Ok(*candidate);
                 }
                 // c. If matchBehaviour is match-minutes, then
                 if match_minutes {
@@ -613,7 +613,7 @@ pub fn interpret_isodatetime_offset(
                     // ii. If roundedCandidateNanoseconds = offsetNanoseconds, then
                     if rounded_candidate == offset.into() {
                         // 1. Return candidate.
-                        return EpochNanoseconds::try_from(*candidate);
+                        return Ok(*candidate);
                     }
                 }
             }

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -3,13 +3,23 @@
 use tinystr::TinyAsciiStr;
 
 use crate::{
-    components::{calendar::Calendar, tz::TimeZone, Instant},
+    Calendar, TimeZone, Instant, Duration, PlainDateTime, PlainDate,
+    components::{tz::TzProvider, calendar::CalendarDateLike},
     iso::IsoDateTime,
     options::{ArithmeticOverflow, Disambiguation},
+    partial::{PartialDate, PartialTime},
     Sign, TemporalError, TemporalResult,
 };
 
-use super::{calendar::CalendarDateLike, tz::TzProvider, Duration, PlainDate, PlainDateTime};
+/// A struct representing a partial `ZonedDateTime`.
+pub struct PartialZonedDateTime {
+    /// The `PartialDate` portion of a `PartialDateTime`
+    pub date: PartialDate,
+    /// The `PartialTime` portion of a `PartialDateTime`
+    pub time: PartialTime,
+    /// The time zone value of a partial time zone.
+    pub timezone: TimeZone,
+}
 
 #[cfg(feature = "experimental")]
 use crate::components::tz::TZ_PROVIDER;
@@ -78,7 +88,7 @@ impl ZonedDateTime {
                 .with_message("Intermediate ISO datetime was not within a valid range."));
         }
         // 6. Let intermediateNs be ! GetEpochNanosecondsFor(timeZone, intermediateDateTime, compatible).
-        let intermediate_ns = self.tz().get_epoch_nanoseconds_for(
+        let intermediate_ns = self.timezone().get_epoch_nanoseconds_for(
             intermediate,
             Disambiguation::Compatible,
             provider,
@@ -111,7 +121,7 @@ impl ZonedDateTime {
         Ok(Self::new_unchecked(
             epoch_ns,
             self.calendar().clone(),
-            self.tz().clone(),
+            self.timezone().clone(),
         ))
     }
 }
@@ -136,8 +146,13 @@ impl ZonedDateTime {
     /// Returns `ZonedDateTime`'s `TimeZone` slot.
     #[inline]
     #[must_use]
-    pub fn tz(&self) -> &TimeZone {
+    pub fn timezone(&self) -> &TimeZone {
         &self.tz
+    }
+
+    #[inline]
+    pub fn from_partial(partial: PartialZonedDateTime) -> TemporalResult<Self> {
+        todo!()
     }
 
     /// Returns the `epochSeconds` value of this `ZonedDateTime`.

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -27,9 +27,9 @@ use std::ops::Deref;
 
 /// A struct representing a partial `ZonedDateTime`.
 pub struct PartialZonedDateTime {
-    /// The `PartialDate` portion of a `PartialDateTime`
+    /// The `PartialDate` portion of a `PartialZonedDateTime`
     pub date: PartialDate,
-    /// The `PartialTime` portion of a `PartialDateTime`
+    /// The `PartialTime` portion of a `PartialZonedDateTime`
     pub time: PartialTime,
     /// An optional offset string
     pub offset: Option<String>,

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -633,7 +633,6 @@ impl IsoTime {
         )
     }
 
-    // NOTE(nekevss): f64 is needed here as values could exceed i32 when input.
     /// Balances and creates a new `IsoTime` with `day` overflow from the provided values.
     pub(crate) fn balance(
         hour: i64,

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -23,7 +23,14 @@ use crate::{
             DateDuration, TimeDuration,
         },
         Duration, PartialTime, PlainDate,
-    }, error::TemporalError, options::{ArithmeticOverflow, ResolvedRoundingOptions, TemporalUnit}, primitive::FiniteF64, rounding::{IncrementRounder, Round}, temporal_assert, time::EpochNanoseconds, utils, TemporalResult, TemporalUnwrap, NS_PER_DAY
+    },
+    error::TemporalError,
+    options::{ArithmeticOverflow, ResolvedRoundingOptions, TemporalUnit},
+    primitive::FiniteF64,
+    rounding::{IncrementRounder, Round},
+    temporal_assert,
+    time::EpochNanoseconds,
+    utils, TemporalResult, TemporalUnwrap, NS_PER_DAY,
 };
 use icu_calendar::{Date as IcuDate, Iso};
 use num_traits::{cast::FromPrimitive, AsPrimitive, ToPrimitive};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub mod partial {
     //! The partial records are `temporal_rs`'s method of addressing
     //! `TemporalFields` in the specification.
     pub use crate::components::{
-        duration::PartialDuration, PartialDate, PartialDateTime, PartialTime,
+        duration::PartialDuration, PartialDate, PartialDateTime, PartialTime, PartialZonedDateTime,
     };
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -522,7 +522,7 @@ impl fmt::Display for Disambiguation {
 }
 
 /// Offset disambiguation options.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum OffsetDisambiguation {
     /// Use option
     Use,

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -545,10 +545,7 @@ impl TzProvider for FsTzdbProvider {
         identifier: &str,
         iso_datetime: IsoDateTime,
     ) -> TemporalResult<Vec<i128>> {
-        let seconds = (iso_datetime
-            .as_nanoseconds()
-            .expect("IsoDateTime to be valid")
-            / 1_000_000_000) as i64;
+        let seconds = (iso_datetime.as_nanoseconds()?.0 / 1_000_000_000) as i64;
         let tzif = self.get(identifier)?;
         let local_time_record_result = tzif.v2_estimate_tz_pair(&Seconds(seconds))?;
         let result = match local_time_record_result {
@@ -650,9 +647,7 @@ mod tests {
             nanosecond: 0,
         };
         let edge_case = IsoDateTime::new(date, time).unwrap();
-        let edge_case_seconds = edge_case
-            .as_nanoseconds()
-            .map_or(0, |nanos| (nanos / 1_000_000_000) as i64);
+        let edge_case_seconds = (edge_case.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
 
         #[cfg(not(target_os = "windows"))]
         let new_york = Tzif::read_tzif("America/New_York");
@@ -688,9 +683,7 @@ mod tests {
             nanosecond: 0,
         };
         let today = IsoDateTime::new(date, time).unwrap();
-        let seconds = today
-            .as_nanoseconds()
-            .map_or(0, |nanos| (nanos / 1_000_000_000) as i64);
+        let seconds = (today.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
 
         #[cfg(not(target_os = "windows"))]
         let sydney = Tzif::read_tzif("Australia/Sydney");
@@ -723,9 +716,7 @@ mod tests {
             nanosecond: 0,
         };
         let edge_case = IsoDateTime::new(date, time).unwrap();
-        let edge_case_seconds = edge_case
-            .as_nanoseconds()
-            .map_or(0, |nanos| (nanos / 1_000_000_000) as i64);
+        let edge_case_seconds = (edge_case.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
 
         #[cfg(not(target_os = "windows"))]
         let new_york = Tzif::read_tzif("America/New_York");
@@ -774,9 +765,7 @@ mod tests {
             nanosecond: 0,
         };
         let today = IsoDateTime::new(date, time).unwrap();
-        let seconds = today
-            .as_nanoseconds()
-            .map_or(0, |nanos| (nanos / 1_000_000_000) as i64);
+        let seconds = (today.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
 
         #[cfg(not(target_os = "windows"))]
         let sydney = Tzif::read_tzif("Australia/Sydney");
@@ -827,9 +816,7 @@ mod tests {
             nanosecond: 0,
         };
         let edge_case = IsoDateTime::new(date, time).unwrap();
-        let edge_case_seconds = edge_case
-            .as_nanoseconds()
-            .map_or(0, |nanos| (nanos / 1_000_000_000) as i64);
+        let edge_case_seconds = (edge_case.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
 
         let locals = new_york
             .v2_estimate_tz_pair(&Seconds(edge_case_seconds))
@@ -872,9 +859,7 @@ mod tests {
             nanosecond: 0,
         };
         let today = IsoDateTime::new(date, time).unwrap();
-        let seconds = today
-            .as_nanoseconds()
-            .map_or(0, |nanos| (nanos / 1_000_000_000) as i64);
+        let seconds = (today.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
 
         let locals = sydney.v2_estimate_tz_pair(&Seconds(seconds)).unwrap();
 
@@ -914,9 +899,7 @@ mod tests {
             nanosecond: 0,
         };
         let edge_case = IsoDateTime::new(date, time).unwrap();
-        let edge_case_seconds = edge_case
-            .as_nanoseconds()
-            .map_or(0, |nanos| (nanos / 1_000_000_000) as i64);
+        let edge_case_seconds = (edge_case.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
 
         #[cfg(not(target_os = "windows"))]
         let new_york = Tzif::read_tzif("America/New_York");
@@ -958,9 +941,7 @@ mod tests {
             nanosecond: 0,
         };
         let today = IsoDateTime::new(date, time).unwrap();
-        let seconds = today
-            .as_nanoseconds()
-            .map_or(0, |nanos| (nanos / 1_000_000_000) as i64);
+        let seconds = (today.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
 
         #[cfg(not(target_os = "windows"))]
         let sydney = Tzif::read_tzif("Australia/Sydney");


### PR DESCRIPTION
Posting this early as a draft as the logic was pretty dense to work through. 

~~This PR still needs some baseline tests added for the methods before it's ready to not be a draft.~~

Update:

Tests have been added! There's also a bug fix in `tzdb.rs`.

Overall, this implements the core logic in temporal_rs for supporting `ToTemporalZonedDateTime` and should unblock implementing `Temporal.ZonedDateTime.from` in Boa.

Overview:

  - Adds `PartialZonedDateTime`
  - Adds `from_partial` and `from_partial_with_provider`
  - Adds `from_str` and `from_str_with_provider`
  - Adds additional tests for the above
  - Fix bug in tzdb.rs `get_local_record`
  - Implements some related abstract ops and moves `IsoDateTime::balance` away from using f64.