### PR TITLE
Add  `ZonedDateTime` calendar accessor methods

### DIFF
--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -74,7 +74,7 @@ impl NormalizedTimeDuration {
 
     // TODO: Potentially, update divisor to u64?
     /// `Divide the NormalizedTimeDuraiton` by a divisor.
-    pub(super) fn divide(&self, divisor: i64) -> i128 {
+    pub(crate) fn divide(&self, divisor: i64) -> i128 {
         // TODO: Validate.
         self.0 / i128::from(divisor)
     }

--- a/src/components/now.rs
+++ b/src/components/now.rs
@@ -86,5 +86,6 @@ mod tests {
         // errors, we only assert a range.
         assert!(tolerable_range.contains(&diff.seconds().as_inner()));
         assert!(diff.hours().is_zero());
+        assert!(diff.minutes().is_zero());
     }
 }

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -130,7 +130,11 @@ impl ZonedDateTime {
         // 8. Let epochNanoseconds be ? AddZonedDateTime(zonedDateTime.[[EpochNanoseconds]], timeZone, calendar, internalDuration, overflow).
         let epoch_ns = self.add_as_instant(duration, overflow, provider)?;
         // 9. Return ! CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar).
-        Ok(Self::new_unchecked(epoch_ns, self.calendar().clone(), self.timezone().clone()))
+        Ok(Self::new_unchecked(
+            epoch_ns,
+            self.calendar().clone(),
+            self.timezone().clone(),
+        ))
     }
 }
 
@@ -323,14 +327,14 @@ impl ZonedDateTime {
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
         self.era_with_provider(provider.deref())
     }
-    
+
     pub fn era_year(&self) -> TemporalResult<Option<i32>> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
         self.era_year_with_provider(provider.deref())
     }
-     
+
     /// Returns the calendar day of week value.
     pub fn day_of_week(&self) -> TemporalResult<u16> {
         let provider = TZ_PROVIDER
@@ -437,7 +441,6 @@ impl ZonedDateTime {
             overflow.unwrap_or(ArithmeticOverflow::Constrain),
             provider.deref(),
         )
-
     }
 
     pub fn from_str(
@@ -559,25 +562,29 @@ impl ZonedDateTime {
 // ==== Core calendar method implementations ====
 
 impl ZonedDateTime {
-    pub fn era_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<Option<TinyAsciiStr<16>>> {
+    pub fn era_with_provider(
+        &self,
+        provider: &impl TzProvider,
+    ) -> TemporalResult<Option<TinyAsciiStr<16>>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar.era(&CalendarDateLike::DateTime(&pdt))
     }
-    
-    pub fn era_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<Option<i32>> {
+
+    pub fn era_year_with_provider(
+        &self,
+        provider: &impl TzProvider,
+    ) -> TemporalResult<Option<i32>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar.era_year(&CalendarDateLike::DateTime(&pdt))
-
     }
-     
+
     /// Returns the calendar day of week value.
     pub fn day_of_week_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar.day_of_week(&CalendarDateLike::DateTime(&pdt))
-
     }
 
     /// Returns the calendar day of year value.
@@ -588,59 +595,66 @@ impl ZonedDateTime {
     }
 
     /// Returns the calendar week of year value.
-    pub fn week_of_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<Option<u16>> {
+    pub fn week_of_year_with_provider(
+        &self,
+        provider: &impl TzProvider,
+    ) -> TemporalResult<Option<u16>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.week_of_year(&CalendarDateLike::DateTime(&pdt))
-
+        self.calendar
+            .week_of_year(&CalendarDateLike::DateTime(&pdt))
     }
 
     /// Returns the calendar year of week value.
-    pub fn year_of_week_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<Option<i32>> {
+    pub fn year_of_week_with_provider(
+        &self,
+        provider: &impl TzProvider,
+    ) -> TemporalResult<Option<i32>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.year_of_week(&CalendarDateLike::DateTime(&pdt))
-
+        self.calendar
+            .year_of_week(&CalendarDateLike::DateTime(&pdt))
     }
 
     /// Returns the calendar days in week value.
     pub fn days_in_week_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.days_in_week(&CalendarDateLike::DateTime(&pdt))
-
+        self.calendar
+            .days_in_week(&CalendarDateLike::DateTime(&pdt))
     }
 
     /// Returns the calendar days in month value.
     pub fn days_in_month_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.days_in_month(&CalendarDateLike::DateTime(&pdt))
-
+        self.calendar
+            .days_in_month(&CalendarDateLike::DateTime(&pdt))
     }
 
     /// Returns the calendar days in year value.
     pub fn days_in_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.days_in_year(&CalendarDateLike::DateTime(&pdt))
