### PR TITLE
Fix `epoch_time_to_epoch_year` date equation bug related to `BalanceISODate`

### DIFF
--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -199,7 +199,12 @@ impl PlainDate {
             overflow,
         )?;
 
-        Ok(Self::new_unchecked(result, self.calendar().clone()))
+        Self::try_new(
+            result.year,
+            result.month.into(),
+            result.day.into(),
+            self.calendar().clone(),
+        )
     }
 
     /// Returns a duration representing the difference between the dates one and two.
@@ -701,6 +706,45 @@ mod tests {
                 day: 8,
             }
         )
+    }
+
+    #[test]
+    fn date_add_limits() {
+        let max = PlainDate::try_new(275_760, 9, 13, Calendar::default()).unwrap();
+        let result = max.add(&Duration::from_str("P1D").unwrap(), None);
+        assert!(result.is_err());
+
+        let max = PlainDate::try_new(275_760, 9, 12, Calendar::default()).unwrap();
+        let result = max.add(&Duration::from_str("P1D").unwrap(), None);
+        assert_eq!(
+            result,
+            Ok(PlainDate {
+                iso: IsoDate {
+                    year: 275760,
+                    month: 9,
+                    day: 13
+                },
+                calendar: Calendar::default(),
+            })
+        );
+
+        let min = PlainDate::try_new(-271_821, 4, 19, Calendar::default()).unwrap();
+        let result = min.add(&Duration::from_str("-P1D").unwrap(), None);
+        assert!(result.is_err());
+
+        let min = PlainDate::try_new(-271_821, 4, 21, Calendar::default()).unwrap();
+        let result = min.add(&Duration::from_str("-P1D").unwrap(), None);
+        assert_eq!(
+            result,
+            Ok(PlainDate {
+                iso: IsoDate {
+                    year: -271_821,
+                    month: 4,
+                    day: 20
+                },
+                calendar: Calendar::default(),
+            })
+        );
     }
 
     #[test]

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -924,6 +924,7 @@ fn to_unchecked_epoch_nanoseconds(date: IsoDate, time: &IsoTime) -> i128 {
 
 // ==== `IsoDate` specific utiltiy functions ====
 
+// TODO: Add unit tests to prove output for limits.
 /// Returns the Epoch days based off the given year, month, and day.
 ///
 /// NOTE: Month should be in a range of 0-11
@@ -933,7 +934,6 @@ fn iso_date_to_epoch_days(year: i32, month: i32, day: i32) -> i32 {
     let resolved_year = year + month.div_euclid(12);
     // 2. Let resolvedMonth be month modulo 12.
     let resolved_month = month.rem_euclid(12);
-
     // 3. Find a time t such that EpochTimeToEpochYear(t) is resolvedYear,
     // EpochTimeToMonthInYear(t) is resolvedMonth, and EpochTimeToDate(t) is 1.
     let year_t = utils::epoch_time_for_year(resolved_year);
@@ -1002,4 +1002,39 @@ fn is_valid_time(hour: i32, minute: i32, second: i32, ms: i32, mis: i32, ns: i32
 #[inline]
 fn div_mod(dividend: i64, divisor: i64) -> (i64, i64) {
     (dividend.div_euclid(divisor), dividend.rem_euclid(divisor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::iso_date_to_epoch_days;
+
+    const MAX_DAYS_BASE: i32 = 100_000_000;
+
+    #[test]
+    fn iso_date_to_epoch_days_limits() {
+        // Succeeds
+        assert_eq!(iso_date_to_epoch_days(-271_821, 3, 20).abs(), MAX_DAYS_BASE);
+        // Succeeds
+        assert_eq!(
+            iso_date_to_epoch_days(-271_821, 3, 19).abs(),
+            MAX_DAYS_BASE + 1
+        );
+        // Fails
+        assert_eq!(
+            iso_date_to_epoch_days(-271_821, 3, 18).abs(),
+            MAX_DAYS_BASE + 2
+        );
+        // Succeeds
+        assert_eq!(iso_date_to_epoch_days(275_760, 8, 13).abs(), MAX_DAYS_BASE);
+        // Succeeds
+        assert_eq!(
+            iso_date_to_epoch_days(275_760, 8, 14).abs(),
+            MAX_DAYS_BASE + 1
+        );
+        // Fails
+        assert_eq!(
+            iso_date_to_epoch_days(275_760, 8, 15).abs(),
+            MAX_DAYS_BASE + 2
+        );
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -242,62 +242,62 @@ mod tests {
         // Test standard year.
         let standard_year_t = epoch_time_for_year(2015);
         assert_eq!(
-            epoch_time_to_date(standard_year_t as f64 + epoch_time_for_month_given_year(0, 2015)),
+            epoch_time_to_date(standard_year_t + epoch_time_for_month_given_year(0, 2015)),
             1,
             "January is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(standard_year_t as f64 + epoch_time_for_month_given_year(1, 2015)),
+            epoch_time_to_date(standard_year_t + epoch_time_for_month_given_year(1, 2015)),
             1,
             "February is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(standard_year_t as f64 + epoch_time_for_month_given_year(2, 2015)),
+            epoch_time_to_date(standard_year_t + epoch_time_for_month_given_year(2, 2015)),
             1,
             "March is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(standard_year_t as f64 + epoch_time_for_month_given_year(3, 2015)),
+            epoch_time_to_date(standard_year_t + epoch_time_for_month_given_year(3, 2015)),
             1,
             "April is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(standard_year_t as f64 + epoch_time_for_month_given_year(4, 2015)),
+            epoch_time_to_date(standard_year_t + epoch_time_for_month_given_year(4, 2015)),
             1,
             "May is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(standard_year_t as f64 + epoch_time_for_month_given_year(5, 2015)),
+            epoch_time_to_date(standard_year_t + epoch_time_for_month_given_year(5, 2015)),
             1,
             "June is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(standard_year_t as f64 + epoch_time_for_month_given_year(6, 2015)),
+            epoch_time_to_date(standard_year_t + epoch_time_for_month_given_year(6, 2015)),
             1,
             "July is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(standard_year_t as f64 + epoch_time_for_month_given_year(7, 2015)),
+            epoch_time_to_date(standard_year_t + epoch_time_for_month_given_year(7, 2015)),
             1,
             "August is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(standard_year_t as f64 + epoch_time_for_month_given_year(8, 2015)),
+            epoch_time_to_date(standard_year_t + epoch_time_for_month_given_year(8, 2015)),
             1,
             "September is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(standard_year_t as f64 + epoch_time_for_month_given_year(9, 2015)),
+            epoch_time_to_date(standard_year_t + epoch_time_for_month_given_year(9, 2015)),
             1,
             "October is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(standard_year_t as f64 + epoch_time_for_month_given_year(10, 2015)),
+            epoch_time_to_date(standard_year_t + epoch_time_for_month_given_year(10, 2015)),
             1,
             "November is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(standard_year_t as f64 + epoch_time_for_month_given_year(11, 2015)),
+            epoch_time_to_date(standard_year_t + epoch_time_for_month_given_year(11, 2015)),
             1,
             "December is unaligned."
         );
@@ -305,62 +305,62 @@ mod tests {
         // Test leap Year
         let leap_year_t = epoch_time_for_year(2020);
         assert_eq!(
-            epoch_time_to_date(leap_year_t as f64 + epoch_time_for_month_given_year(0, 2020)),
+            epoch_time_to_date(leap_year_t + epoch_time_for_month_given_year(0, 2020)),
             1,
             "January is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(leap_year_t as f64 + epoch_time_for_month_given_year(1, 2020)),
+            epoch_time_to_date(leap_year_t + epoch_time_for_month_given_year(1, 2020)),
             1,
             "February is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(leap_year_t as f64 + epoch_time_for_month_given_year(2, 2020)),
+            epoch_time_to_date(leap_year_t + epoch_time_for_month_given_year(2, 2020)),
             1,
             "March is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(leap_year_t as f64 + epoch_time_for_month_given_year(3, 2020)),
+            epoch_time_to_date(leap_year_t + epoch_time_for_month_given_year(3, 2020)),
             1,
             "April is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(leap_year_t as f64 + epoch_time_for_month_given_year(4, 2020)),
+            epoch_time_to_date(leap_year_t + epoch_time_for_month_given_year(4, 2020)),
             1,
             "May is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(leap_year_t as f64 + epoch_time_for_month_given_year(5, 2020)),
+            epoch_time_to_date(leap_year_t + epoch_time_for_month_given_year(5, 2020)),
             1,
             "June is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(leap_year_t as f64 + epoch_time_for_month_given_year(6, 2020)),
+            epoch_time_to_date(leap_year_t + epoch_time_for_month_given_year(6, 2020)),
             1,
             "July is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(leap_year_t as f64 + epoch_time_for_month_given_year(7, 2020)),
+            epoch_time_to_date(leap_year_t + epoch_time_for_month_given_year(7, 2020)),
             1,
             "August is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(leap_year_t as f64 + epoch_time_for_month_given_year(8, 2020)),
+            epoch_time_to_date(leap_year_t + epoch_time_for_month_given_year(8, 2020)),
             1,
             "September is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(leap_year_t as f64 + epoch_time_for_month_given_year(9, 2020)),
+            epoch_time_to_date(leap_year_t + epoch_time_for_month_given_year(9, 2020)),
             1,
             "October is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(leap_year_t as f64 + epoch_time_for_month_given_year(10, 2020)),
+            epoch_time_to_date(leap_year_t + epoch_time_for_month_given_year(10, 2020)),
             1,
             "November is unaligned."
         );
         assert_eq!(
-            epoch_time_to_date(leap_year_t as f64 + epoch_time_for_month_given_year(11, 2020)),
+            epoch_time_to_date(leap_year_t + epoch_time_for_month_given_year(11, 2020)),
             1,
             "December is unaligned."
         );


### PR DESCRIPTION
This PR fixes a bug in the current implementation where at the date limits, we were returning incorrect years, and thus balancing wrong as a result. Furthermore, incorrect output was not being verified via `PlainDate::try_new`, so that has been added to `PlainDate::add_date`

NOTE: I am planning on coming back to `epoch_time_to_epoch_year` in the near future after some reading / research. But this does fix the bug.