### PR TITLE
Add ZonedDateTime functionality to `Duration::round`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ combine = { workspace = true, optional = true }
 web-time = { workspace = true, optional =  true }
 
 [features]
-default = ["experimental", "now"]
+default = ["now"]
 log = ["dep:log"]
 experimental = ["tzdb"]
 now = ["std", "dep:web-time"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ combine = { workspace = true, optional = true }
 web-time = { workspace = true, optional =  true }
 
 [features]
+default = ["experimental", "now"]
 log = ["dep:log"]
 experimental = ["tzdb"]
 now = ["std", "dep:web-time"]

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -3,6 +3,8 @@
 //! The goal of the calendar module of `boa_temporal` is to provide
 //! Temporal compatible calendar implementations.
 
+// TODO: It may finally be time to clean up API to use `IsoDate` and `DateDuration` directly.
+
 use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     parsers::parse_date_time,
     primitive::FiniteF64,
-    Sign, TemporalError, TemporalResult, TemporalUnwrap,
+    Sign, TemporalError, TemporalResult, TemporalUnwrap, TimeZone,
 };
 
 use alloc::format;
@@ -24,6 +24,7 @@ use core::str::FromStr;
 use super::{
     calendar::{ascii_four_to_integer, month_to_month_code},
     duration::{normalized::NormalizedDurationRecord, TimeDuration},
+    tz::NeverProvider,
     PlainMonthDay, PlainTime, PlainYearMonth,
 };
 
@@ -289,7 +290,12 @@ impl PlainDate {
             );
             // c. Set duration to ? RoundRelativeDuration(duration, destEpochNs, dateTime, calendarRec, unset, settings.[[LargestUnit]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
             *duration
