### PR TITLE
Migrate to `web_time::SystemTime` for `wasm32-unknown-unknown` targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
  "rustc-hash",
  "tinystr",
  "tzif",
+ "web-time",
 ]
 
 [[package]]
@@ -446,6 +447,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ tzif = { version = "0.2.3", optional = true }
 jiff-tzdb = { version = "0.1.1", optional = true }
 combine = { version = "4.6.7", optional = true }
 
+# System time feature
+web-time = { version = "1.1.0", optional =  true }
+
 [features]
 log = ["dep:log"]
 experimental = ["tzdb"]

--- a/src/components/now.rs
+++ b/src/components/now.rs
@@ -92,10 +92,10 @@ mod tests {
         })
         .unwrap();
 
-        let now_plus_three = now.add(&two_seconds, None).unwrap();
+        let now_plus_two = now.add(&two_seconds, None).unwrap();
 
-        assert_eq!(now_plus_three.second(), then.second());
-        assert_eq!(now_plus_three.minute(), then.minute());
-        assert_eq!(now_plus_three.hour(), then.hour());
+        assert_eq!(now_plus_two.second(), then.second());
+        assert_eq!(now_plus_two.minute(), then.minute());
+        assert_eq!(now_plus_two.hour(), then.hour());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@
 extern crate alloc;
 extern crate core;
 
-// TODO: Support SystemTime directly / pull in OS code from std::time?
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -2,9 +2,9 @@ use alloc::string::{String, ToString};
 
 use crate::{TemporalError, TemporalResult};
 
-use std::time::{SystemTime, UNIX_EPOCH};
+use web_time::{SystemTime, UNIX_EPOCH};
 
-// TODO: Need to implement system handling for non_std.
+// TODO: Need to implement SystemTime handling for non_std.
 
 /// Returns the system time in nanoseconds.
 pub(crate) fn get_system_nanoseconds() -> TemporalResult<u128> {

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -298,7 +298,9 @@ impl Tzif {
 
 #[inline]
 fn get_local_record(db: &DataBlock, idx: usize) -> LocalTimeTypeRecord {
-    db.local_time_type_records[db.transition_types[idx]]
+    // NOTE: Transition type can be empty. If no transition_type exists,
+    // then use 0 as the default index of local_time_type_records.
+    db.local_time_type_records[db.transition_types.get(idx).copied().unwrap_or(0)]
 }
 
 #[inline]


### PR DESCRIPTION
See title.

This should allow `SystemTime` to work on any wasm targets.