### PR TITLE
Add validation logic to `from_diff_settings`

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -94,7 +94,7 @@ impl ResolvedRoundingOptions {
         // 11. If LargerOfTwoTemporalUnits(largestUnit, smallestUnit) is not largestUnit, throw a RangeError exception.
         // 12. Let maximum be MaximumTemporalDurationRoundingIncrement(smallestUnit).
         // 13. If maximum is not unset, perform ? ValidateTemporalRoundingIncrement(roundingIncrement, maximum, false).
-        if largest_unit.max(smallest_unit) != largest_unit {
+        if largest_unit < smallest_unit {
             return Err(TemporalError::range().with_message(
                 "largestUnit when rounding Duration was not the largest provided unit",
             ));
@@ -156,7 +156,7 @@ impl ResolvedRoundingOptions {
             Some(unit) => unit,
         };
 
-        if largest_unit.max(smallest_unit) != largest_unit {
+        if largest_unit < smallest_unit {
             return Err(TemporalError::range().with_message(
                 "largestUnit when rounding Duration was not the largest provided unit",
             ));

--- a/src/options.rs
+++ b/src/options.rs
@@ -92,6 +92,20 @@ impl ResolvedRoundingOptions {
             .largest_unit
             .unwrap_or(smallest_unit.max(fallback_largest));
 
+        // 11. If LargerOfTwoTemporalUnits(largestUnit, smallestUnit) is not largestUnit, throw a RangeError exception.
+        // 12. Let maximum be MaximumTemporalDurationRoundingIncrement(smallestUnit).
+        // 13. If maximum is not unset, perform ? ValidateTemporalRoundingIncrement(roundingIncrement, maximum, false).
+        if largest_unit.max(smallest_unit) != largest_unit {
+            return Err(TemporalError::range().with_message(
+                "largestUnit when rounding Duration was not the largest provided unit",
+            ));
+        }
+
+        let maximum = smallest_unit.to_maximum_rounding_increment();
+        if let Some(max) = maximum {
+            increment.validate(max.into(), false)?;
+        }
+
         let resolved = ResolvedRoundingOptions {
             largest_unit,
             smallest_unit,


### PR DESCRIPTION
This PR adds missing steps from `GetDifferenceSettings` to the options resolution logic of `from_diff_settings`