-                .round_relative_duration(dest_epoch_ns.0, &dt, None, resolved)?
+                .round_relative_duration(
+                    dest_epoch_ns.0,
+                    &dt,
+                    Option::<(&TimeZone, &NeverProvider)>::None,
+                    resolved,
+                )?
                 .0
                 .date()
         } else {

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -1,7 +1,7 @@
 //! This module implements `DateTime` any directly related algorithms.
 
 use crate::{
-    components::{calendar::Calendar, duration::TimeDuration, Instant},
+    components::{calendar::Calendar, Instant},
     iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions,
@@ -12,12 +12,11 @@ use crate::{
 };
 
 use core::{cmp::Ordering, str::FromStr};
-use num_traits::AsPrimitive;
 use tinystr::TinyAsciiStr;
 
 use super::{
     calendar::{CalendarDateLike, GetTemporalCalendar},
-    duration::normalized::{NormalizedTimeDuration, RelativeRoundResult},
+    duration::normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
     tz::NeverProvider,
     Duration, PartialDate, PartialTime, PlainDate, PlainTime,
 };
@@ -145,7 +144,9 @@ impl PlainDateTime {
         }
 
         // Step 10-11.
-        let (result, _) = self.diff_dt_with_rounding(other, options)?;
+        let norm_record = self.diff_dt_with_rounding(other, options)?;
+
+        let result = Duration::from_normalized(norm_record, options.largest_unit)?;
 
         // Step 12
         match sign {
@@ -161,63 +162,28 @@ impl PlainDateTime {
         &self,
         other: &Self,
         options: ResolvedRoundingOptions,
-    ) -> TemporalResult<RelativeRoundResult> {
+    ) -> TemporalResult<NormalizedDurationRecord> {
         // 1. Assert: IsValidISODate(y1, mon1, d1) is true.
         // 2. Assert: IsValidISODate(y2, mon2, d2) is true.
         // 3. If CompareISODateTime(y1, mon1, d1, h1, min1, s1, ms1, mus1, ns1, y2, mon2, d2, h2, min2, s2, ms2, mus2, ns2) = 0, then
         if matches!(self.iso.cmp(&other.iso), Ordering::Equal) {
             // a. Let durationRecord be CreateDurationRecord(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
             // b. Return the Record { [[DurationRecord]]: durationRecord, [[Total]]: 0 }.
-            return Ok((Duration::default(), Some(0)));
+            return Ok(NormalizedDurationRecord::default());
         }
-
-        // 4. Let diff be ? DifferenceISODateTime(y1, mon1, d1, h1, min1, s1, ms1, mus1, ns1, y2, mon2, d2, h2, min2, s2, ms2, mus2, ns2, calendarRec, largestUnit, resolvedOptions).
+        // 3. Let diff be DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, largestUnit).
         let diff = self
             .iso
             .diff(&other.iso, &self.calendar, options.largest_unit)?;
 
-        // 5. If smallestUnit is "nanosecond" and roundingIncrement = 1, then
+        // 4. If smallestUnit is nanosecond and roundingIncrement = 1, return diff.
         if options.smallest_unit == TemporalUnit::Nanosecond && options.increment.get() == 1 {
-            // a. Let normWithDays be ? Add24HourDaysToNormalizedTimeDuration(diff.[[NormalizedTime]], diff.[[Days]]).
-            let norm_with_days = diff
-                .normalized_time_duration()
-                .add_days(diff.date().days.as_())?;
-            // b. Let timeResult be ! BalanceTimeDuration(normWithDays, largestUnit).
-            let (days, time_duration) =
-                TimeDuration::from_normalized(norm_with_days, options.largest_unit)?;
-
-            // c. Let total be NormalizedTimeDurationSeconds(normWithDays) × 10**9 + NormalizedTimeDurationSubseconds(normWithDays).
-            let total =
-                norm_with_days.seconds() * 1_000_000_000 + i64::from(norm_with_days.subseconds());
-
-            // d. Let durationRecord be CreateDurationRecord(diff.[[Years]], diff.[[Months]], diff.[[Weeks]], timeResult.[[Days]],
-            // timeResult.[[Hours]], timeResult.[[Minutes]], timeResult.[[Seconds]], timeResult.[[Milliseconds]],
-            // timeResult.[[Microseconds]], timeResult.[[Nanoseconds]]).
-            let duration = Duration::new(
-                diff.date().years,
-                diff.date().months,
-                diff.date().weeks,
-                days,
-                time_duration.hours,
-                time_duration.minutes,
-                time_duration.seconds,
-                time_duration.milliseconds,
-                time_duration.microseconds,
-                time_duration.nanoseconds,
-            )?;
-
-            // e. Return the Record { [[DurationRecord]]: durationRecord, [[Total]]: total }.
-            return Ok((duration, Some(i128::from(total))));
+            return Ok(diff);
         }
 
-        // 6. Let dateTime be ISO Date-TimeRecord { [[Year]]: y1, [[Month]]: mon1,
-        // [[Day]]: d1, [[Hour]]: h1, [[Minute]]: min1, [[Second]]: s1, [[Millisecond]]:
-        // ms1, [[Microsecond]]: mus1, [[Nanosecond]]: ns1 }.
-        // 7. Let destEpochNs be GetUTCEpochNanoseconds(y2, mon2, d2, h2, min2, s2, ms2, mus2, ns2).
+        // 5. Let destEpochNs be GetUTCEpochNanoseconds(isoDateTime2).
         let dest_epoch_ns = other.iso.as_nanoseconds()?;
-
-        // 8. Return ? RoundRelativeDuration(diff, destEpochNs, dateTime, calendarRec, unset, largestUnit,
-        // roundingIncrement, smallestUnit, roundingMode).
+        // 6. Return ? RoundRelativeDuration(diff, destEpochNs, isoDateTime1, unset, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode).
         diff.round_relative_duration(
             dest_epoch_ns.0,
             self,

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -8,7 +8,7 @@ use crate::{
         RoundingOptions, TemporalUnit,
     },
     parsers::parse_date_time,
-    temporal_assert, Sign, TemporalError, TemporalResult, TemporalUnwrap,
+    temporal_assert, Sign, TemporalError, TemporalResult, TemporalUnwrap, TimeZone,
 };
 
 use core::{cmp::Ordering, str::FromStr};
@@ -18,6 +18,7 @@ use tinystr::TinyAsciiStr;
 use super::{
     calendar::{CalendarDateLike, GetTemporalCalendar},
     duration::normalized::{NormalizedTimeDuration, RelativeRoundResult},
+    tz::NeverProvider,
     Duration, PartialDate, PartialTime, PlainDate, PlainTime,
 };
 
@@ -217,7 +218,12 @@ impl PlainDateTime {
 
         // 8. Return ? RoundRelativeDuration(diff, destEpochNs, dateTime, calendarRec, unset, largestUnit,
         // roundingIncrement, smallestUnit, roundingMode).
-        diff.round_relative_duration(dest_epoch_ns.0, self, None, options)
+        diff.round_relative_duration(
+            dest_epoch_ns.0,
+            self,
+            Option::<(&TimeZone, &NeverProvider)>::None,
+            options,
+        )
     }
 }
 

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -1,11 +1,7 @@
 //! This module implements `Duration` along with it's methods and components.
 
 use crate::{
-    components::{PlainDateTime, PlainTime},
-    iso::{IsoDateTime, IsoTime},
-    options::{RelativeTo, ResolvedRoundingOptions, RoundingOptions, TemporalUnit},
-    primitive::FiniteF64,
-    temporal_assert, Sign, TemporalError, TemporalResult,
+    components::{PlainDateTime, PlainTime, tz::TzProvider}, iso::{IsoDateTime, IsoTime}, options::{ArithmeticOverflow, RelativeTo, ResolvedRoundingOptions, RoundingOptions, TemporalUnit}, primitive::FiniteF64, temporal_assert, Sign, TemporalError, TemporalResult
 };
 use alloc::format;
 use alloc::vec;
@@ -15,6 +11,11 @@ use ixdtf::parsers::{records::TimeDurationRecord, IsoDurationParser};
 use num_traits::AsPrimitive;
 
 use self::normalized::NormalizedTimeDuration;
+
+#[cfg(feature = "experimental")]
+use core::ops::Deref;
+#[cfg(feature = "experimental")]
+use crate::components::tz::TZ_PROVIDER;
 
 mod date;
 pub(crate) mod normalized;
@@ -28,6 +29,8 @@ mod tests;
 pub use date::DateDuration;
 #[doc(inline)]
 pub use time::TimeDuration;
+
+use super::ZonedDateTime;
 
 /// A `PartialDuration` is a Duration that may have fields not set.
 #[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd)]
@@ -415,10 +418,11 @@ impl Duration {
     }
 
     #[inline]
-    pub fn round(
+    pub fn round_with_provider(
         &self,
         options: RoundingOptions,
-        relative_to: &RelativeTo,
+        relative_to: Option<RelativeTo>,
+        provider: &impl TzProvider,
     ) -> TemporalResult<Self> {
         // NOTE: Steps 1-14 seem to be implementation specific steps.
         // 14. Let roundingIncrement be ? ToTemporalRoundingIncrement(roundTo).
@@ -444,11 +448,16 @@ impl Duration {
         let resolved_options =
             ResolvedRoundingOptions::from_duration_options(options, existing_largest_unit)?;
 
+        let is_zoned_datetime = match relative_to {
+            Some(RelativeTo::ZonedDateTime(_)) => true,
+            _=> false,
+        };
+
         // 26. Let hoursToDaysConversionMayOccur be false.
         // 27. If duration.[[Days]] ≠ 0 and zonedRelativeTo is not undefined, set hoursToDaysConversionMayOccur to true.
         // 28. Else if abs(duration.[[Hours]]) ≥ 24, set hoursToDaysConversionMayOccur to true.
         let hours_to_days_may_occur =
-            (self.days() != 0.0 && relative_to.zdt.is_some()) || self.hours().abs() >= 24.0;
+            (self.days() != 0.0 && is_zoned_datetime) || self.hours().abs() >= 24.0;
 
         // 29. If smallestUnit is "nanosecond" and roundingIncrement = 1, let roundingGranularityIsNoop
         // be true; else let roundingGranularityIsNoop be false.
@@ -487,25 +496,7 @@ impl Duration {
         // 33. If roundingGranularityIsNoop is false, or IsCalendarUnit(largestUnit) is true, or largestUnit is "day",
         // or calendarUnitsPresent is true, or duration.[[Days]] ≠ 0, let plainDateTimeOrRelativeToWillBeUsed be true;
         // else let plainDateTimeOrRelativeToWillBeUsed be false.
-        let pdtr_will_be_used = !is_noop
-            || resolved_options.largest_unit.is_calendar_unit()
-            || resolved_options.largest_unit == TemporalUnit::Day
-            || calendar_units_present
-            || self.days() == 0.0;
-
         // 34. If zonedRelativeTo is not undefined and plainDateTimeOrRelativeToWillBeUsed is true, then
-        let _precalculated: Option<PlainDateTime> =
-            if relative_to.zdt.is_some() && pdtr_will_be_used {
-                return Err(TemporalError::general("Not yet implemented."));
-                // a. NOTE: The above conditions mean that the corresponding Temporal.PlainDateTime or
-                // Temporal.PlainDate for zonedRelativeTo will be used in one of the operations below.
-                // b. Let instant be ! CreateTemporalInstant(zonedRelativeTo.[[Nanoseconds]]).
-                // c. Set precalculatedPlainDateTime to ? GetPlainDateTimeFor(timeZoneRec, instant, zonedRelativeTo.[[Calendar]]).
-                // d. Set plainRelativeTo to ! CreateTemporalDate(precalculatedPlainDateTime.[[ISOYear]],
-                // precalculatedPlainDateTime.[[ISOMonth]], precalculatedPlainDateTime.[[ISODay]], zonedRelativeTo.[[Calendar]]).
-            } else {
-                None
-            };
         // 35. Let calendarRec be ? CreateCalendarMethodsRecordFromRelativeTo(plainRelativeTo, zonedRelativeTo, « DATE-ADD, DATE-UNTIL »).
 
         // 36. Let norm be NormalizeTimeDuration(duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]],
@@ -513,80 +504,99 @@ impl Duration {
         let norm = NormalizedTimeDuration::from_time_duration(self.time());
         // 37. Let emptyOptions be OrdinaryObjectCreate(null).
 
-        // 38. If zonedRelativeTo is not undefined, then
-        let round_result = if let Some(_zdt) = relative_to.zdt {
-            // a. Let relativeEpochNs be zonedRelativeTo.[[Nanoseconds]].
-            // b. Let relativeInstant be ! CreateTemporalInstant(relativeEpochNs).
-            // c. Let targetEpochNs be ? AddZonedDateTime(relativeInstant, timeZoneRec, calendarRec, duration.[[Years]], duration.[[Months]], duration.[[Weeks]], duration.[[Days]], norm, precalculatedPlainDateTime).
-            // d. Let roundRecord be ? DifferenceZonedDateTimeWithRounding(relativeEpochNs, targetEpochNs, calendarRec, timeZoneRec, precalculatedPlainDateTime, emptyOptions, largestUnit, roundingIncrement, smallestUnit, roundingMode).
-            // e. Let roundResult be roundRecord.[[DurationRecord]].
-            return Err(TemporalError::general("Not yet implemented."));
-        // 39. Else if plainRelativeTo is not undefined, then
-        } else if let Some(plain_date) = relative_to.date {
-            // a. Let targetTime be AddTime(0, 0, 0, 0, 0, 0, norm).
-            let (balanced_days, time) = PlainTime::default().add_normalized_time_duration(norm);
-            // b. Let dateDuration be ? CreateTemporalDuration(duration.[[Years]], duration.[[Months]], duration.[[Weeks]],
-            // duration.[[Days]] + targetTime.[[Days]], 0, 0, 0, 0, 0, 0).
-            let date_duration = DateDuration::new(
-                self.years(),
-                self.months(),
-                self.weeks(),
-                self.days().checked_add(&FiniteF64::from(balanced_days))?,
-            )?;
+        match relative_to {
+            // 38. If zonedRelativeTo is not undefined, then
+            Some(RelativeTo::ZonedDateTime(zoned_datetime)) => {
+                // a. Let relativeEpochNs be zonedRelativeTo.[[Nanoseconds]].
+                // b. Let relativeInstant be ! CreateTemporalInstant(relativeEpochNs).
+                // c. Let targetEpochNs be ? AddZonedDateTime(relativeInstant, timeZoneRec, calendarRec, duration.[[Years]], duration.[[Months]], duration.[[Weeks]], duration.[[Days]], norm, precalculatedPlainDateTime).
+                let target_epoch_ns = zoned_datetime.add_as_instant(self, ArithmeticOverflow::Constrain, provider)?;
+                // d. Let roundRecord be ? DifferenceZonedDateTimeWithRounding(relativeEpochNs, targetEpochNs, calendarRec, timeZoneRec, precalculatedPlainDateTime, emptyOptions, largestUnit, roundingIncrement, smallestUnit, roundingMode).
+                // e. Let roundResult be roundRecord.[[DurationRecord]].
+                zoned_datetime.diff_with_rounding(&ZonedDateTime::new_unchecked(target_epoch_ns, zoned_datetime.calendar().clone(), zoned_datetime.timezone().clone()), resolved_options, provider)
+            },
+            // 39. Else if plainRelativeTo is not undefined, then
+            Some(RelativeTo::PlainDate(plain_date)) => {
+                // a. Let targetTime be AddTime(0, 0, 0, 0, 0, 0, norm).
+                let (balanced_days, time) = PlainTime::default().add_normalized_time_duration(norm);
+                // b. Let dateDuration be ? CreateTemporalDuration(duration.[[Years]], duration.[[Months]], duration.[[Weeks]],
+                // duration.[[Days]] + targetTime.[[Days]], 0, 0, 0, 0, 0, 0).
+                let date_duration = DateDuration::new(
+                    self.years(),
+                    self.months(),
+                    self.weeks(),
+                    self.days().checked_add(&FiniteF64::from(balanced_days))?,
+                )?;
 
-            // c. Let targetDate be ? AddDate(calendarRec, plainRelativeTo, dateDuration).
-            let target_date = plain_date.add_date(&Duration::from(date_duration), None)?;
+                // c. Let targetDate be ? AddDate(calendarRec, plainRelativeTo, dateDuration).
+                let target_date = plain_date.add_date(&Duration::from(date_duration), None)?;
 
-            let plain_dt = PlainDateTime::new_unchecked(
-                IsoDateTime::new(plain_date.iso, IsoTime::default())?,
-                plain_date.calendar().clone(),
-            );
+                let plain_dt = PlainDateTime::new_unchecked(
+                    IsoDateTime::new(plain_date.iso, IsoTime::default())?,
+                    plain_date.calendar().clone(),
+                );
 
-            let target_dt = PlainDateTime::new_unchecked(
-                IsoDateTime::new(target_date.iso, time.iso)?,
-                target_date.calendar().clone(),
-            );
+                let target_dt = PlainDateTime::new_unchecked(
+                    IsoDateTime::new(target_date.iso, time.iso)?,
+                    target_date.calendar().clone(),
+                );
 
-            // d. Let roundRecord be ? DifferencePlainDateTimeWithRounding(plainRelativeTo.[[ISOYear]], plainRelativeTo.[[ISOMonth]],
-            // plainRelativeTo.[[ISODay]], 0, 0, 0, 0, 0, 0, targetDate.[[ISOYear]], targetDate.[[ISOMonth]], targetDate.[[ISODay]],
-            // targetTime.[[Hours]], targetTime.[[Minutes]], targetTime.[[Seconds]], targetTime.[[Milliseconds]],
-            // targetTime.[[Microseconds]], targetTime.[[Nanoseconds]], calendarRec, largestUnit, roundingIncrement,
-            // smallestUnit, roundingMode, emptyOptions).
-            let round_record = plain_dt.diff_dt_with_rounding(&target_dt, resolved_options)?;
-            // e. Let roundResult be roundRecord.[[DurationRecord]].
-            round_record.0
-        // 40. Else,
-        } else {
-            // a. If calendarUnitsPresent is true, or IsCalendarUnit(largestUnit) is true, throw a RangeError exception.
-            if calendar_units_present || resolved_options.largest_unit.is_calendar_unit() {
-                return Err(TemporalError::range()
-                    .with_message("Calendar units cannot be present without a relative point."));
+                // d. Let roundRecord be ? DifferencePlainDateTimeWithRounding(plainRelativeTo.[[ISOYear]], plainRelativeTo.[[ISOMonth]],
+                // plainRelativeTo.[[ISODay]], 0, 0, 0, 0, 0, 0, targetDate.[[ISOYear]], targetDate.[[ISOMonth]], targetDate.[[ISODay]],
+                // targetTime.[[Hours]], targetTime.[[Minutes]], targetTime.[[Seconds]], targetTime.[[Milliseconds]],
+                // targetTime.[[Microseconds]], targetTime.[[Nanoseconds]], calendarRec, largestUnit, roundingIncrement,
+                // smallestUnit, roundingMode, emptyOptions).
+                let round_record = plain_dt.diff_dt_with_rounding(&target_dt, resolved_options)?;
+                // e. Let roundResult be roundRecord.[[DurationRecord]].
+                Ok(round_record.0)
             }
-            // b. Assert: IsCalendarUnit(smallestUnit) is false.
-            temporal_assert!(
-                !resolved_options.smallest_unit.is_calendar_unit(),
-                "Assertion failed: resolvedOptions contains a calendar unit\n{:?}",
-                resolved_options
-            );
+            // 40. Else,
+            None => {
+                // a. If calendarUnitsPresent is true, or IsCalendarUnit(largestUnit) is true, throw a RangeError exception.
+                if calendar_units_present || resolved_options.largest_unit.is_calendar_unit() {
+                    return Err(TemporalError::range()
+                        .with_message("Calendar units cannot be present without a relative point."));
+                }
+                // b. Assert: IsCalendarUnit(smallestUnit) is false.
+                temporal_assert!(
+                    !resolved_options.smallest_unit.is_calendar_unit(),
+                    "Assertion failed: resolvedOptions contains a calendar unit\n{:?}",
+                    resolved_options
+                );
 
-            // c. Let roundRecord be ? RoundTimeDuration(duration.[[Days]], norm, roundingIncrement, smallestUnit, roundingMode).
-            let (round_record, _) = norm.round(self.days(), resolved_options)?;
-            // d. Let normWithDays be ? Add24HourDaysToNormalizedTimeDuration(roundRecord.[[NormalizedDuration]].[[NormalizedTime]],
-            // roundRecord.[[NormalizedDuration]].[[Days]]).
-            let norm_with_days = round_record
-                .normalized_time_duration()
-                .add_days(round_record.date().days.as_())?;
-            // e. Let balanceResult be ? BalanceTimeDuration(normWithDays, largestUnit).
-            let (balanced_days, balanced_time) =
-                TimeDuration::from_normalized(norm_with_days, resolved_options.largest_unit)?;
-            // f. Let roundResult be CreateDurationRecord(0, 0, 0, balanceResult.[[Days]], balanceResult.[[Hours]],
-            // balanceResult.[[Minutes]], balanceResult.[[Seconds]], balanceResult.[[Milliseconds]],
-            // balanceResult.[[Microseconds]], balanceResult.[[Nanoseconds]]).
-            Duration::from_day_and_time(balanced_days, &balanced_time)
-        };
+                // c. Let roundRecord be ? RoundTimeDuration(duration.[[Days]], norm, roundingIncrement, smallestUnit, roundingMode).
+                let (round_record, _) = norm.round(self.days(), resolved_options)?;
+                // d. Let normWithDays be ? Add24HourDaysToNormalizedTimeDuration(roundRecord.[[NormalizedDuration]].[[NormalizedTime]],
+                // roundRecord.[[NormalizedDuration]].[[Days]]).
+                let norm_with_days = round_record
+                    .normalized_time_duration()
+                    .add_days(round_record.date().days.as_())?;
+                // e. Let balanceResult be ? BalanceTimeDuration(normWithDays, largestUnit).
+                let (balanced_days, balanced_time) =
+                    TimeDuration::from_normalized(norm_with_days, resolved_options.largest_unit)?;
+                // f. Let roundResult be CreateDurationRecord(0, 0, 0, balanceResult.[[Days]], balanceResult.[[Hours]],
+                // balanceResult.[[Minutes]], balanceResult.[[Seconds]], balanceResult.[[Milliseconds]],
+                // balanceResult.[[Microseconds]], balanceResult.[[Nanoseconds]]).
 
-        // 41. Return ? CreateTemporalDuration(roundResult.[[Years]], roundResult.[[Months]], roundResult.[[Weeks]], roundResult.[[Days]], roundResult.[[Hours]], roundResult.[[Minutes]], roundResult.[[Seconds]], roundResult.[[Milliseconds]], roundResult.[[Microseconds]], roundResult.[[Nanoseconds]]).
-        Ok(round_result)
+                // 41. Return ? CreateTemporalDuration(roundResult.[[Years]], roundResult.[[Months]],
+                // roundResult.[[Weeks]], roundResult.[[Days]], roundResult.[[Hours]],
+                // roundResult.[[Minutes]], roundResult.[[Seconds]], roundResult.[[Milliseconds]],
+                // roundResult.[[Microseconds]], roundResult.[[Nanoseconds]]).
+
+
+                Ok(Duration::from_day_and_time(balanced_days, &balanced_time))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "experimental")]
+impl Duration {
+    pub fn round(&self, options: RoundingOptions, relative_to: Option<RelativeTo<'_>>) -> TemporalResult<Self> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.round_with_provider(options, relative_to, provider.deref())
     }
 }
 

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -800,6 +800,7 @@ impl NormalizedDurationRecord {
         Ok(duration)
     }
 
+    // TODO: Potentially revisit and optimize
     // 7.5.44 RoundRelativeDuration ( duration, destEpochNs, dateTime, calendarRec, timeZoneRec, largestUnit, increment, smallestUnit, roundingMode )
     #[inline]
     pub(crate) fn round_relative_duration(

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -1,7 +1,6 @@
 //! This module implements the normalized `Duration` records.
 
 use core::{num::NonZeroU128, ops::Add};
-use std::println;
 
 use num_traits::{AsPrimitive, Euclid, FromPrimitive};
 
@@ -912,7 +911,6 @@ impl NormalizedDurationRecord {
         timezone_record: Option<(&TimeZone, &impl TzProvider)>,
         options: ResolvedRoundingOptions,
     ) -> TemporalResult<NormalizedDurationRecord> {
-        println!("Round relative called");
         // 1. Let irregularLengthUnit be false.
         // 2. If IsCalendarUnit(smallestUnit) is true, set irregularLengthUnit to true.
         // 3. If timeZoneRec is not unset and smallestUnit is "day", set irregularLengthUnit to true.
@@ -936,7 +934,6 @@ impl NormalizedDurationRecord {
             self.nudge_to_day_or_time(dest_epoch_ns, options)?
         };
 
-        println!("nudgeresult: {nudge_result:?}");
         // 8. Set duration to nudgeResult.[[Duration]].
         let mut duration = nudge_result.normalized;
 

--- a/src/components/duration/tests.rs
+++ b/src/components/duration/tests.rs
@@ -452,7 +452,9 @@ fn rounding_increment_non_integer() {
     let _ = options
         .increment
         .insert(RoundingIncrement::try_from(2.5).unwrap());
-    let result = test_duration.round(options, Some(relative_to.clone())).unwrap();
+    let result = test_duration
+        .round(options, Some(relative_to.clone()))
+        .unwrap();
 
     assert_eq!(
         result.fields(),

--- a/src/components/duration/tests.rs
+++ b/src/components/duration/tests.rs
@@ -1,6 +1,7 @@
 use crate::{
     components::{calendar::Calendar, PlainDate},
     options::{RoundingIncrement, TemporalRoundingMode},
+    TimeZone,
 };
 
 use super::*;
@@ -605,4 +606,38 @@ fn partial_duration_values() {
     let _ = partial.years.insert(FiniteF64(20.0));
     let result = Duration::from_partial_duration(partial).unwrap();
     assert_eq!(result.years(), 20.0);
+}
+
+// days-24-hours-relative-to-zoned-date-time.js
+#[test]
+fn round_relative_to_zoned_datetime() {
+    let duration = Duration::from(
+        TimeDuration::new(
+            25.into(),
+            FiniteF64::default(),
+            FiniteF64::default(),
+            FiniteF64::default(),
+            FiniteF64::default(),
+            FiniteF64::default(),
+        )
+        .unwrap(),
+    );
+    let zdt = ZonedDateTime::try_new(
+        1_000_000_000_000_000_000,
+        Calendar::default(),
+        TimeZone::try_from_str("+04:30").unwrap(),
+    )
+    .unwrap();
+    let options = RoundingOptions {
+        largest_unit: Some(TemporalUnit::Day),
+        smallest_unit: None,
+        rounding_mode: None,
+        increment: None,
+    };
+    let result = duration
+        .round(options, Some(RelativeTo::ZonedDateTime(&zdt)))
+        .unwrap();
+    // Result duration should be: (0, 0, 0, 1, 1, 0, 0, 0, 0, 0)
+    assert_eq!(result.days(), 1.0);
+    assert_eq!(result.hours(), 1.0);
 }

--- a/src/components/duration/tests.rs
+++ b/src/components/duration/tests.rs
@@ -7,11 +7,11 @@ use super::*;
 
 fn get_round_result(
     test_duration: &Duration,
-    relative_to: &RelativeTo,
+    relative_to: RelativeTo,
     options: RoundingOptions,
 ) -> Vec<i32> {
     test_duration
-        .round(options, relative_to)
+        .round(options, Some(relative_to))
         .unwrap()
         .fields()
         .iter()
@@ -37,10 +37,7 @@ fn basic_positive_floor_rounding_v2() {
     .unwrap();
     let forward_date = PlainDate::new(2020, 4, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
-    let relative_forward = RelativeTo {
-        date: Some(&forward_date),
-        zdt: None,
-    };
+    let relative_forward = RelativeTo::PlainDate(&forward_date);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -50,43 +47,43 @@ fn basic_positive_floor_rounding_v2() {
     };
 
     let _ = options.smallest_unit.insert(TemporalUnit::Year);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 0, 0, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Month);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Week);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 3, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Day);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Hour);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Minute);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Second);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Millisecond);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Microsecond);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 987, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Nanosecond);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 987, 500],);
 }
 
@@ -109,10 +106,7 @@ fn basic_negative_floor_rounding_v2() {
     let backward_date =
         PlainDate::new(2020, 12, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
-    let relative_backward = RelativeTo {
-        date: Some(&backward_date),
-        zdt: None,
-    };
+    let relative_backward = RelativeTo::PlainDate(&backward_date);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -122,43 +116,43 @@ fn basic_negative_floor_rounding_v2() {
     };
 
     let _ = options.smallest_unit.insert(TemporalUnit::Year);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-6, 0, 0, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Month);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -8, 0, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Week);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, -4, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Day);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -28, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Hour);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -17, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Minute);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -31, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Second);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -21, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Millisecond);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -124, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Microsecond);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -988, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Nanosecond);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -987, -500],);
 }
 
