### PR TITLE
Adjust `RelativeTo` according to specification and implementation

### DIFF
--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -628,7 +628,7 @@ impl Duration {
     pub fn round(
         &self,
         options: RoundingOptions,
-        relative_to: Option<RelativeTo<'_>>,
+        relative_to: Option<RelativeTo>,
     ) -> TemporalResult<Self> {
         let provider = TZ_PROVIDER
             .lock()

--- a/src/components/duration/tests.rs
+++ b/src/components/duration/tests.rs
@@ -38,7 +38,7 @@ fn basic_positive_floor_rounding_v2() {
     .unwrap();
     let forward_date = PlainDate::new(2020, 4, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
-    let relative_forward = RelativeTo::PlainDate(&forward_date);
+    let relative_forward = RelativeTo::PlainDate(forward_date);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -107,7 +107,7 @@ fn basic_negative_floor_rounding_v2() {
     let backward_date =
         PlainDate::new(2020, 12, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
-    let relative_backward = RelativeTo::PlainDate(&backward_date);
+    let relative_backward = RelativeTo::PlainDate(backward_date);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -175,7 +175,7 @@ fn basic_positive_ceil_rounding() {
     .unwrap();
     let forward_date = PlainDate::new(2020, 4, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
-    let relative_forward = RelativeTo::PlainDate(&forward_date);
+    let relative_forward = RelativeTo::PlainDate(forward_date);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -242,7 +242,7 @@ fn basic_negative_ceil_rounding() {
     .unwrap();
     let backward_date =
         PlainDate::new(2020, 12, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
-    let relative_backward = RelativeTo::PlainDate(&backward_date);
+    let relative_backward = RelativeTo::PlainDate(backward_date);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -309,7 +309,7 @@ fn basic_positive_expand_rounding() {
     )
     .unwrap();
     let forward_date = PlainDate::new(2020, 4, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
-    let relative_forward = RelativeTo::PlainDate(&forward_date);
+    let relative_forward = RelativeTo::PlainDate(forward_date);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -378,7 +378,7 @@ fn basic_negative_expand_rounding() {
     let backward_date =
         PlainDate::new(2020, 12, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
-    let relative_backward = RelativeTo::PlainDate(&backward_date);
+    let relative_backward = RelativeTo::PlainDate(backward_date);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -441,7 +441,7 @@ fn rounding_increment_non_integer() {
         .unwrap(),
     );
     let binding = PlainDate::new(2000, 1, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
-    let relative_to = RelativeTo::PlainDate(&binding);
+    let relative_to = RelativeTo::PlainDate(binding);
 
     let mut options = RoundingOptions {
         largest_unit: None,
@@ -635,7 +635,7 @@ fn round_relative_to_zoned_datetime() {
         increment: None,
     };
     let result = duration
-        .round(options, Some(RelativeTo::ZonedDateTime(&zdt)))
+        .round(options, Some(RelativeTo::ZonedDateTime(zdt)))
         .unwrap();
     // Result duration should be: (0, 0, 0, 1, 1, 0, 0, 0, 0, 0)
     assert_eq!(result.days(), 1.0);

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -16,7 +16,7 @@ mod instant;
 mod month_day;
 mod time;
 mod year_month;
-mod zoneddatetime;
+pub(crate) mod zoneddatetime;
 
 #[cfg(feature = "now")]
 mod now;

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -40,7 +40,7 @@ pub struct PartialZonedDateTime {
     /// An optional offset string
     pub offset: Option<String>,
     /// The time zone value of a partial time zone.
-    pub timezone: TimeZone,
+    pub timezone: Option<TimeZone>,
 }
 
 /// The native Rust implementation of `Temporal.ZonedDateTime`.
@@ -316,12 +316,14 @@ impl ZonedDateTime {
             _ => unreachable!(),
         };
 
+        let timezone = partial.timezone.unwrap_or_default();
+
         let epoch_nanos = interpret_isodatetime_offset(
             date,
             time,
             false,
             offset_nanos,
-            &partial.timezone,
+            &timezone,
             disambiguation,
             offset_option,
             true,
@@ -331,7 +333,7 @@ impl ZonedDateTime {
         Ok(Self::new_unchecked(
             Instant::from(epoch_nanos),
             partial.date.calendar.clone(),
-            partial.timezone,
+            timezone,
         ))
     }
 
@@ -999,7 +1001,7 @@ impl ZonedDateTime {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn interpret_isodatetime_offset(
+pub(crate) fn interpret_isodatetime_offset(
     date: IsoDate,
     time: Option<IsoTime>,
     is_exact: bool,

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -1261,7 +1261,7 @@ mod tests {
             },
             time: PartialTime::default(),
             offset: None,
-            timezone: TimeZone::default(),
+            timezone: Some(TimeZone::default()),
         };
 
         let result = ZonedDateTime::from_partial_with_provider(partial, None, None, None, provider);

--- a/src/options.rs
+++ b/src/options.rs
@@ -3,16 +3,15 @@
 //! Temporal has various instances where user's can define options for how an
 //! operation may be completed.
 
+use crate::{Sign, TemporalError, TemporalResult, MS_PER_DAY, NS_PER_DAY};
 use core::ops::Add;
 use core::{fmt, str::FromStr};
 
-use crate::{
-    components::{PlainDate, ZonedDateTime},
-    Sign, TemporalError, TemporalResult, MS_PER_DAY, NS_PER_DAY,
-};
-
 mod increment;
+mod relative_to;
+
 pub use increment::RoundingIncrement;
+pub use relative_to::RelativeTo;
 
 // ==== RoundingOptions / DifferenceSettings ====
 
@@ -216,26 +215,6 @@ impl ResolvedRoundingOptions {
 
     pub(crate) fn is_noop(&self) -> bool {
         self.smallest_unit == TemporalUnit::Nanosecond && self.increment == RoundingIncrement::ONE
-    }
-}
-
-// ==== RelativeTo Object ====
-
-#[derive(Debug, Clone)]
-pub enum RelativeTo<'a> {
-    PlainDate(&'a PlainDate),
-    ZonedDateTime(&'a ZonedDateTime),
-}
-
-impl<'a> From<&'a PlainDate> for RelativeTo<'a> {
-    fn from(value: &'a PlainDate) -> Self {
-        Self::PlainDate(value)
-    }
-}
-
-impl<'a> From<&'a ZonedDateTime> for RelativeTo<'a> {
-    fn from(value: &'a ZonedDateTime) -> Self {
-        Self::ZonedDateTime(value)
     }
 }
 

--- a/src/options/relative_to.rs
+++ b/src/options/relative_to.rs
@@ -1,0 +1,135 @@
+//! RelativeTo rounding option
+
+use alloc::string::String;
+
+use crate::components::{timezone::TzProvider, zoneddatetime::interpret_isodatetime_offset};
+use crate::iso::{IsoDate, IsoTime};
+use crate::options::{ArithmeticOverflow, Disambiguation, OffsetDisambiguation};
+use crate::parsers::parse_date_time;
+use crate::{
+    Calendar, PlainDate, TemporalError, TemporalResult, TemporalUnwrap, TimeZone, ZonedDateTime,
+};
+
+use ixdtf::parsers::records::{TimeZoneRecord, UtcOffsetRecordOrZ};
+
+// ==== RelativeTo Object ====
+
+#[derive(Debug, Clone)]
+pub enum RelativeTo {
+    PlainDate(PlainDate),
+    ZonedDateTime(ZonedDateTime),
+}
+
+impl From<PlainDate> for RelativeTo {
+    fn from(value: PlainDate) -> Self {
+        Self::PlainDate(value)
+    }
+}
+
+impl From<ZonedDateTime> for RelativeTo {
+    fn from(value: ZonedDateTime) -> Self {
+        Self::ZonedDateTime(value)
+    }
+}
+
+impl RelativeTo {
+    /// Attempts to parse a `ZonedDateTime` string falling back to a `PlainDate`
+    /// if possible.
+    ///
+    /// If the fallback fails or either the `ZonedDateTime` or `PlainDate`
+    /// is invalid, then an error is returned.
+    pub fn try_from_str_with_provider(
+        source: &str,
+        provider: &impl TzProvider,
+    ) -> TemporalResult<Self> {
+        let result = parse_date_time(source)?;
+
+        let Some(annotation) = result.tz else {
+            let date_record = result.date.temporal_unwrap()?;
+
+            let calendar = result
+                .calendar
+                .map(Calendar::from_utf8)
+                .transpose()?
+                .unwrap_or_default();
+
+            return Ok(PlainDate::try_new(
+                date_record.year,
+                date_record.month,
+                date_record.day,
+                calendar,
+            )?
+            .into());
+        };
+
+        let timezone = match annotation.tz {
+            TimeZoneRecord::Name(s) => {
+                TimeZone::IanaIdentifier(String::from_utf8_lossy(s).into_owned())
+            }
+            TimeZoneRecord::Offset(offset_record) => {
+                // NOTE: ixdtf parser restricts minute/second to 0..=60
+                let minutes = i16::from((offset_record.hour * 60) + offset_record.minute);
+                TimeZone::OffsetMinutes(minutes * i16::from(offset_record.sign as i8))
+            }
+            // TimeZoneRecord is non_exhaustive, but all current branches are matching.
+            _ => return Err(TemporalError::assert()),
+        };
+
+        let (offset_nanos, is_exact) = result
+            .offset
+            .map(|record| {
+                let UtcOffsetRecordOrZ::Offset(offset) = record else {
+                    return (None, true);
+                };
+                let hours_in_ns = i64::from(offset.hour) * 3_600_000_000_000_i64;
+                let minutes_in_ns = i64::from(offset.minute) * 60_000_000_000_i64;
+                let seconds_in_ns = i64::from(offset.minute) * 1_000_000_000_i64;
+                (
+                    Some(
+                        (hours_in_ns
+                            + minutes_in_ns
+                            + seconds_in_ns
+                            + i64::from(offset.nanosecond))
+                            * i64::from(offset.sign as i8),
+                    ),
+                    false,
+                )
+            })
+            .unwrap_or((None, false));
+
+        let calendar = result
+            .calendar
+            .map(Calendar::from_utf8)
+            .transpose()?
+            .unwrap_or_default();
+
+        let time = result
+            .time
+            .map(|time| {
+                IsoTime::from_components(time.hour, time.minute, time.second, time.nanosecond)
+            })
+            .transpose()?;
+
+        let date = result.date.temporal_unwrap()?;
+        let iso = IsoDate::new_with_overflow(
+            date.year,
+            date.month,
+            date.day,
+            ArithmeticOverflow::Constrain,
+        )?;
+
+        let epoch_ns = interpret_isodatetime_offset(
+            iso,
+            time,
+            is_exact,
+            offset_nanos,
+            &timezone,
+            Disambiguation::Compatible,
+            OffsetDisambiguation::Reject,
+            true,
+            provider,
+        )?;
+
+        Ok(ZonedDateTime::try_new(epoch_ns.0, calendar, timezone)?.into())
+    }
+}


### PR DESCRIPTION
These are adjustments to the `RelativeTo` option based off integrating the most recent commits into Boa.

The primary issue is that `RelativeTo` is a specific `to_relative_to` abstract operation (specifically, [GetTemporalRelativeToOption](https://tc39.es/proposal-temporal/#sec-temporal-gettemporalrelativetooption)) that parses a string or property bag obj as a `ZonedDateTime` but has special cases to fall back to a `PlainDate` where that is possible.

This also removes keeping `RelativeTo` as a reference, because it's not really possible to have a reference where the `PlainDateTime`.