### PR TITLE
Patch the now test per matrix discussion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "temporal_rs"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "bitflags",
  "combine",


### PR DESCRIPTION
Previous now test caused sporadic CI failures due to asserting exactly the sleep time. This changes the method of calculation and accounts for sleep being >= to its argument.