+        self.calendar
+            .days_in_year(&CalendarDateLike::DateTime(&pdt))
     }
 
     /// Returns the calendar months in year value.
     pub fn months_in_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.months_in_year(&CalendarDateLike::DateTime(&pdt))
-
+        self.calendar
+            .months_in_year(&CalendarDateLike::DateTime(&pdt))
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
     pub fn in_leap_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<bool> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.in_leap_year(&CalendarDateLike::DateTime(&pdt))
+        self.calendar
+            .in_leap_year(&CalendarDateLike::DateTime(&pdt))
     }
-
 }
 
 // ==== Core method implementations ====

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -8,6 +8,7 @@ use tinystr::TinyAsciiStr;
 use crate::{
     components::{
         calendar::CalendarDateLike,
+        duration::normalized::NormalizedTimeDuration,
         tz::{parse_offset, TzProvider},
         EpochNanoseconds,
     },
@@ -129,11 +130,7 @@ impl ZonedDateTime {
         // 8. Let epochNanoseconds be ? AddZonedDateTime(zonedDateTime.[[EpochNanoseconds]], timeZone, calendar, internalDuration, overflow).
         let epoch_ns = self.add_as_instant(duration, overflow, provider)?;
         // 9. Return ! CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar).
-        Ok(Self::new_unchecked(
-            epoch_ns,
-            self.calendar().clone(),
-            self.timezone().clone(),
-        ))
+        Ok(Self::new_unchecked(epoch_ns, self.calendar().clone(), self.timezone().clone()))
     }
 }
 
@@ -240,7 +237,7 @@ impl ZonedDateTime {
     }
 }
 
-// ===== TzProvider APIs for ZonedDateTime =====
+// ===== Experimental TZ_PROVIDER accessor implementations =====
 
 #[cfg(feature = "experimental")]
 impl ZonedDateTime {
@@ -314,7 +311,103 @@ impl ZonedDateTime {
 
         self.millisecond_with_provider(provider.deref())
     }
+}
 
+// ==== Experimental TZ_PROVIDER calendar method implementations ====
+
+#[cfg(feature = "experimental")]
+impl ZonedDateTime {
+    pub fn era(&self) -> TemporalResult<Option<TinyAsciiStr<16>>> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.era_with_provider(provider.deref())
+    }
+    
+    pub fn era_year(&self) -> TemporalResult<Option<i32>> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.era_year_with_provider(provider.deref())
+    }
+     
+    /// Returns the calendar day of week value.
+    pub fn day_of_week(&self) -> TemporalResult<u16> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.day_of_week_with_provider(provider.deref())
+    }
+
+    /// Returns the calendar day of year value.
+    pub fn day_of_year(&self) -> TemporalResult<u16> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.day_of_year_with_provider(provider.deref())
+    }
+
+    /// Returns the calendar week of year value.
+    pub fn week_of_year(&self) -> TemporalResult<Option<u16>> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.week_of_year_with_provider(provider.deref())
+    }
+
+    /// Returns the calendar year of week value.
+    pub fn year_of_week(&self) -> TemporalResult<Option<i32>> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.year_of_week_with_provider(provider.deref())
+    }
+
+    /// Returns the calendar days in week value.
+    pub fn days_in_week(&self) -> TemporalResult<u16> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.days_in_week_with_provider(provider.deref())
+    }
+
+    /// Returns the calendar days in month value.
+    pub fn days_in_month(&self) -> TemporalResult<u16> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.days_in_month_with_provider(provider.deref())
+    }
+
+    /// Returns the calendar days in year value.
+    pub fn days_in_year(&self) -> TemporalResult<u16> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.days_in_year_with_provider(provider.deref())
+    }
+
+    /// Returns the calendar months in year value.
+    pub fn months_in_year(&self) -> TemporalResult<u16> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.months_in_year_with_provider(provider.deref())
+    }
+
+    /// Returns returns whether the date in a leap year for the given calendar.
+    pub fn in_leap_year(&self) -> TemporalResult<bool> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.in_leap_year_with_provider(provider.deref())
+    }
+}
+
+// ==== Experimental TZ_PROVIDER method implementations ====
+
+#[cfg(feature = "experimental")]
+impl ZonedDateTime {
     pub fn add(
         &self,
         duration: &Duration,
@@ -344,6 +437,7 @@ impl ZonedDateTime {
             overflow.unwrap_or(ArithmeticOverflow::Constrain),
             provider.deref(),
         )
+
     }
 
     pub fn from_str(
@@ -357,6 +451,40 @@ impl ZonedDateTime {
         Self::from_str_with_provider(source, disambiguation, offset_option, provider.deref())
     }
 }
+
+// ==== HoursInDay accessor method implementation ====
+
+impl ZonedDateTime {
+    #[cfg(feature = "experimental")]
+    pub fn hours_in_day(&self) -> TemporalResult<u8> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.hours_in_day_with_provider(provider.deref())
+    }
+
+    pub fn hours_in_day_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u8> {
+        // 1-3. Is engine specific steps
+        // 4. Let isoDateTime be GetISODateTimeFor(timeZone, zonedDateTime.[[EpochNanoseconds]]).
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        // 5. Let today be isoDateTime.[[ISODate]].
+        let today = iso.date;
+        // 6. Let tomorrow be BalanceISODate(today.[[Year]], today.[[Month]], today.[[Day]] + 1).
+        let tomorrow = IsoDate::balance(today.year, today.month.into(), i32::from(today.day + 1));
+        // 7. Let todayNs be ? GetStartOfDay(timeZone, today).
+        let today_ns = self.tz.get_start_of_day(&today, provider)?;
+        // 8. Let tomorrowNs be ? GetStartOfDay(timeZone, tomorrow).
+        let tomorrow_ns = self.tz.get_start_of_day(&tomorrow, provider)?;
+        // 9. Let diff be TimeDurationFromEpochNanosecondsDifference(tomorrowNs, todayNs).
+        let diff = NormalizedTimeDuration::from_nanosecond_difference(tomorrow_ns.0, today_ns.0)?;
+        // NOTE: The below should be safe as today_ns and tomorrow_ns should be at most 25 hours.
+        // TODO: Tests for the below cast.
+        // 10. Return 𝔽(TotalTimeDuration(diff, hour)).
+        Ok(diff.divide(60_000_000_000) as u8)
+    }
+}
+
+// ==== Core accessor methods ====
 
 impl ZonedDateTime {
     /// Returns the `year` value for this `ZonedDateTime`.
@@ -426,7 +554,98 @@ impl ZonedDateTime {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(iso.time.nanosecond)
     }
+}
 
