### PR TITLE
Add now feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,6 @@ web-time = { version = "1.1.0", optional =  true }
 [features]
 log = ["dep:log"]
 experimental = ["tzdb"]
+now = ["std", "dep:web-time"]
 tzdb = ["dep:tzif", "std", "dep:jiff-tzdb", "dep:combine"]
 std = []

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -18,10 +18,10 @@ mod time;
 mod year_month;
 mod zoneddatetime;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "now")]
 mod now;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "now")]
 #[doc(inline)]
 pub use now::Now;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub mod primitive;
 pub(crate) mod components;
 pub(crate) mod iso;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "now")]
 mod sys;
 
 #[cfg(feature = "tzdb")]

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -7,6 +7,7 @@ use web_time::{SystemTime, UNIX_EPOCH};
 // TODO: Need to implement SystemTime handling for non_std.
 
 /// Returns the system time in nanoseconds.
+#[cfg(feature = "now")]
 pub(crate) fn get_system_nanoseconds() -> TemporalResult<u128> {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
This PR adds now feature flag. It fixes a small import bug around the optional import of `web-time` with `sys.rs`. 