### PR TITLE
Complete some general cleanup of `temporal_rs`

### DIFF
--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -283,7 +283,7 @@ impl Calendar {
         partial: &PartialDate,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<PlainDate> {
-        let resolved_fields = self.resolve_partial_date_fields(partial, overflow)?;
+        let resolved_fields = ResolvedCalendarFields::try_from_partial(partial, overflow)?;
 
         if self.is_iso() {
             // Resolve month and monthCode;
@@ -321,7 +321,7 @@ impl Calendar {
         partial: &PartialDate,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<PlainMonthDay> {
-        let resolved_fields = self.resolve_partial_date_fields(partial, overflow)?;
+        let resolved_fields = ResolvedCalendarFields::try_from_partial(partial, overflow)?;
         if self.is_iso() {
             return PlainMonthDay::new_with_overflow(
                 resolved_fields.month_code.as_iso_month_integer()?,
@@ -343,7 +343,7 @@ impl Calendar {
         partial: &PartialDate,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<PlainYearMonth> {
-        let resolved_fields = self.resolve_partial_date_fields(partial, overflow)?;
+        let resolved_fields = ResolvedCalendarFields::try_from_partial(partial, overflow)?;
         if self.is_iso() {
             return PlainYearMonth::new_with_overflow(
                 resolved_fields.era_year.year,
@@ -587,16 +587,6 @@ impl Calendar {
 }
 
 impl Calendar {
-    /// CalendarFields equivalent.
-    #[inline]
-    pub fn resolve_partial_date_fields(
-        &self,
-        partial_date: &PartialDate,
-        overflow: ArithmeticOverflow,
-    ) -> TemporalResult<ResolvedCalendarFields> {
-        ResolvedCalendarFields::try_from_partial_and_calendar(self, partial_date, overflow)
-    }
-
     pub(crate) fn get_era_info(&self, era_alias: &TinyAsciiStr<19>) -> Option<EraInfo> {
         match self.0 .0.kind() {
             AnyCalendarKind::Buddhist if era::BUDDHIST_ERA_IDENTIFIERS.contains(era_alias) => {

--- a/src/components/calendar/types.rs
+++ b/src/components/calendar/types.rs
@@ -22,8 +22,7 @@ pub struct ResolvedCalendarFields {
 
 impl ResolvedCalendarFields {
     #[inline]
-    pub fn try_from_partial_and_calendar(
-        calendar: &Calendar,
+    pub fn try_from_partial(
         partial_date: &PartialDate,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<Self> {
@@ -31,9 +30,9 @@ impl ResolvedCalendarFields {
             partial_date.year,
             partial_date.era,
             partial_date.era_year,
-            calendar,
+            &partial_date.calendar,
         )?;
-        if calendar.is_iso() {
+        if partial_date.calendar.is_iso() {
             let month_code =
                 resolve_iso_month(partial_date.month_code, partial_date.month, overflow)?;
             let day = partial_date
@@ -57,7 +56,7 @@ impl ResolvedCalendarFields {
             });
         }
 
-        let month_code = MonthCode::try_from_partial_date(partial_date, calendar)?;
+        let month_code = MonthCode::try_from_partial_date(partial_date, &partial_date.calendar)?;
         let day = partial_date
             .day
             .ok_or(TemporalError::r#type().with_message("Required day field is empty."))?;
@@ -356,12 +355,7 @@ mod tests {
             ..Default::default()
         };
 
-        let cal = Calendar::default();
-        let err = ResolvedCalendarFields::try_from_partial_and_calendar(
-            &cal,
-            &bad_fields,
-            ArithmeticOverflow::Reject,
-        );
+        let err = ResolvedCalendarFields::try_from_partial(&bad_fields, ArithmeticOverflow::Reject);
         assert!(err.is_err());
     }
 
@@ -373,20 +367,11 @@ mod tests {
             ..Default::default()
         };
 
-        let cal = Calendar::default();
-        let err = ResolvedCalendarFields::try_from_partial_and_calendar(
-            &cal,
-            &bad_fields,
-            ArithmeticOverflow::Reject,
-        );
+        let err = ResolvedCalendarFields::try_from_partial(&bad_fields, ArithmeticOverflow::Reject);
         assert!(err.is_err());
 
         let bad_fields = PartialDate::default();
-        let err = ResolvedCalendarFields::try_from_partial_and_calendar(
-            &cal,
-            &bad_fields,
-            ArithmeticOverflow::Reject,
-        );
+        let err = ResolvedCalendarFields::try_from_partial(&bad_fields, ArithmeticOverflow::Reject);
         assert!(err.is_err());
     }
 }

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -370,9 +370,8 @@ impl PlainDate {
             return Err(TemporalError::range().with_message("Invalid PlainDate fields provided."));
         }
 
-        let calendar = partial.calendar.clone();
         let overflow = overflow.unwrap_or_default();
-        calendar.date_from_partial(&partial, overflow)
+        partial.calendar.date_from_partial(&partial, overflow)
     }
 
     /// Creates a date time with values from a `PartialDate`.

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -8,7 +8,7 @@ use crate::{
         duration::DateDuration,
         Duration, PlainDateTime,
     },
-    iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime},
+    iso::{IsoDate, IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions,
         TemporalUnit,
@@ -24,7 +24,7 @@ use core::str::FromStr;
 use super::{
     calendar::{ascii_four_to_integer, month_to_month_code},
     duration::{normalized::NormalizedDurationRecord, TimeDuration},
-    tz::NeverProvider,
+    timezone::NeverProvider,
     PlainMonthDay, PlainTime, PlainYearMonth,
 };
 
@@ -32,7 +32,7 @@ use super::{
 // "ethiopic-amete-alem". TODO: PrepareTemporalFields expects a type
 // error to be thrown when all partial fields are None/undefined.
 /// A partial PlainDate that may or may not be complete.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct PartialDate {
     // A potentially set `year` field.
     pub year: Option<i32>,
@@ -46,6 +46,8 @@ pub struct PartialDate {
     pub era: Option<TinyAsciiStr<19>>,
     // A potentially set `era_year` field.
     pub era_year: Option<i32>,
+    /// The calendar field
+    pub calendar: Calendar,
 }
 
 impl PartialDate {
@@ -75,6 +77,7 @@ impl PartialDate {
             day: Some(1),
             era,
             era_year,
+            calendar: year_month.calendar().clone(),
         })
     }
 
@@ -120,6 +123,7 @@ macro_rules! impl_with_fallback_method {
                 day: Some(self.day.unwrap_or(fallback.day()?.into())),
                 era,
                 era_year,
+                calendar: fallback.calendar().clone(),
             })
         }
     };
@@ -175,7 +179,7 @@ impl PlainDate {
             // i. Set dateAdd to unused.
             // ii. If calendar is an Object, set dateAdd to ? GetMethod(calendar, "dateAdd").
             // b. Return ? CalendarDateAdd(calendar, plainDate, duration, options, dateAdd).
-            return self.calendar().date_add(self, duration, overflow);
+            return self.calendar().date_add(&self.iso, duration, overflow);
         }
 
         // 4. Let overflow be ? ToTemporalOverflow(options).
@@ -234,7 +238,8 @@ impl PlainDate {
             )?));
         }
 
-        self.calendar().date_until(self, other, largest_unit)
+        self.calendar()
+            .date_until(&self.iso, &other.iso, largest_unit)
     }
 
     /// Equivalent: DifferenceTemporalPlainDate
@@ -561,7 +566,7 @@ impl PlainDate {
     #[inline]
     pub fn to_date_time(&self, time: Option<PlainTime>) -> TemporalResult<PlainDateTime> {
         let time = time.unwrap_or_default();
-        let iso = IsoDateTime::new(self.iso_date(), time.iso)?;
+        let iso = IsoDateTime::new(self.iso, time.iso)?;
         Ok(PlainDateTime::new_unchecked(iso, self.get_calendar()))
     }
 
@@ -589,13 +594,6 @@ impl PlainDate {
 impl GetTemporalCalendar for PlainDate {
     fn get_calendar(&self) -> Calendar {
         self.calendar.clone()
-    }
-}
-
-impl IsoDateSlots for PlainDate {
-    /// Returns the structs `IsoDate`
-    fn iso_date(&self) -> IsoDate {
-        self.iso
     }
 }
 

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -361,7 +361,6 @@ impl PlainDate {
     #[inline]
     pub fn from_partial(
         partial: PartialDate,
-        calendar: Option<Calendar>,
         overflow: Option<ArithmeticOverflow>,
     ) -> TemporalResult<Self> {
         let year_check =
@@ -370,7 +369,8 @@ impl PlainDate {
         if !year_check || !month_check || partial.day.is_none() {
             return Err(TemporalError::range().with_message("Invalid PlainDate fields provided."));
         }
-        let calendar = calendar.unwrap_or_default();
+
+        let calendar = partial.calendar.clone();
         let overflow = overflow.unwrap_or_default();
         calendar.date_from_partial(&partial, overflow)
     }

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -350,7 +350,7 @@ impl PlainDate {
     ///     ..Default::default()
     /// };
     ///
-    /// let date = PlainDate::from_partial(partial, None, None).unwrap();
+    /// let date = PlainDate::from_partial(partial, None).unwrap();
     ///
     /// assert_eq!(date.year().unwrap(), 2000);
     /// assert_eq!(date.month().unwrap(), 12);

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -306,7 +306,7 @@ impl PlainDateTime {
     ///
     /// let partial = PartialDateTime { date, time };
     ///
-    /// let date = PlainDateTime::from_partial(partial, None, None).unwrap();
+    /// let date = PlainDateTime::from_partial(partial, None).unwrap();
     ///
     /// assert_eq!(date.year().unwrap(), 2000);
     /// assert_eq!(date.month().unwrap(), 12);

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -320,10 +320,9 @@ impl PlainDateTime {
     /// ```
     pub fn from_partial(
         partial: PartialDateTime,
-        calendar: Option<Calendar>,
         overflow: Option<ArithmeticOverflow>,
     ) -> TemporalResult<Self> {
-        let date = PlainDate::from_partial(partial.date, calendar, overflow)?;
+        let date = PlainDate::from_partial(partial.date, overflow)?;
         let time = PlainTime::from_partial(partial.time, overflow)?;
         Self::from_date_and_time(date, time)
     }

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     components::{calendar::Calendar, Instant},
-    iso::{IsoDate, IsoDateSlots, IsoDateTime, IsoTime},
+    iso::{IsoDate, IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions,
         RoundingOptions, TemporalUnit,
@@ -17,12 +17,12 @@ use tinystr::TinyAsciiStr;
 use super::{
     calendar::{CalendarDateLike, GetTemporalCalendar},
     duration::normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
-    tz::NeverProvider,
+    timezone::NeverProvider,
     Duration, PartialDate, PartialTime, PlainDate, PlainTime,
 };
 
 /// A partial PlainDateTime record
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct PartialDateTime {
     /// The `PartialDate` portion of a `PartialDateTime`
     pub date: PartialDate,
@@ -61,17 +61,9 @@ impl PlainDateTime {
     }
 
     // TODO: Potentially deprecate and remove.
-    /// Utility function for validating `IsoDate`s
-    #[inline]
-    #[must_use]
-    fn validate_iso(iso: IsoDate) -> bool {
-        IsoDateTime::new_unchecked(iso, IsoTime::noon()).is_within_limits()
-    }
-
-    // TODO: Potentially deprecate and remove.
     /// Create a new `DateTime` from an `Instant`.
-    #[inline]
     #[allow(unused)]
+    #[inline]
     pub(crate) fn from_instant(
         instant: &Instant,
         offset: i64,
@@ -428,12 +420,6 @@ impl PlainDateTime {
         )
     }
 
-    /// Validates whether ISO date slots are within iso limits at noon.
-    #[inline]
-    pub fn validate<T: IsoDateSlots>(target: &T) -> bool {
-        Self::validate_iso(target.iso_date())
-    }
-
     /// Returns this `Date`'s ISO year value.
     #[inline]
     #[must_use]
@@ -641,12 +627,6 @@ impl PlainDateTime {
 impl GetTemporalCalendar for PlainDateTime {
     fn get_calendar(&self) -> Calendar {
         self.calendar.clone()
-    }
-}
-
-impl IsoDateSlots for PlainDateTime {
-    fn iso_date(&self) -> IsoDate {
-        self.iso.date
     }
 }
 

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -1,7 +1,7 @@
 //! This module implements `Duration` along with it's methods and components.
 
 use crate::{
-    components::{tz::TzProvider, PlainDateTime, PlainTime},
+    components::{timezone::TzProvider, PlainDateTime, PlainTime},
     iso::{IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, RelativeTo, ResolvedRoundingOptions, RoundingOptions, TemporalUnit,
@@ -20,7 +20,7 @@ use num_traits::AsPrimitive;
 use self::normalized::NormalizedTimeDuration;
 
 #[cfg(feature = "experimental")]
-use crate::components::tz::TZ_PROVIDER;
+use crate::components::timezone::TZ_PROVIDER;
 #[cfg(feature = "experimental")]
 use core::ops::Deref;
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -8,7 +8,7 @@
 
 pub mod calendar;
 pub mod duration;
-pub mod tz;
+pub mod timezone;
 
 mod date;
 mod datetime;

--- a/src/components/month_day.rs
+++ b/src/components/month_day.rs
@@ -5,10 +5,8 @@ use core::str::FromStr;
 use tinystr::TinyAsciiStr;
 
 use crate::{
-    components::calendar::Calendar,
-    iso::{IsoDate, IsoDateSlots},
-    options::ArithmeticOverflow,
-    TemporalError, TemporalResult, TemporalUnwrap,
+    components::calendar::Calendar, iso::IsoDate, options::ArithmeticOverflow, TemporalError,
+    TemporalResult, TemporalUnwrap,
 };
 
 use super::calendar::{CalendarDateLike, GetTemporalCalendar};
@@ -17,7 +15,7 @@ use super::calendar::{CalendarDateLike, GetTemporalCalendar};
 #[non_exhaustive]
 #[derive(Debug, Default, Clone)]
 pub struct PlainMonthDay {
-    iso: IsoDate,
+    pub iso: IsoDate,
     calendar: Calendar,
 }
 
@@ -89,14 +87,6 @@ impl PlainMonthDay {
 impl GetTemporalCalendar for PlainMonthDay {
     fn get_calendar(&self) -> Calendar {
         self.calendar.clone()
-    }
-}
-
-impl IsoDateSlots for PlainMonthDay {
-    #[inline]
-    /// Returns this structs `IsoDate`.
-    fn iso_date(&self) -> IsoDate {
-        self.iso
     }
 }
 

--- a/src/components/now.rs
+++ b/src/components/now.rs
@@ -9,7 +9,7 @@ use crate::{iso::IsoDateTime, TemporalUnwrap};
 
 use super::{
     calendar::Calendar,
-    tz::{TimeZone, TzProvider},
+    timezone::{TimeZone, TzProvider},
     EpochNanoseconds, Instant, PlainDateTime,
 };
 

--- a/src/components/timezone.rs
+++ b/src/components/timezone.rs
@@ -26,6 +26,8 @@ use std::{
 pub static TZ_PROVIDER: LazyLock<Mutex<FsTzdbProvider>> =
     LazyLock::new(|| Mutex::new(FsTzdbProvider::default()));
 
+// NOTE: It may be a good idea to eventually move this into it's
+// own individual crate rather than having it tied directly into `temporal_rs`
 pub trait TzProvider {
     fn check_identifier(&self, identifier: &str) -> bool;
 

--- a/src/components/year_month.rs
+++ b/src/components/year_month.rs
@@ -6,10 +6,7 @@ use core::str::FromStr;
 use tinystr::TinyAsciiStr;
 
 use crate::{
-    components::calendar::Calendar,
-    iso::{IsoDate, IsoDateSlots},
-    options::ArithmeticOverflow,
-    utils::pad_iso_year,
+    components::calendar::Calendar, iso::IsoDate, options::ArithmeticOverflow, utils::pad_iso_year,
     TemporalError, TemporalResult, TemporalUnwrap,
 };
 
@@ -22,7 +19,7 @@ use super::{
 #[non_exhaustive]
 #[derive(Debug, Default, Clone)]
 pub struct PlainYearMonth {
-    iso: IsoDate,
+    pub(crate) iso: IsoDate,
     calendar: Calendar,
 }
 
@@ -167,14 +164,6 @@ impl GetTemporalCalendar for PlainYearMonth {
     /// Returns a reference to `YearMonth`'s `CalendarSlot`
     fn get_calendar(&self) -> Calendar {
         self.calendar.clone()
-    }
-}
-
-impl IsoDateSlots for PlainYearMonth {
-    #[inline]
-    /// Returns this `YearMonth`'s `IsoDate`
-    fn iso_date(&self) -> IsoDate {
-        self.iso
     }
 }
 

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -286,12 +286,15 @@ impl ZonedDateTime {
         offset_option: Option<OffsetDisambiguation>,
         provider: &impl TzProvider,
     ) -> TemporalResult<Self> {
-        let calendar = partial.date.calendar.clone();
         let overflow = overflow.unwrap_or(ArithmeticOverflow::Constrain);
         let disambiguation = disambiguation.unwrap_or(Disambiguation::Compatible);
         let offset_option = offset_option.unwrap_or(OffsetDisambiguation::Reject);
 
-        let date = calendar.date_from_partial(&partial.date, overflow)?.iso;
+        let date = partial
+            .date
+            .calendar
+            .date_from_partial(&partial.date, overflow)?
+            .iso;
         let time = if !partial.time.is_empty() {
             Some(IsoTime::default().with(partial.time, overflow)?)
         } else {
@@ -327,7 +330,7 @@ impl ZonedDateTime {
 
         Ok(Self::new_unchecked(
             Instant::from(epoch_nanos),
-            calendar,
+            partial.date.calendar.clone(),
             partial.timezone,
         ))
     }

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -1259,8 +1259,7 @@ mod tests {
             timezone: TimeZone::default(),
         };
 
-        let result =
-            ZonedDateTime::from_partial_with_provider(partial, None, None, None, None, provider);
+        let result = ZonedDateTime::from_partial_with_provider(partial, None, None, None, provider);
         assert!(result.is_ok());
     }
 

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -9,7 +9,7 @@ use crate::{
     components::{
         calendar::CalendarDateLike,
         duration::normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
-        tz::{parse_offset, TzProvider},
+        timezone::{parse_offset, TzProvider},
         EpochNanoseconds,
     },
     iso::{IsoDate, IsoDateTime, IsoTime},
@@ -25,7 +25,7 @@ use crate::{
 };
 
 #[cfg(feature = "experimental")]
-use crate::components::tz::TZ_PROVIDER;
+use crate::components::timezone::TZ_PROVIDER;
 #[cfg(feature = "experimental")]
 use std::ops::Deref;
 
@@ -92,11 +92,9 @@ impl ZonedDateTime {
         // 2. Let isoDateTime be GetISODateTimeFor(timeZone, epochNanoseconds).
         let iso_datetime = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         // 3. Let addedDate be ? CalendarDateAdd(calendar, isoDateTime.[[ISODate]], duration.[[Date]], overflow).
-        let added_date = self.calendar().date_add(
-            &PlainDate::new_unchecked(iso_datetime.date, self.calendar().clone()),
-            duration,
-            overflow,
-        )?;
+        let added_date = self
+            .calendar()
+            .date_add(&iso_datetime.date, duration, overflow)?;
         // 4. Let intermediateDateTime be CombineISODateAndTimeRecord(addedDate, isoDateTime.[[Time]]).
         let intermediate = IsoDateTime::new_unchecked(added_date.iso, iso_datetime.time);
         // 5. If ISODateTimeWithinLimits(intermediateDateTime) is false, throw a RangeError exception.
@@ -249,11 +247,9 @@ impl ZonedDateTime {
         let date_largest = largest_unit.max(TemporalUnit::Day);
         // 13. Let dateDifference be CalendarDateUntil(calendar, startDateTime.[[ISODate]], intermediateDateTime.[[ISODate]], dateLargestUnit).
         // 14. Return CombineDateAndTimeDuration(dateDifference, timeDuration).
-        let date_diff = self.calendar().date_until(
-            &PlainDate::new_unchecked(start.date, self.calendar().clone()),
-            &PlainDate::new_unchecked(intermediate_dt.date, self.calendar().clone()),
-            date_largest,
-        )?;
+        let date_diff =
+            self.calendar()
+                .date_until(&start.date, &intermediate_dt.date, date_largest)?;
         NormalizedDurationRecord::new(*date_diff.date(), time_duration)
     }
 }

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -281,13 +281,12 @@ impl ZonedDateTime {
     #[inline]
     pub fn from_partial_with_provider(
         partial: PartialZonedDateTime,
-        calendar: Option<Calendar>,
         overflow: Option<ArithmeticOverflow>,
         disambiguation: Option<Disambiguation>,
         offset_option: Option<OffsetDisambiguation>,
         provider: &impl TzProvider,
     ) -> TemporalResult<Self> {
-        let calendar = calendar.unwrap_or_default();
+        let calendar = partial.date.calendar.clone();
         let overflow = overflow.unwrap_or(ArithmeticOverflow::Constrain);
         let disambiguation = disambiguation.unwrap_or(Disambiguation::Compatible);
         let offset_option = offset_option.unwrap_or(OffsetDisambiguation::Reject);

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -1,14 +1,24 @@
-//! This module implements the internal ISO field slots.
+//! This module implements the internal ISO field records.
 //!
-//! The three main types of slots are:
+//! While these are public structs, the records are primarily
+//! meant for internal Temporal calculations or calling `Calendar`
+//! methods. Prefer using `PlainDateTime`, `PlainDate`, or `PlainTime`
+//!
+//! The three main types of records are:
 //!   - `IsoDateTime`
 //!   - `IsoDate`
 //!   - `IsoTime`
 //!
+//! ## `IsoDate`
+//!
 //! An `IsoDate` represents the `[[ISOYear]]`, `[[ISOMonth]]`, and `[[ISODay]]` internal slots.
+//!
+//! ## `IsoTime`
 //!
 //! An `IsoTime` represents the `[[ISOHour]]`, `[[ISOMinute]]`, `[[ISOsecond]]`, `[[ISOmillisecond]]`,
 //! `[[ISOmicrosecond]]`, and `[[ISOnanosecond]]` internal slots.
+//!
+//! ## `IsoDateTime`
 //!
 //! An `IsoDateTime` has the internal slots of both an `IsoDate` and `IsoTime`.
 
@@ -39,7 +49,9 @@ use num_traits::{cast::FromPrimitive, AsPrimitive, Euclid, ToPrimitive};
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct IsoDateTime {
+    /// The `IsoDate` fields.
     pub date: IsoDate,
+    /// The `IsoTime` fields.
     pub time: IsoTime,
 }
 
@@ -112,7 +124,7 @@ impl IsoDateTime {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn balance(
+    pub(crate) fn balance(
         year: i32,
         month: i32,
         day: i32,
@@ -268,12 +280,6 @@ impl IsoDateTime {
 
 // ==== `IsoDate` section ====
 
-/// A trait for accessing the `IsoDate` across the various Temporal objects
-pub trait IsoDateSlots {
-    /// Returns the target's internal `IsoDate`.
-    fn iso_date(&self) -> IsoDate;
-}
-
 /// `IsoDate` serves as a record for the `[[ISOYear]]`, `[[ISOMonth]]`,
 /// and `[[ISODay]]` internal fields.
 ///
@@ -282,8 +288,11 @@ pub trait IsoDateSlots {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct IsoDate {
+    /// An ISO year within a range -271821..=275760
     pub year: i32,
+    /// An ISO month within a valid range 1..=12
     pub month: u8,
+    /// An ISO day within a valid range of 1..=31
     pub day: u8,
 }
 
@@ -509,12 +518,18 @@ impl IsoDate {
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct IsoTime {
-    pub hour: u8,         // 0..=23
-    pub minute: u8,       // 0..=59
-    pub second: u8,       // 0..=59
+    /// A valid hour value between 0..=23
+    pub hour: u8, // 0..=23
+    /// A valid minute value between 0..=59
+    pub minute: u8, // 0..=59
+    /// A valid second value between 0..=59
+    pub second: u8, // 0..=59
+    /// A valid millisecond value between 0..=999
     pub millisecond: u16, // 0..=999
+    /// A valid microsecond value between 0..=999
     pub microsecond: u16, // 0..=999
-    pub nanosecond: u16,  // 0..=999
+    /// A valid nanosecond value between 0..=999
+    pub nanosecond: u16, // 0..=999
 }
 
 impl IsoTime {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //!
 //! This library's primary source is the Temporal Proposal
 //! [specification][spec].
+//!
 //! [proposal]: https://github.com/tc39/proposal-temporal
 //! [spec]: https://tc39.es/proposal-temporal/
 #![doc(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! The `Temporal` crate is an implementation of ECMAScript's Temporal
+//! The `temporal_rs` crate is an implementation of ECMAScript's Temporal
 //! built-in objects.
 //!
 //! The crate is being designed with both engine and general use in
@@ -10,7 +10,6 @@
 //!
 //! This library's primary source is the Temporal Proposal
 //! [specification][spec].
-//!
 //! [proposal]: https://github.com/tc39/proposal-temporal
 //! [spec]: https://tc39.es/proposal-temporal/
 #![doc(
@@ -47,12 +46,12 @@ extern crate core;
 extern crate std;
 
 pub mod error;
+pub mod iso;
 pub mod options;
 pub mod parsers;
 pub mod primitive;
 
 pub(crate) mod components;
-pub(crate) mod iso;
 
 #[cfg(feature = "now")]
 mod sys;
@@ -94,8 +93,8 @@ pub mod time {
 }
 
 pub use crate::components::{
-    calendar::Calendar, tz::TimeZone, Duration, Instant, PlainDate, PlainDateTime, PlainMonthDay,
-    PlainTime, PlainYearMonth, ZonedDateTime,
+    calendar::Calendar, timezone::TimeZone, Duration, Instant, PlainDate, PlainDateTime,
+    PlainMonthDay, PlainTime, PlainYearMonth, ZonedDateTime,
 };
 
 #[cfg(feature = "std")]

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -48,7 +48,7 @@ use tzif::{
 };
 
 use crate::{
-    components::{tz::TzProvider, EpochNanoseconds},
+    components::{timezone::TzProvider, EpochNanoseconds},
     iso::IsoDateTime,
     utils, TemporalError, TemporalResult,
 };


### PR DESCRIPTION
This PR is primarily to do some cleanup that's been needed. 

An overview of the changes made are below.

  - Adds a `calendar` field to `PartialDate`
  - Removes the `IsoDateSlots` trait that was no longer needed
  - Makes the ISO records public
  - Adds `IsoDate` to the calendar API over `PlainDate`
  - Some docs cleanup