### PR TITLE
Remove epochSeconds and epochMicroseconds + adjust epochMillseconds

### DIFF
--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -253,22 +253,10 @@ impl Instant {
         Self::try_new(round_result)
     }
 
-    /// Returns the `epochSeconds` value for this `Instant`.
-    #[must_use]
-    pub fn epoch_seconds(&self) -> i128 {
-        self.as_i128() / 1_000_000_000
-    }
-
     /// Returns the `epochMilliseconds` value for this `Instant`.
     #[must_use]
-    pub fn epoch_milliseconds(&self) -> i128 {
-        self.as_i128() / 1_000_000
-    }
-
-    /// Returns the `epochMicroseconds` value for this `Instant`.
-    #[must_use]
-    pub fn epoch_microseconds(&self) -> i128 {
-        self.as_i128() / 1_000
+    pub fn epoch_milliseconds(&self) -> i64 {
+        (self.as_i128() / 1_000_000) as i64
     }
 
     /// Returns the `epochNanoseconds` value for this `Instant`.

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -216,22 +216,10 @@ impl ZonedDateTime {
         ))
     }
 
-    /// Returns the `epochSeconds` value of this `ZonedDateTime`.
-    #[must_use]
-    pub fn epoch_seconds(&self) -> i128 {
-        self.instant.epoch_seconds()
-    }
-
     /// Returns the `epochMilliseconds` value of this `ZonedDateTime`.
     #[must_use]
-    pub fn epoch_milliseconds(&self) -> i128 {
+    pub fn epoch_milliseconds(&self) -> i64 {
         self.instant.epoch_milliseconds()
-    }
-
-    /// Returns the `epochMicroseconds` value of this `ZonedDateTime`.
-    #[must_use]
-    pub fn epoch_microseconds(&self) -> i128 {
-        self.instant.epoch_microseconds()
     }
 
     /// Returns the `epochNanoseconds` value of this `ZonedDateTime`.


### PR DESCRIPTION
This PR updates the epoch* methods on `Instant` and `ZonedDateTime` and closes #122