@@ -180,10 +174,7 @@ fn basic_positive_ceil_rounding() {
     .unwrap();
     let forward_date = PlainDate::new(2020, 4, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
-    let relative_forward = RelativeTo {
-        date: Some(&forward_date),
-        zdt: None,
-    };
+    let relative_forward = RelativeTo::PlainDate(&forward_date);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -193,43 +184,43 @@ fn basic_positive_ceil_rounding() {
     };
 
     let _ = options.smallest_unit.insert(TemporalUnit::Year);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[6, 0, 0, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Month);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 8, 0, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Week);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 4, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Day);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 28, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Hour);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 17, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Minute);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 31, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Second);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 21, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Millisecond);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 124, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Microsecond);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 988, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Nanosecond);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 987, 500],);
 }
 
@@ -250,10 +241,7 @@ fn basic_negative_ceil_rounding() {
     .unwrap();
     let backward_date =
         PlainDate::new(2020, 12, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
-    let relative_backward = RelativeTo {
-        date: Some(&backward_date),
-        zdt: None,
-    };
+    let relative_backward = RelativeTo::PlainDate(&backward_date);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -263,43 +251,43 @@ fn basic_negative_ceil_rounding() {
     };
 
     let _ = options.smallest_unit.insert(TemporalUnit::Year);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, 0, 0, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Month);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Week);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, -3, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Day);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Hour);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Minute);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Second);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Millisecond);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Microsecond);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -987, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Nanosecond);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -987, -500],);
 }
 
