### PR TITLE
Update try_new, new, and new_with_overflow integer type

### DIFF
--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -281,14 +281,14 @@ impl Calendar {
         partial: &PartialDate,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<PlainDate> {
-        let fields = self.resolve_partial_date_fields(partial, overflow)?;
+        let resolved_fields = self.resolve_partial_date_fields(partial, overflow)?;
 
         if self.is_iso() {
             // Resolve month and monthCode;
             return PlainDate::new_with_overflow(
-                fields.era_year.year,
-                fields.month_code.as_iso_month_integer()?.into(),
-                fields.day,
+                resolved_fields.era_year.year,
+                resolved_fields.month_code.as_iso_month_integer()?,
+                resolved_fields.day,
                 self.clone(),
                 overflow,
             );
@@ -297,17 +297,17 @@ impl Calendar {
         let calendar_date = self
             .0
             .date_from_codes(
-                Some(IcuEra(fields.era_year.era.0)),
-                fields.era_year.year,
-                IcuMonthCode(fields.month_code.0),
-                fields.day as u8, // TODO: FIX
+                Some(IcuEra(resolved_fields.era_year.era.0)),
+                resolved_fields.era_year.year,
+                IcuMonthCode(resolved_fields.month_code.0),
+                resolved_fields.day,
             )
             .map_err(TemporalError::from_icu4x)?;
         let iso = self.0.date_to_iso(&calendar_date);
         PlainDate::new_with_overflow(
             iso.year().extended_year,
-            iso.month().ordinal as i32,
-            iso.day_of_month().0 as i32,
+            iso.month().ordinal,
+            iso.day_of_month().0,
             self.clone(),
             overflow,
         )
@@ -322,7 +322,7 @@ impl Calendar {
         let resolved_fields = self.resolve_partial_date_fields(partial, overflow)?;
         if self.is_iso() {
             return PlainMonthDay::new_with_overflow(
-                resolved_fields.month_code.as_iso_month_integer()?.into(),
+                resolved_fields.month_code.as_iso_month_integer()?,
                 resolved_fields.day,
                 self.clone(),
                 overflow,
@@ -345,7 +345,7 @@ impl Calendar {
         if self.is_iso() {
             return PlainYearMonth::new_with_overflow(
                 resolved_fields.era_year.year,
-                resolved_fields.month_code.as_iso_month_integer()?.into(),
+                resolved_fields.month_code.as_iso_month_integer()?,
                 Some(resolved_fields.day),
                 self.clone(),
                 overflow,
@@ -359,14 +359,14 @@ impl Calendar {
                 Some(IcuEra(resolved_fields.era_year.era.0)),
                 resolved_fields.era_year.year,
                 IcuMonthCode(resolved_fields.month_code.0),
-                resolved_fields.day as u8, // NOTE: Not the best idea, probably action overflow behavior prior to this.
+                resolved_fields.day,
             )
             .map_err(TemporalError::from_icu4x)?;
         let iso = self.0.date_to_iso(&calendar_date);
         PlainYearMonth::new_with_overflow(
             iso.year().extended_year,
-            iso.month().ordinal as i32,
-            Some(iso.day_of_month().0 as i32),
+            iso.month().ordinal,
+            Some(iso.day_of_month().0),
             self.clone(),
             overflow,
         )
@@ -400,8 +400,8 @@ impl Calendar {
             // 11. Return ? CreateTemporalDate(result.[[Year]], result.[[Month]], result.[[Day]], "iso8601").
             return PlainDate::try_new(
                 result.year,
-                result.month.into(),
-                result.day.into(),
+                result.month,
+                result.day,
                 date.calendar().clone(),
             );
         }

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -36,11 +36,11 @@ pub struct PartialDate {
     // A potentially set `year` field.
     pub year: Option<i32>,
     // A potentially set `month` field.
-    pub month: Option<i32>,
+    pub month: Option<u8>,
     // A potentially set `month_code` field.
     pub month_code: Option<TinyAsciiStr<4>>,
     // A potentially set `day` field.
-    pub day: Option<i32>,
+    pub day: Option<u8>,
     // A potentially set `era` field.
     pub era: Option<TinyAsciiStr<19>>,
     // A potentially set `era_year` field.
@@ -69,7 +69,7 @@ impl PartialDate {
         };
         Ok(Self {
             year,
-            month: Some(year_month.month()?.into()),
+            month: Some(year_month.month()?),
             month_code: Some(year_month.month_code()?),
             day: Some(1),
             era,
@@ -201,8 +201,8 @@ impl PlainDate {
 
         Self::try_new(
             result.year,
-            result.month.into(),
-            result.day.into(),
+            result.month,
+            result.day,
             self.calendar().clone(),
         )
     }
@@ -308,12 +308,12 @@ impl PlainDate {
 
 impl PlainDate {
     /// Creates a new `PlainDate` automatically constraining any values that may be invalid.
-    pub fn new(year: i32, month: i32, day: i32, calendar: Calendar) -> TemporalResult<Self> {
+    pub fn new(year: i32, month: u8, day: u8, calendar: Calendar) -> TemporalResult<Self> {
         Self::new_with_overflow(year, month, day, calendar, ArithmeticOverflow::Constrain)
     }
 
     /// Creates a new `PlainDate` rejecting any date that may be invalid.
-    pub fn try_new(year: i32, month: i32, day: i32, calendar: Calendar) -> TemporalResult<Self> {
+    pub fn try_new(year: i32, month: u8, day: u8, calendar: Calendar) -> TemporalResult<Self> {
         Self::new_with_overflow(year, month, day, calendar, ArithmeticOverflow::Reject)
     }
 
@@ -323,8 +323,8 @@ impl PlainDate {
     #[inline]
     pub fn new_with_overflow(
         year: i32,
-        month: i32,
-        day: i32,
+        month: u8,
+        day: u8,
         calendar: Calendar,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<Self> {
@@ -391,12 +391,7 @@ impl PlainDate {
 
     /// Creates a new `Date` from the current `Date` and the provided calendar.
     pub fn with_calendar(&self, calendar: Calendar) -> TemporalResult<Self> {
-        Self::try_new(
-            self.iso_year(),
-            self.iso_month().into(),
-            self.iso_day().into(),
-            calendar,
-        )
+        Self::try_new(self.iso_year(), self.iso_month(), self.iso_day(), calendar)
     }
 
     #[inline]
@@ -626,7 +621,7 @@ impl FromStr for PlainDate {
         // Assertion: PlainDate must exist on a DateTime parse.
         let date = parse_record.date.temporal_unwrap()?;
 
-        Self::try_new(date.year, date.month.into(), date.day.into(), calendar)
+        Self::try_new(date.year, date.month, date.day, calendar)
     }
 }
 

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -228,14 +228,14 @@ impl PlainDateTime {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         year: i32,
-        month: i32,
-        day: i32,
-        hour: i32,
-        minute: i32,
-        second: i32,
-        millisecond: i32,
-        microsecond: i32,
-        nanosecond: i32,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        millisecond: u16,
+        microsecond: u16,
+        nanosecond: u16,
         calendar: Calendar,
     ) -> TemporalResult<Self> {
         Self::new_with_overflow(
@@ -257,14 +257,14 @@ impl PlainDateTime {
     #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         year: i32,
-        month: i32,
-        day: i32,
-        hour: i32,
-        minute: i32,
-        second: i32,
-        millisecond: i32,
-        microsecond: i32,
-        nanosecond: i32,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        millisecond: u16,
+        microsecond: u16,
+        nanosecond: u16,
         calendar: Calendar,
     ) -> TemporalResult<Self> {
         Self::new_with_overflow(
@@ -287,14 +287,14 @@ impl PlainDateTime {
     #[allow(clippy::too_many_arguments)]
     pub fn new_with_overflow(
         year: i32,
-        month: i32,
-        day: i32,
-        hour: i32,
-        minute: i32,
-        second: i32,
-        millisecond: i32,
-        microsecond: i32,
-        nanosecond: i32,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        millisecond: u16,
+        microsecond: u16,
+        nanosecond: u16,
         calendar: Calendar,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<Self> {
@@ -428,14 +428,14 @@ impl PlainDateTime {
     pub fn with_time(&self, time: PlainTime) -> TemporalResult<Self> {
         Self::try_new(
             self.iso_year(),
-            self.iso_month().into(),
-            self.iso_day().into(),
-            time.hour().into(),
-            time.minute().into(),
-            time.second().into(),
-            time.millisecond().into(),
-            time.microsecond().into(),
-            time.nanosecond().into(),
+            self.iso_month(),
+            self.iso_day(),
+            time.hour(),
+            time.minute(),
+            time.second(),
+            time.millisecond(),
+            time.microsecond(),
+            time.nanosecond(),
             self.calendar.clone(),
         )
     }
@@ -444,14 +444,14 @@ impl PlainDateTime {
     pub fn with_calendar(&self, calendar: Calendar) -> TemporalResult<Self> {
         Self::try_new(
             self.iso_year(),
-            self.iso_month().into(),
-            self.iso_day().into(),
-            self.hour().into(),
-            self.minute().into(),
-            self.second().into(),
-            self.millisecond().into(),
-            self.microsecond().into(),
-            self.nanosecond().into(),
+            self.iso_month(),
+            self.iso_day(),
+            self.hour(),
+            self.minute(),
+            self.second(),
+            self.millisecond(),
+            self.microsecond(),
+            self.nanosecond(),
             calendar,
         )
     }
@@ -699,23 +699,20 @@ impl FromStr for PlainDateTime {
             .transpose()?
             .unwrap_or_default();
 
-        let time = if let Some(time) = parse_record.time {
-            IsoTime::from_components(
-                i32::from(time.hour),
-                i32::from(time.minute),
-                i32::from(time.second),
-                f64::from(time.nanosecond),
-            )?
-        } else {
-            IsoTime::default()
-        };
+        let time = parse_record
+            .time
+            .map(|time| {
+                IsoTime::from_components(time.hour, time.minute, time.second, time.nanosecond)
+            })
+            .transpose()?
+            .unwrap_or_default();
 
         let parsed_date = parse_record.date.temporal_unwrap()?;
 
         let date = IsoDate::new_with_overflow(
             parsed_date.year,
-            parsed_date.month.into(),
-            parsed_date.day.into(),
+            parsed_date.month,
+            parsed_date.day,
             ArithmeticOverflow::Reject,
         )?;
 
@@ -757,7 +754,7 @@ mod tests {
         assert_eq!(dt.nanosecond(), fields.9);
     }
 
-    fn pdt_from_date(year: i32, month: i32, day: i32) -> TemporalResult<PlainDateTime> {
+    fn pdt_from_date(year: i32, month: u8, day: u8) -> TemporalResult<PlainDateTime> {
         PlainDateTime::try_new(year, month, day, 0, 0, 0, 0, 0, 0, Calendar::default())
     }
 

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -92,7 +92,6 @@ impl NormalizedTimeDuration {
         days as f64 + (remainder as f64 / NS_PER_DAY as f64)
     }
 
-    // TODO: Potentially abstract sign into `Sign`
     /// Equivalent: 7.5.31 NormalizedTimeDurationSign ( d )
     #[inline]
     #[must_use]
@@ -380,8 +379,8 @@ impl NormalizedDurationRecord {
                 // calendarRec.[[Receiver]]).
                 let weeks_start = PlainDate::try_new(
                     iso_one.year,
-                    iso_one.month.into(),
-                    iso_one.day.into(),
+                    iso_one.month,
+                    iso_one.day,
                     dt.calendar().clone(),
                 )?;
 
@@ -389,8 +388,8 @@ impl NormalizedDurationRecord {
                 // calendarRec.[[Receiver]]).
                 let weeks_end = PlainDate::try_new(
                     iso_two.year,
-                    iso_two.month.into(),
-                    iso_two.day.into(),
+                    iso_two.month,
+                    iso_two.day,
                     dt.calendar().clone(),
                 )?;
 

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use ixdtf::parsers::records::UtcOffsetRecordOrZ;
-use num_traits::{Euclid, FromPrimitive};
+use num_traits::FromPrimitive;
 
 use super::duration::normalized::NormalizedTimeDuration;
 
@@ -284,22 +284,17 @@ impl FromStr for Instant {
         // Find the IsoDate
         let iso_date = IsoDate::new_with_overflow(
             ixdtf_record.date.year,
-            ixdtf_record.date.month.into(),
-            ixdtf_record.date.day.into(),
+            ixdtf_record.date.month,
+            ixdtf_record.date.day,
             ArithmeticOverflow::Reject,
         )?;
 
         // Find the IsoTime
-        let (millisecond, remainder) = ixdtf_record.time.nanosecond.div_rem_euclid(&1_000_000);
-        let (microsecond, nanosecond) = remainder.div_rem_euclid(&1_000);
-        let iso_time = IsoTime::new(
-            ixdtf_record.time.hour.into(),
-            ixdtf_record.time.minute.into(),
-            ixdtf_record.time.second.into(),
-            millisecond as i32,
-            microsecond as i32,
-            nanosecond as i32,
-            ArithmeticOverflow::Reject,
+        let iso_time = IsoTime::from_components(
+            ixdtf_record.time.hour,
+            ixdtf_record.time.minute,
+            ixdtf_record.time.second,
+            ixdtf_record.time.nanosecond,
         )?;
 
         // Find the offset

--- a/src/components/month_day.rs
+++ b/src/components/month_day.rs
@@ -32,8 +32,8 @@ impl PlainMonthDay {
     /// Creates a new valid `MonthDay`.
     #[inline]
     pub fn new_with_overflow(
-        month: i32,
-        day: i32,
+        month: u8,
+        day: u8,
         calendar: Calendar,
         overflow: ArithmeticOverflow,
         ref_year: Option<i32>,
@@ -117,8 +117,8 @@ impl FromStr for PlainMonthDay {
         let date = date.temporal_unwrap()?;
 
         Self::new_with_overflow(
-            date.month.into(),
-            date.day.into(),
+            date.month,
+            date.day,
             calendar,
             ArithmeticOverflow::Reject,
             None,

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -22,17 +22,17 @@ use core::str::FromStr;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PartialTime {
     // A potentially set `hour` field.
-    pub hour: Option<i32>,
+    pub hour: Option<u8>,
     // A potentially set `minute` field.
-    pub minute: Option<i32>,
+    pub minute: Option<u8>,
     // A potentially set `second` field.
-    pub second: Option<i32>,
+    pub second: Option<u8>,
     // A potentially set `millisecond` field.
-    pub millisecond: Option<i32>,
+    pub millisecond: Option<u16>,
     // A potentially set `microsecond` field.
-    pub microsecond: Option<i32>,
+    pub microsecond: Option<u16>,
     // A potentially set `nanosecond` field.
-    pub nanosecond: Option<i32>,
+    pub nanosecond: Option<u16>,
 }
 
 impl PartialTime {
@@ -173,12 +173,12 @@ impl PlainTime {
     /// assert_eq!(time, constrained_time);
     /// ```
     pub fn new(
-        hour: i32,
-        minute: i32,
-        second: i32,
-        millisecond: i32,
-        microsecond: i32,
-        nanosecond: i32,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        millisecond: u16,
+        microsecond: u16,
+        nanosecond: u16,
     ) -> TemporalResult<Self> {
         Self::new_with_overflow(
             hour,
@@ -202,12 +202,12 @@ impl PlainTime {
     /// assert!(invalid_time.is_err());
     /// ```
     pub fn try_new(
-        hour: i32,
-        minute: i32,
-        second: i32,
-        millisecond: i32,
-        microsecond: i32,
-        nanosecond: i32,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        millisecond: u16,
+        microsecond: u16,
+        nanosecond: u16,
     ) -> TemporalResult<Self> {
         Self::new_with_overflow(
             hour,
@@ -223,12 +223,12 @@ impl PlainTime {
     /// Creates a new `PlainTime` with the provided [`ArithmeticOverflow`] option.
     #[inline]
     pub fn new_with_overflow(
-        hour: i32,
-        minute: i32,
-        second: i32,
-        millisecond: i32,
-        microsecond: i32,
-        nanosecond: i32,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        millisecond: u16,
+        microsecond: u16,
+        nanosecond: u16,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<Self> {
         let time = IsoTime::new(
@@ -448,18 +448,10 @@ impl FromStr for PlainTime {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let result = parse_time(s)?;
 
-        let (millisecond, rem) = (result.nanosecond / 1_000_000, result.nanosecond % 1_000_000);
-        let (microsecond, nanosecond) = (rem / 1_000, rem % 1_000);
+        let iso =
+            IsoTime::from_components(result.hour, result.minute, result.second, result.nanosecond)?;
 
-        PlainTime::new_with_overflow(
-            result.hour.into(),
-            result.minute.into(),
-            result.second.into(),
-            millisecond as i32,
-            microsecond as i32,
-            nanosecond as i32,
-            ArithmeticOverflow::Reject,
-        )
+        Ok(Self::new_unchecked(iso))
     }
 }
 

--- a/src/components/year_month.rs
+++ b/src/components/year_month.rs
@@ -38,8 +38,8 @@ impl PlainYearMonth {
     #[inline]
     pub fn new_with_overflow(
         year: i32,
-        month: i32,
-        reference_day: Option<i32>,
+        month: u8,
+        reference_day: Option<u8>,
         calendar: Calendar,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<Self> {
@@ -194,7 +194,7 @@ impl FromStr for PlainYearMonth {
 
         Self::new_with_overflow(
             date.year,
-            date.month.into(),
+            date.month,
             None,
             calendar,
             ArithmeticOverflow::Reject,

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -845,12 +845,7 @@ impl ZonedDateTime {
         let time = parse_result
             .time
             .map(|time| {
-                IsoTime::from_components(
-                    i32::from(time.hour),
-                    i32::from(time.minute),
-                    i32::from(time.second),
-                    f64::from(time.nanosecond),
-                )
+                IsoTime::from_components(time.hour, time.minute, time.second, time.nanosecond)
             })
             .transpose()?;
 
@@ -862,8 +857,8 @@ impl ZonedDateTime {
 
         let date = IsoDate::new_with_overflow(
             parsed_date.year,
-            parsed_date.month.into(),
-            parsed_date.day.into(),
+            parsed_date.month,
+            parsed_date.day,
             ArithmeticOverflow::Reject,
         )?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -117,7 +117,7 @@ pub(crate) fn epoch_time_to_month_in_year(t: f64) -> u8 {
 }
 
 // Returns the time for a month in a given year plus date(t) = 1.
-pub(crate) fn epoch_time_for_month_given_year(m: i32, y: i32) -> f64 {
+pub(crate) fn epoch_time_for_month_given_year(m: u8, y: i32) -> f64 {
     let leap_day = mathematical_days_in_year(y) - 365;
 
     // Includes day. i.e. end of month + 1
@@ -126,7 +126,7 @@ pub(crate) fn epoch_time_for_month_given_year(m: i32, y: i32) -> f64 {
     f64::from(MS_PER_DAY) * f64::from(days)
 }
 
-fn month_to_day(m: i32, leap_day: u16) -> u16 {
+fn month_to_day(m: u8, leap_day: u16) -> u16 {
     match m {
         0 => 0,
         1 => 31,
@@ -177,10 +177,7 @@ pub(crate) fn epoch_seconds_to_day_of_week(t: f64) -> u16 {
 pub(crate) fn epoch_seconds_to_day_of_month(t: f64) -> u16 {
     let leap_day = mathematical_in_leap_year(t);
     epoch_time_to_day_in_year(t * 1_000.0) as u16
-        - month_to_day(
-            epoch_time_to_month_in_year(t * 1_000.0) as i32,
-            leap_day as u16,
-        )
+        - month_to_day(epoch_time_to_month_in_year(t * 1_000.0), leap_day as u16)
 }
 
 // Trait implementations
@@ -194,11 +191,11 @@ pub(crate) fn epoch_seconds_to_day_of_month(t: f64) -> u16 {
 // NOTE: below was the iso methods in temporal::calendar -> Need to be reassessed.
 
 /// 12.2.31 `ISODaysInMonth ( year, month )`
-pub(crate) fn iso_days_in_month(year: i32, month: i32) -> i32 {
+pub(crate) fn iso_days_in_month(year: i32, month: i32) -> u8 {
     match month {
         1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
         4 | 6 | 9 | 11 => 30,
-        2 => 28 + mathematical_in_leap_year(epoch_time_for_year(year)),
+        2 => 28 + mathematical_in_leap_year(epoch_time_for_year(year)) as u8,
         _ => unreachable!("ISODaysInMonth panicking is an implementation error."),
     }
 }


### PR DESCRIPTION
With the change from #131, there is no longer a need for any of the new methods to use all `i32`s for their arguments. This PR updates `temporal_rs` accordingly.