+// ==== Core calendar method implementations ====
+
+impl ZonedDateTime {
+    pub fn era_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<Option<TinyAsciiStr<16>>> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
+        self.calendar.era(&CalendarDateLike::DateTime(&pdt))
+    }
+    
+    pub fn era_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<Option<i32>> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
+        self.calendar.era_year(&CalendarDateLike::DateTime(&pdt))
+
+    }
+     
+    /// Returns the calendar day of week value.
+    pub fn day_of_week_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
+        self.calendar.day_of_week(&CalendarDateLike::DateTime(&pdt))
+
+    }
+
+    /// Returns the calendar day of year value.
+    pub fn day_of_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
+        self.calendar.day_of_year(&CalendarDateLike::DateTime(&pdt))
+    }
+
+    /// Returns the calendar week of year value.
+    pub fn week_of_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<Option<u16>> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
+        self.calendar.week_of_year(&CalendarDateLike::DateTime(&pdt))
+
+    }
+
+    /// Returns the calendar year of week value.
+    pub fn year_of_week_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<Option<i32>> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
+        self.calendar.year_of_week(&CalendarDateLike::DateTime(&pdt))
+
+    }
+
+    /// Returns the calendar days in week value.
+    pub fn days_in_week_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
+        self.calendar.days_in_week(&CalendarDateLike::DateTime(&pdt))
+
+    }
+
+    /// Returns the calendar days in month value.
+    pub fn days_in_month_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
+        self.calendar.days_in_month(&CalendarDateLike::DateTime(&pdt))
+
+    }
+
+    /// Returns the calendar days in year value.
+    pub fn days_in_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
+        self.calendar.days_in_year(&CalendarDateLike::DateTime(&pdt))
+    }
+
+    /// Returns the calendar months in year value.
+    pub fn months_in_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
+        self.calendar.months_in_year(&CalendarDateLike::DateTime(&pdt))
+
+    }
+
+    /// Returns returns whether the date in a leap year for the given calendar.
+    pub fn in_leap_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<bool> {
+        let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
+        self.calendar.in_leap_year(&CalendarDateLike::DateTime(&pdt))
+    }
+
+}
+
+// ==== Core method implementations ====
+
+impl ZonedDateTime {
     pub fn add_with_provider(
         &self,
         duration: &Duration,


### PR DESCRIPTION
This PR is dependent on #115 and will need a rebase once that PR is merged.

This continues to build out methods that `ZonedDateTime` needs for accessor methods.

Overall the features implemented are:

  - All calendar accessor methods
  - An implementation of `HoursInDay` method