@@ -320,11 +308,7 @@ fn basic_positive_expand_rounding() {
     )
     .unwrap();
     let forward_date = PlainDate::new(2020, 4, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
-
-    let relative_forward = RelativeTo {
-        date: Some(&forward_date),
-        zdt: None,
-    };
+    let relative_forward = RelativeTo::PlainDate(&forward_date);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -334,43 +318,43 @@ fn basic_positive_expand_rounding() {
     };
 
     let _ = options.smallest_unit.insert(TemporalUnit::Year);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[6, 0, 0, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Month);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 8, 0, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Week);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 4, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Day);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 28, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Hour);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 17, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Minute);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 31, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Second);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 21, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Millisecond);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 124, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Microsecond);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 988, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Nanosecond);
-    let result = get_round_result(&test_duration, &relative_forward, options);
+    let result = get_round_result(&test_duration, relative_forward.clone(), options);
     assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 987, 500],);
 }
 
@@ -393,10 +377,7 @@ fn basic_negative_expand_rounding() {
     let backward_date =
         PlainDate::new(2020, 12, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
-    let relative_backward = RelativeTo {
-        date: Some(&backward_date),
-        zdt: None,
-    };
+    let relative_backward = RelativeTo::PlainDate(&backward_date);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -406,43 +387,43 @@ fn basic_negative_expand_rounding() {
     };
 
     let _ = options.smallest_unit.insert(TemporalUnit::Year);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-6, 0, 0, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Month);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -8, 0, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Week);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, -4, 0, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Day);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -28, 0, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Hour);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -17, 0, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Minute);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -31, 0, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Second);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -21, 0, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Millisecond);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -124, 0, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Microsecond);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -988, 0],);
 
     let _ = options.smallest_unit.insert(TemporalUnit::Nanosecond);
