### PR TITLE
Fix bug introduced by `EpochNanoseconds` + adjust tests to catch better

### DIFF
--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -629,6 +629,35 @@ mod tests {
     use super::*;
 
     #[test]
+    fn new_date_limits() {
+        let err = PlainDate::try_new(-271_821, 4, 18, Calendar::default());
+        assert!(err.is_err());
+        let err = PlainDate::try_new(275_760, 9, 14, Calendar::default());
+        assert!(err.is_err());
+        let ok = PlainDate::try_new(-271_821, 4, 19, Calendar::default()).unwrap();
+        assert_eq!(ok, PlainDate {
+            iso: IsoDate {
+                year: -271_821,
+                month: 4,
+                day: 19,
+            },
+            calendar: Calendar::default(),
+        });
+
+        let ok = PlainDate::try_new(275_760, 9, 13, Calendar::default()).unwrap();
+        assert_eq!(ok, PlainDate {
+            iso: IsoDate {
+                year: 275760,
+                month: 9,
+                day: 13,
+            },
+            calendar: Calendar::default(),
+        });
+
+
+    }
+
+    #[test]
     fn simple_date_add() {
         let base = PlainDate::from_str("1976-11-18").unwrap();
 

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -635,26 +635,30 @@ mod tests {
         let err = PlainDate::try_new(275_760, 9, 14, Calendar::default());
         assert!(err.is_err());
         let ok = PlainDate::try_new(-271_821, 4, 19, Calendar::default()).unwrap();
-        assert_eq!(ok, PlainDate {
-            iso: IsoDate {
-                year: -271_821,
-                month: 4,
-                day: 19,
-            },
-            calendar: Calendar::default(),
-        });
+        assert_eq!(
+            ok,
+            PlainDate {
+                iso: IsoDate {
+                    year: -271_821,
+                    month: 4,
+                    day: 19,
+                },
+                calendar: Calendar::default(),
+            }
+        );
 
         let ok = PlainDate::try_new(275_760, 9, 13, Calendar::default()).unwrap();
-        assert_eq!(ok, PlainDate {
-            iso: IsoDate {
-                year: 275760,
-                month: 9,
-                day: 13,
-            },
-            calendar: Calendar::default(),
-        });
-
-
+        assert_eq!(
+            ok,
+            PlainDate {
+                iso: IsoDate {
+                    year: 275760,
+                    month: 9,
+                    day: 13,
+                },
+                calendar: Calendar::default(),
+            }
+        );
     }
 
     #[test]

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -730,10 +730,14 @@ mod tests {
         components::{
             calendar::Calendar, duration::DateDuration, Duration, PartialDate, PartialDateTime,
             PartialTime, PlainDateTime,
-        }, iso::{IsoDate, IsoDateTime, IsoTime}, options::{
+        },
+        iso::{IsoDate, IsoDateTime, IsoTime},
+        options::{
             DifferenceSettings, RoundingIncrement, RoundingOptions, TemporalRoundingMode,
             TemporalUnit,
-        }, primitive::FiniteF64, TemporalResult
+        },
+        primitive::FiniteF64,
+        TemporalResult,
     };
 
     fn assert_datetime(
@@ -753,18 +757,7 @@ mod tests {
     }
 
     fn pdt_from_date(year: i32, month: i32, day: i32) -> TemporalResult<PlainDateTime> {
-        PlainDateTime::try_new(
-            year,
-            month,
-            day,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            Calendar::default(),
-        )
+        PlainDateTime::try_new(year, month, day, 0, 0, 0, 0, 0, 0, Calendar::default())
     }
 
     #[test]
@@ -777,30 +770,36 @@ mod tests {
         let positive_limit = pdt_from_date(275_760, 9, 14);
         assert!(positive_limit.is_err());
         let within_negative_limit = pdt_from_date(-271_821, 4, 20);
-        assert_eq!(within_negative_limit, Ok(PlainDateTime {
-            iso: IsoDateTime {
-                date: IsoDate {
-                    year: -271_821,
-                    month: 4,
-                    day: 20,
+        assert_eq!(
+            within_negative_limit,
+            Ok(PlainDateTime {
+                iso: IsoDateTime {
+                    date: IsoDate {
+                        year: -271_821,
+                        month: 4,
+                        day: 20,
+                    },
+                    time: IsoTime::default(),
                 },
-                time: IsoTime::default(),
-            },
-            calendar: Calendar::default(),
-        }));
+                calendar: Calendar::default(),
+            })
+        );
 
         let within_positive_limit = pdt_from_date(275_760, 9, 13);
-         assert_eq!(within_positive_limit, Ok(PlainDateTime {
-            iso: IsoDateTime {
-                date: IsoDate {
-                    year: 275_760,
-                    month: 9,
-                    day: 13,
+        assert_eq!(
+            within_positive_limit,
+            Ok(PlainDateTime {
+                iso: IsoDateTime {
+                    date: IsoDate {
+                        year: 275_760,
+                        month: 9,
+                        day: 13,
+                    },
+                    time: IsoTime::default(),
                 },
-                time: IsoTime::default(),
-            },
-            calendar: Calendar::default(),
-        }));
+                calendar: Calendar::default(),
+            })
+        );
     }
 
     #[test]

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -724,20 +724,16 @@ impl FromStr for PlainDateTime {
 
 #[cfg(test)]
 mod tests {
-    use core::str::FromStr;
-
     use tinystr::{tinystr, TinyAsciiStr};
 
     use crate::{
         components::{
             calendar::Calendar, duration::DateDuration, Duration, PartialDate, PartialDateTime,
             PartialTime, PlainDateTime,
-        },
-        options::{
+        }, iso::{IsoDate, IsoDateTime, IsoTime}, options::{
             DifferenceSettings, RoundingIncrement, RoundingOptions, TemporalRoundingMode,
             TemporalUnit,
-        },
-        primitive::FiniteF64,
+        }, primitive::FiniteF64, TemporalResult
     };
 
     fn assert_datetime(
@@ -756,28 +752,55 @@ mod tests {
         assert_eq!(dt.nanosecond(), fields.9);
     }
 
+    fn pdt_from_date(year: i32, month: i32, day: i32) -> TemporalResult<PlainDateTime> {
+        PlainDateTime::try_new(
+            year,
+            month,
+            day,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Calendar::default(),
+        )
+    }
+
     #[test]
     #[allow(clippy::float_cmp)]
     fn plain_date_time_limits() {
         // This test is primarily to assert that the `expect` in the epoch methods is
         // valid, i.e., a valid instant is within the range of an f64.
-        let negative_limit = PlainDateTime::try_new(
-            -271_821,
-            4,
-            19,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            Calendar::from_str("iso8601").unwrap(),
-        );
-        let positive_limit =
-            PlainDateTime::try_new(275_760, 9, 14, 0, 0, 0, 0, 0, 0, Calendar::default());
-
+        let negative_limit = pdt_from_date(-271_821, 4, 19);
         assert!(negative_limit.is_err());
+        let positive_limit = pdt_from_date(275_760, 9, 14);
         assert!(positive_limit.is_err());
+        let within_negative_limit = pdt_from_date(-271_821, 4, 20);
+        assert_eq!(within_negative_limit, Ok(PlainDateTime {
+            iso: IsoDateTime {
+                date: IsoDate {
+                    year: -271_821,
+                    month: 4,
+                    day: 20,
+                },
+                time: IsoTime::default(),
+            },
+            calendar: Calendar::default(),
+        }));
+
+        let within_positive_limit = pdt_from_date(275_760, 9, 13);
+         assert_eq!(within_positive_limit, Ok(PlainDateTime {
+            iso: IsoDateTime {
+                date: IsoDate {
+                    year: 275_760,
+                    month: 9,
+                    day: 13,
+                },
+                time: IsoTime::default(),
+            },
+            calendar: Calendar::default(),
+        }));
     }
 
     #[test]

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -911,7 +911,7 @@ fn utc_epoch_nanos(date: IsoDate, time: &IsoTime) -> TemporalResult<EpochNanosec
 }
 
 #[inline]
-fn to_unchecked_epoch_nanoseconds(date:IsoDate, time: &IsoTime) -> i128 {
+fn to_unchecked_epoch_nanoseconds(date: IsoDate, time: &IsoTime) -> i128 {
     let ms = time.to_epoch_ms();
     let epoch_ms = utils::epoch_days_to_epoch_ms(date.to_epoch_days(), ms);
 


### PR DESCRIPTION
This fixes a bug that was introduced by #116.

General gist is that the in the proposal [`5.5.4 ISODateTimeWithinLimits ( isoDateTime )`](https://tc39.es/proposal-temporal/#sec-temporal-isodatetimewithinlimits) there is a call to `GetUTCEpochNanoseconds`. However, this value is not checked to be valid, and instead of constraining to the NS_MAX_INSTANT/NS_MIN_INSTANT +/- NS_PER_DAY, respectively, we were constraining to NS_MAX_INSTANT/NS_MIN_INSTANT.

There was a limit test on datetime, but we were only asserting the negative case, not the positive case, so the regression was not caught.

So adjusted to handle the potentially invalid value, adjusted the preexisting datetime test, and added a date limit test based off the test262 limit test.

EDIT: Potentially relevant context to #119