-    let result = get_round_result(&test_duration.negated(), &relative_backward, options);
+    let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -987, -500],);
 }
 
@@ -459,10 +440,7 @@ fn rounding_increment_non_integer() {
         .unwrap(),
     );
     let binding = PlainDate::new(2000, 1, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
-    let relative_to = RelativeTo {
-        date: Some(&binding),
-        zdt: None,
-    };
+    let relative_to = RelativeTo::PlainDate(&binding);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -474,7 +452,7 @@ fn rounding_increment_non_integer() {
     let _ = options
         .increment
         .insert(RoundingIncrement::try_from(2.5).unwrap());
-    let result = test_duration.round(options, &relative_to).unwrap();
+    let result = test_duration.round(options, Some(relative_to.clone())).unwrap();
 
     assert_eq!(
         result.fields(),
@@ -495,7 +473,7 @@ fn rounding_increment_non_integer() {
     let _ = options
         .increment
         .insert(RoundingIncrement::try_from(1e9 + 0.5).unwrap());
-    let result = test_duration.round(options, &relative_to).unwrap();
+    let result = test_duration.round(options, Some(relative_to)).unwrap();
     assert_eq!(
         result.fields(),
         &[

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -1,10 +1,10 @@
 //! An implementation of `TimeDuration` and it's methods.
 
 use crate::{
-    options::TemporalUnit, primitive::FiniteF64, temporal_assert, TemporalError, TemporalResult,
+    options::TemporalUnit, primitive::FiniteF64, temporal_assert, Sign, TemporalError, TemporalResult
 };
 
-use super::{is_valid_duration, normalized::NormalizedTimeDuration};
+use super::{duration_sign, is_valid_duration, normalized::NormalizedTimeDuration};
 
 use alloc::vec::Vec;
 use num_traits::Euclid;
@@ -316,5 +316,10 @@ impl TimeDuration {
             && self.milliseconds.abs() < 1000f64
             && self.milliseconds.abs() < 1000f64
             && self.milliseconds.abs() < 1000f64
+    }
+
+    #[inline]
+    pub fn sign(&self) -> Sign {
+        duration_sign(&self.fields())
     }
 }

--- a/src/components/duration/time.rs
+++ b/src/components/duration/time.rs
@@ -1,7 +1,8 @@
 //! An implementation of `TimeDuration` and it's methods.
 
 use crate::{
-    options::TemporalUnit, primitive::FiniteF64, temporal_assert, Sign, TemporalError, TemporalResult
+    options::TemporalUnit, primitive::FiniteF64, temporal_assert, Sign, TemporalError,
+    TemporalResult,
 };
 
 use super::{duration_sign, is_valid_duration, normalized::NormalizedTimeDuration};

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -90,17 +90,24 @@ impl Instant {
         Ok(Self::from(EpochNanoseconds::try_from(result)?))
     }
 
+    pub(crate) fn diff_instant_internal(&self, other: &Self, resolved_options: ResolvedRoundingOptions) -> TemporalResult<Duration> {
+        let diff =
+            NormalizedTimeDuration::from_nanosecond_difference(other.as_i128(), self.as_i128())?;
+        let (round_record, _) = diff.round(FiniteF64::default(), resolved_options)?;
+        let (_, time_duration) = TimeDuration::from_normalized(round_record.normalized_time_duration(), resolved_options.largest_unit)?;
+        Ok(Duration::from_day_and_time(0.into(), &time_duration))
+    }
+
     // TODO: Add test for `diff_instant`.
     // NOTE(nekevss): As the below is internal, op will be left as a boolean
     // with a `since` op being true and `until` being false.
     /// Internal operation to handle `since` and `until` difference ops.
-    #[allow(unused)]
     pub(crate) fn diff_instant(
         &self,
         op: DifferenceOperation,
         other: &Self,
         options: DifferenceSettings,
-    ) -> TemporalResult<TimeDuration> {
+    ) -> TemporalResult<Duration> {
         // 1. If operation is since, let sign be -1. Otherwise, let sign be 1.
         // 2. Set other to ? ToTemporalInstant(other).
         // 3. Let resolvedOptions be ? SnapshotOwnProperties(? GetOptionsObject(options), null).
@@ -115,17 +122,10 @@ impl Instant {
         // Below are the steps from Difference Instant.
         // 5. Let diffRecord be DifferenceInstant(instant.[[Nanoseconds]], other.[[Nanoseconds]],
         // settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
-        let diff =
-            NormalizedTimeDuration::from_nanosecond_difference(other.as_i128(), self.as_i128())?;
-        let (round_record, _) = diff.round(FiniteF64::default(), resolved_options)?;
+        let result = self.diff_instant_internal(other, resolved_options)?;
 
         // 6. Let norm be diffRecord.[[NormalizedTimeDuration]].
         // 7. Let result be ! BalanceTimeDuration(norm, settings.[[LargestUnit]]).
-        let (_, result) = TimeDuration::from_normalized(
-            round_record.normalized_time_duration(),
-            resolved_options.largest_unit,
-        )?;
-
         // 8. Return ! CreateTemporalDuration(0, 0, 0, 0, sign × result.[[Hours]], sign × result.[[Minutes]], sign × result.[[Seconds]], sign × result.[[Milliseconds]], sign × result.[[Microseconds]], sign × result.[[Nanoseconds]]).
         match sign {
             Sign::Positive | Sign::Zero => Ok(result),
@@ -232,7 +232,7 @@ impl Instant {
         &self,
         other: &Self,
         settings: DifferenceSettings,
-    ) -> TemporalResult<TimeDuration> {
+    ) -> TemporalResult<Duration> {
         self.diff_instant(DifferenceOperation::Since, other, settings)
     }
 
@@ -242,7 +242,7 @@ impl Instant {
         &self,
         other: &Self,
         settings: DifferenceSettings,
-    ) -> TemporalResult<TimeDuration> {
+    ) -> TemporalResult<Duration> {
         self.diff_instant(DifferenceOperation::Until, other, settings)
     }
 
@@ -362,10 +362,10 @@ mod tests {
             }
         };
 
-        let assert_time_duration = |td: TimeDuration, expected: (f64, f64, f64, f64, f64, f64)| {
+        let assert_time_duration = |td: &TimeDuration, expected: (f64, f64, f64, f64, f64, f64)| {
             assert_eq!(
                 td,
-                TimeDuration {
+                &TimeDuration {
                     hours: FiniteF64(expected.0),
                     minutes: FiniteF64(expected.1),
                     seconds: FiniteF64(expected.2),
@@ -388,44 +388,44 @@ mod tests {
         let positive_result = earlier
             .until(&later, init_diff_setting(TemporalUnit::Hour))
             .unwrap();
-        assert_time_duration(positive_result, (376436.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+        assert_time_duration(positive_result.time(), (376436.0, 0.0, 0.0, 0.0, 0.0, 0.0));
         let negative_result = later
             .until(&earlier, init_diff_setting(TemporalUnit::Hour))
             .unwrap();
-        assert_time_duration(negative_result, (-376435.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+        assert_time_duration(negative_result.time(), (-376435.0, 0.0, 0.0, 0.0, 0.0, 0.0));
 
         let positive_result = earlier
             .until(&later, init_diff_setting(TemporalUnit::Minute))
             .unwrap();
-        assert_time_duration(positive_result, (376435.0, 24.0, 0.0, 0.0, 0.0, 0.0));
+        assert_time_duration(positive_result.time(), (376435.0, 24.0, 0.0, 0.0, 0.0, 0.0));
         let negative_result = later
             .until(&earlier, init_diff_setting(TemporalUnit::Minute))
             .unwrap();
-        assert_time_duration(negative_result, (-376435.0, -23.0, 0.0, 0.0, 0.0, 0.0));
+        assert_time_duration(negative_result.time(), (-376435.0, -23.0, 0.0, 0.0, 0.0, 0.0));
 
         // ... Skip to lower units ...
 
         let positive_result = earlier
             .until(&later, init_diff_setting(TemporalUnit::Microsecond))
             .unwrap();
-        assert_time_duration(positive_result, (376435.0, 23.0, 8.0, 148.0, 530.0, 0.0));
+        assert_time_duration(positive_result.time(), (376435.0, 23.0, 8.0, 148.0, 530.0, 0.0));
         let negative_result = later
             .until(&earlier, init_diff_setting(TemporalUnit::Microsecond))
             .unwrap();
         assert_time_duration(
-            negative_result,
+            negative_result.time(),
             (-376435.0, -23.0, -8.0, -148.0, -529.0, 0.0),
         );
 
         let positive_result = earlier
             .until(&later, init_diff_setting(TemporalUnit::Nanosecond))
             .unwrap();
-        assert_time_duration(positive_result, (376435.0, 23.0, 8.0, 148.0, 529.0, 500.0));
+        assert_time_duration(positive_result.time(), (376435.0, 23.0, 8.0, 148.0, 529.0, 500.0));
         let negative_result = later
             .until(&earlier, init_diff_setting(TemporalUnit::Nanosecond))
             .unwrap();
         assert_time_duration(
-            negative_result,
+            negative_result.time(),
             (-376435.0, -23.0, -8.0, -148.0, -529.0, -500.0),
         );
     }
@@ -441,10 +441,10 @@ mod tests {
             }
         };
 
-        let assert_time_duration = |td: TimeDuration, expected: (f64, f64, f64, f64, f64, f64)| {
+        let assert_time_duration = |td: &TimeDuration, expected: (f64, f64, f64, f64, f64, f64)| {
             assert_eq!(
                 td,
-                TimeDuration {
+                &TimeDuration {
                     hours: FiniteF64(expected.0),
                     minutes: FiniteF64(expected.1),
                     seconds: FiniteF64(expected.2),
@@ -467,44 +467,44 @@ mod tests {
         let positive_result = later
             .since(&earlier, init_diff_setting(TemporalUnit::Hour))
             .unwrap();
-        assert_time_duration(positive_result, (376436.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+        assert_time_duration(positive_result.time(), (376436.0, 0.0, 0.0, 0.0, 0.0, 0.0));
         let negative_result = earlier
             .since(&later, init_diff_setting(TemporalUnit::Hour))
             .unwrap();
-        assert_time_duration(negative_result, (-376435.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+        assert_time_duration(negative_result.time(), (-376435.0, 0.0, 0.0, 0.0, 0.0, 0.0));
 
         let positive_result = later
             .since(&earlier, init_diff_setting(TemporalUnit::Minute))
             .unwrap();
-        assert_time_duration(positive_result, (376435.0, 24.0, 0.0, 0.0, 0.0, 0.0));
+        assert_time_duration(positive_result.time(), (376435.0, 24.0, 0.0, 0.0, 0.0, 0.0));
         let negative_result = earlier
             .since(&later, init_diff_setting(TemporalUnit::Minute))
             .unwrap();
-        assert_time_duration(negative_result, (-376435.0, -23.0, 0.0, 0.0, 0.0, 0.0));
+        assert_time_duration(negative_result.time(), (-376435.0, -23.0, 0.0, 0.0, 0.0, 0.0));
 
         // ... Skip to lower units ...
 
         let positive_result = later
             .since(&earlier, init_diff_setting(TemporalUnit::Microsecond))
             .unwrap();
-        assert_time_duration(positive_result, (376435.0, 23.0, 8.0, 148.0, 530.0, 0.0));
+        assert_time_duration(positive_result.time(), (376435.0, 23.0, 8.0, 148.0, 530.0, 0.0));
         let negative_result = earlier
             .since(&later, init_diff_setting(TemporalUnit::Microsecond))
             .unwrap();
         assert_time_duration(
-            negative_result,
+            negative_result.time(),
             (-376435.0, -23.0, -8.0, -148.0, -529.0, 0.0),
         );
 
         let positive_result = later
             .since(&earlier, init_diff_setting(TemporalUnit::Nanosecond))
             .unwrap();
-        assert_time_duration(positive_result, (376435.0, 23.0, 8.0, 148.0, 529.0, 500.0));
+        assert_time_duration(positive_result.time(), (376435.0, 23.0, 8.0, 148.0, 529.0, 500.0));
         let negative_result = earlier
             .since(&later, init_diff_setting(TemporalUnit::Nanosecond))
             .unwrap();
         assert_time_duration(
-            negative_result,
+            negative_result.time(),
             (-376435.0, -23.0, -8.0, -148.0, -529.0, -500.0),
         );
     }

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -90,11 +90,18 @@ impl Instant {
         Ok(Self::from(EpochNanoseconds::try_from(result)?))
     }
 
-    pub(crate) fn diff_instant_internal(&self, other: &Self, resolved_options: ResolvedRoundingOptions) -> TemporalResult<Duration> {
+    pub(crate) fn diff_instant_internal(
+        &self,
+        other: &Self,
+        resolved_options: ResolvedRoundingOptions,
+    ) -> TemporalResult<Duration> {
         let diff =
             NormalizedTimeDuration::from_nanosecond_difference(other.as_i128(), self.as_i128())?;
         let (round_record, _) = diff.round(FiniteF64::default(), resolved_options)?;
-        let (_, time_duration) = TimeDuration::from_normalized(round_record.normalized_time_duration(), resolved_options.largest_unit)?;
+        let (_, time_duration) = TimeDuration::from_normalized(
+            round_record.normalized_time_duration(),
+            resolved_options.largest_unit,
+        )?;
         Ok(Duration::from_day_and_time(0.into(), &time_duration))
     }
 
@@ -228,21 +235,13 @@ impl Instant {
 
     /// Returns a `TimeDuration` representing the duration since provided `Instant`
     #[inline]
-    pub fn since(
-        &self,
-        other: &Self,
-        settings: DifferenceSettings,
-    ) -> TemporalResult<Duration> {
+    pub fn since(&self, other: &Self, settings: DifferenceSettings) -> TemporalResult<Duration> {
         self.diff_instant(DifferenceOperation::Since, other, settings)
     }
 
     /// Returns a `TimeDuration` representing the duration until provided `Instant`
     #[inline]
-    pub fn until(
-        &self,
-        other: &Self,
-        settings: DifferenceSettings,
-    ) -> TemporalResult<Duration> {
+    pub fn until(&self, other: &Self, settings: DifferenceSettings) -> TemporalResult<Duration> {
         self.diff_instant(DifferenceOperation::Until, other, settings)
     }
 
@@ -401,14 +400,20 @@ mod tests {
         let negative_result = later
             .until(&earlier, init_diff_setting(TemporalUnit::Minute))
             .unwrap();
-        assert_time_duration(negative_result.time(), (-376435.0, -23.0, 0.0, 0.0, 0.0, 0.0));
+        assert_time_duration(
+            negative_result.time(),
+            (-376435.0, -23.0, 0.0, 0.0, 0.0, 0.0),
+        );
 
         // ... Skip to lower units ...
 
         let positive_result = earlier
             .until(&later, init_diff_setting(TemporalUnit::Microsecond))
             .unwrap();
-        assert_time_duration(positive_result.time(), (376435.0, 23.0, 8.0, 148.0, 530.0, 0.0));
+        assert_time_duration(
+            positive_result.time(),
+            (376435.0, 23.0, 8.0, 148.0, 530.0, 0.0),
+        );
         let negative_result = later
             .until(&earlier, init_diff_setting(TemporalUnit::Microsecond))
             .unwrap();
@@ -420,7 +425,10 @@ mod tests {
         let positive_result = earlier
             .until(&later, init_diff_setting(TemporalUnit::Nanosecond))
             .unwrap();
-        assert_time_duration(positive_result.time(), (376435.0, 23.0, 8.0, 148.0, 529.0, 500.0));
+        assert_time_duration(
+            positive_result.time(),
+            (376435.0, 23.0, 8.0, 148.0, 529.0, 500.0),
+        );
         let negative_result = later
             .until(&earlier, init_diff_setting(TemporalUnit::Nanosecond))
             .unwrap();
@@ -480,14 +488,20 @@ mod tests {
         let negative_result = earlier
             .since(&later, init_diff_setting(TemporalUnit::Minute))
             .unwrap();
-        assert_time_duration(negative_result.time(), (-376435.0, -23.0, 0.0, 0.0, 0.0, 0.0));
+        assert_time_duration(
+            negative_result.time(),
+            (-376435.0, -23.0, 0.0, 0.0, 0.0, 0.0),
+        );
 
         // ... Skip to lower units ...
 
         let positive_result = later
             .since(&earlier, init_diff_setting(TemporalUnit::Microsecond))
             .unwrap();
-        assert_time_duration(positive_result.time(), (376435.0, 23.0, 8.0, 148.0, 530.0, 0.0));
+        assert_time_duration(
+            positive_result.time(),
+            (376435.0, 23.0, 8.0, 148.0, 530.0, 0.0),
+        );
         let negative_result = earlier
             .since(&later, init_diff_setting(TemporalUnit::Microsecond))
             .unwrap();
@@ -499,7 +513,10 @@ mod tests {
         let positive_result = later
             .since(&earlier, init_diff_setting(TemporalUnit::Nanosecond))
             .unwrap();
-        assert_time_duration(positive_result.time(), (376435.0, 23.0, 8.0, 148.0, 529.0, 500.0));
+        assert_time_duration(
+            positive_result.time(),
+            (376435.0, 23.0, 8.0, 148.0, 529.0, 500.0),
+        );
         let negative_result = earlier
             .since(&later, init_diff_setting(TemporalUnit::Nanosecond))
             .unwrap();

--- a/src/components/now.rs
+++ b/src/components/now.rs
@@ -59,6 +59,7 @@ fn system_instant() -> TemporalResult<Instant> {
     Instant::try_new(i128::from_u128(nanos).temporal_unwrap()?)
 }
 
+#[cfg(feature = "tzdb")]
 #[cfg(test)]
 mod tests {
     use std::thread;
@@ -66,7 +67,6 @@ mod tests {
 
     use crate::{options::DifferenceSettings, tzdb::FsTzdbProvider, Now};
 
-    #[cfg(feature = "tzdb")]
     #[test]
     fn now_datetime_test() {
         let provider = &FsTzdbProvider::default();

--- a/src/components/tz.rs
+++ b/src/components/tz.rs
@@ -42,6 +42,26 @@ pub trait TzProvider {
     ) -> TemporalResult<i128>;
 }
 
+pub struct NeverProvider;
+
+impl TzProvider for NeverProvider {
+    fn check_identifier(&self, _: &str) -> bool {
+        unimplemented!()
+    }
+
+    fn get_named_tz_epoch_nanoseconds(
+        &self,
+        _: &str,
+        _: IsoDateTime,
+    ) -> TemporalResult<Vec<EpochNanoseconds>> {
+        unimplemented!()
+    }
+
+    fn get_named_tz_offset_nanoseconds(&self, _: &str, _: i128) -> TemporalResult<i128> {
+        unimplemented!()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TimeZone {
     IanaIdentifier(String),

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -162,8 +162,6 @@ impl ZonedDateTime {
         if resolved_options.smallest_unit == TemporalUnit::Nanosecond
             && resolved_options.increment == RoundingIncrement::ONE
         {
-            std::println!("Nano was none");
-            std::println!("Returning diff");
             return Ok(diff);
         }
         // 4. let datetime be getisodatetimefor(timezone, ns1).

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -7,13 +7,10 @@ use tinystr::TinyAsciiStr;
 
 use crate::{
     components::{
-        calendar::CalendarDateLike,
-        duration::normalized::NormalizedTimeDuration,
-        tz::{parse_offset, TzProvider},
-        EpochNanoseconds,
+        calendar::CalendarDateLike, duration::{normalized::{NormalizedDurationRecord, NormalizedTimeDuration}, TimeDuration}, tz::{parse_offset, TzProvider}, EpochNanoseconds
     },
     iso::{IsoDate, IsoDateTime, IsoTime},
-    options::{ArithmeticOverflow, Disambiguation, OffsetDisambiguation, TemporalRoundingMode},
+    options::{ArithmeticOverflow, Disambiguation, OffsetDisambiguation, ResolvedRoundingOptions, RoundingIncrement, TemporalRoundingMode, TemporalUnit},
     parsers,
     partial::{PartialDate, PartialTime},
     rounding::{IncrementRounder, Round},
@@ -112,10 +109,10 @@ impl ZonedDateTime {
         Instant::from(intermediate_ns).add_to_instant(duration.time())
     }
 
-    #[inline]
     /// Adds a duration to the current `ZonedDateTime`, returning the resulting `ZonedDateTime`.
     ///
-    /// Aligns with Abstract Operation 6.5.10 and 6.5.5
+    /// Aligns with Abstract Operation 6.5.10
+    #[inline]
     pub(crate) fn add_internal(
         &self,
         duration: &Duration,
@@ -138,6 +135,86 @@ impl ZonedDateTime {
             self.timezone().clone(),
         ))
     }
+
+    /// Internal representation of Abstract Op 6.5.7
+    pub(crate) fn diff_with_rounding(&self, other: &Self, resolved_options: ResolvedRoundingOptions, provider: &impl TzProvider) -> TemporalResult<Duration> {
+        // 1. If TemporalUnitCategory(largestUnit) is time, then
+        if resolved_options.largest_unit.is_time_unit() {
+            // a. Return DifferenceInstant(ns1, ns2, roundingIncrement, smallestUnit, roundingMode).
+            return self.instant.diff_instant_internal(&other.instant, resolved_options)
+        }
+        // 2. let difference be ? differencezoneddatetime(ns1, ns2, timezone, calendar, largestunit).
+        let diff = self.diff_zoned_datetime(other, resolved_options.largest_unit, provider)?;
+        // 3. if smallestunit is nanosecond and roundingincrement = 1, return difference.
+        if resolved_options.smallest_unit == TemporalUnit::Nanosecond && resolved_options.increment == RoundingIncrement::ONE {
+            return Ok(diff)
+        }
+        // 4. let datetime be getisodatetimefor(timezone, ns1).
+        let iso = self.timezone().get_iso_datetime_for(&self.instant, provider)?;
+        // 5. Return ? RoundRelativeDuration(difference, ns2, dateTime, timeZone, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode).
+        let normalized_duration = NormalizedDurationRecord::new(*diff.date(), NormalizedTimeDuration::from_time_duration(diff.time()))?;
+        let (result, _) = normalized_duration.round_relative_duration(other.epoch_nanoseconds(), &PlainDateTime::new_unchecked(iso, self.calendar().clone()), Some(self.timezone().clone()), resolved_options)?;
+        Ok(result)
+    }
+
+    pub(crate) fn diff_zoned_datetime(&self, other: &Self, largest_unit: TemporalUnit, provider: &impl TzProvider) -> TemporalResult<Duration> {
+        // 1. If ns1 = ns2, return CombineDateAndTimeDuration(ZeroDateDuration(), 0).
+        if self.epoch_nanoseconds() == other.epoch_nanoseconds() {
+            return Ok(Duration::default())
+        }
+        // 2. Let startDateTime be GetISODateTimeFor(timeZone, ns1).
+        let start = self.tz.get_iso_datetime_for(&self.instant, provider)?;
+        // 3. Let endDateTime be GetISODateTimeFor(timeZone, ns2).
+        let end = self.tz.get_iso_datetime_for(&other.instant, provider)?;
+        // 4. If ns2 - ns1 < 0, let sign be -1; else let sign be 1.
+        let sign =  if other.epoch_nanoseconds() - self.epoch_nanoseconds() < 0 { Sign::Negative} else { Sign::Positive };
+        // 5. If sign = 1, let maxDayCorrection be 2; else let maxDayCorrection be 1.
+        let max_correction = if sign == Sign::Positive {
+            2
+        } else {
+            1
+        };
+        // 6. Let dayCorrection be 0.
+        // 7. Let timeDuration be DifferenceTime(startDateTime.[[Time]], endDateTime.[[Time]]).
+        let time = start.time.diff(&end.time);
+        // 8. If TimeDurationSign(timeDuration) = -sign, set dayCorrection to dayCorrection + 1.
+        let mut day_correction = if time.sign() as i8 == -(sign as i8) {
+            1
+        } else {
+            0
+        };
+
+        // 9. Let success be false.
+        let mut intermediate_dt = IsoDateTime::default();
+        let mut result_duration = None;
+        // 10. Repeat, while dayCorrection ≤ maxDayCorrection and success is false,
+        while day_correction <= max_correction && result_duration.is_none() {
+            // a. Let intermediateDate be BalanceISODate(endDateTime.[[ISODate]].[[Year]], endDateTime.[[ISODate]].[[Month]], endDateTime.[[ISODate]].[[Day]] - dayCorrection × sign).
+            let intermediate = IsoDate::balance(end.date.year, end.date.month.into(), i32::from(end.date.day) - i32::from(day_correction * sign as i8));
+            // b. Let intermediateDateTime be CombineISODateAndTimeRecord(intermediateDate, startDateTime.[[Time]]).
+            intermediate_dt = IsoDateTime::new_unchecked(intermediate, start.time);
+            // c. Let intermediateNs be ? GetEpochNanosecondsFor(timeZone, intermediateDateTime, compatible).
+            let intermediate_ns = self.tz.get_epoch_nanoseconds_for(intermediate_dt, Disambiguation::Compatible, provider)?;
+            // d. Set timeDuration to TimeDurationFromEpochNanosecondsDifference(ns2, intermediateNs).
+            let (_, time_duration) = TimeDuration::from_normalized(NormalizedTimeDuration(intermediate_ns.0), largest_unit)?;
+            // e. Let timeSign be TimeDurationSign(timeDuration).
+            let time_sign = time_duration.sign() as i8;
+            // f. If sign ≠ -timeSign, then
+            if sign as i8 != -time_sign {
+                // i. Set success to true.
+                let _ = result_duration.insert(time_duration);
+            }
+            // g. Set dayCorrection to dayCorrection + 1.
+            day_correction += 1;
+        }
+        // 11. Assert: success is true.
+        // 12. Let dateLargestUnit be LargerOfTwoTemporalUnits(largestUnit, day).
+        let date_largest = largest_unit.max(TemporalUnit::Day);
+        // 13. Let dateDifference be CalendarDateUntil(calendar, startDateTime.[[ISODate]], intermediateDateTime.[[ISODate]], dateLargestUnit).
+        // 14. Return CombineDateAndTimeDuration(dateDifference, timeDuration).
+        self.calendar().date_until(&PlainDate::new_unchecked(start.date, self.calendar().clone()), &PlainDate::new_unchecked(intermediate_dt.date, self.calendar().clone()), date_largest)
+    }
+
 }
 
 // ==== Public API ====

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,10 @@ impl Sign {
         }
         *self as i8
     }
+
+    pub(crate) fn negate(&self) -> Sign {
+        Sign::from(-(*self as i8))
+    }
 }
 
 // Relevant numeric constants

--- a/src/options.rs
+++ b/src/options.rs
@@ -221,9 +221,22 @@ impl ResolvedRoundingOptions {
 
 // ==== RelativeTo Object ====
 
-pub struct RelativeTo<'a> {
-    pub date: Option<&'a PlainDate>,
-    pub zdt: Option<&'a ZonedDateTime>,
+#[derive(Debug, Clone)]
+pub enum RelativeTo<'a> {
+    PlainDate(&'a PlainDate),
+    ZonedDateTime(&'a ZonedDateTime),
+}
+
+impl<'a> From<&'a PlainDate> for RelativeTo<'a> {
+    fn from(value: &'a PlainDate) -> Self {
+        Self::PlainDate(value)
+    }
+}
+
+impl<'a> From<&'a ZonedDateTime> for RelativeTo<'a> {
+    fn from(value: &'a ZonedDateTime) -> Self {
+        Self::ZonedDateTime(value)
+    }
 }
 
 // ==== Options enums and methods ====
@@ -304,10 +317,18 @@ impl TemporalUnit {
         }
     }
 
+    #[inline]
     #[must_use]
     pub fn is_calendar_unit(&self) -> bool {
         use TemporalUnit::{Month, Week, Year};
         matches!(self, Year | Month | Week)
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn is_time_unit(&self) -> bool {
+        use TemporalUnit::{Hour, Minute, Second, Millisecond, Microsecond, Nanosecond};
+        matches!(self, Hour | Minute | Second | Millisecond | Microsecond | Nanosecond)
     }
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -327,8 +327,11 @@ impl TemporalUnit {
     #[inline]
     #[must_use]
     pub fn is_time_unit(&self) -> bool {
-        use TemporalUnit::{Hour, Minute, Second, Millisecond, Microsecond, Nanosecond};
-        matches!(self, Hour | Minute | Second | Millisecond | Microsecond | Nanosecond)
+        use TemporalUnit::{Hour, Microsecond, Millisecond, Minute, Nanosecond, Second};
+        matches!(
+            self,
+            Hour | Minute | Second | Millisecond | Microsecond | Nanosecond
+        )
     }
 }
 


### PR DESCRIPTION
This PR focuses primarily on adding `ZonedDateTime` functionality to `Duration::round`. There were also a few more changes per the below.

Overview:

  - Add `ZonedDateTime` functionality to `Duration::round` code paths.
  - Adds a `round_with_provider` and `round` method for `Duration` (old method renamed to `round_with_provider`, new method named `round` and flagged `experimental`
  - Updates `RelativeTo` to an enum
  - More heavily utilizes `NormalizedDurationRecord` (what the specification is now calling an `Internal Duration Record`
  - Adds `now` feature flag to default.
  - Implements a `NeverProvider` for `TzProvider`