### PR TITLE
Build out the rest of the Now methods

### DIFF
--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -21,8 +21,6 @@ use self::normalized::NormalizedTimeDuration;
 
 #[cfg(feature = "experimental")]
 use crate::components::timezone::TZ_PROVIDER;
-#[cfg(feature = "experimental")]
-use core::ops::Deref;
 
 mod date;
 pub(crate) mod normalized;
@@ -633,7 +631,7 @@ impl Duration {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.round_with_provider(options, relative_to, provider.deref())
+        self.round_with_provider(options, relative_to, &*provider)
     }
 }
 

--- a/src/components/now.rs
+++ b/src/components/now.rs
@@ -10,18 +10,16 @@ use crate::{iso::IsoDateTime, TemporalUnwrap};
 use super::{
     calendar::Calendar,
     timezone::{TimeZone, TzProvider},
-    EpochNanoseconds, Instant, PlainDateTime,
+    EpochNanoseconds, Instant, PlainDate, PlainDateTime, PlainTime, ZonedDateTime,
 };
+
+#[cfg(feature = "experimental")]
+use crate::{components::timezone::TZ_PROVIDER, TemporalError};
+#[cfg(feature = "experimental")]
+use std::ops::Deref;
 
 /// The Temporal Now object.
 pub struct Now;
-
-impl Now {
-    /// Returns the current time zone.
-    pub fn time_zone_id() -> TemporalResult<String> {
-        sys::get_system_tz_identifier()
-    }
-}
 
 impl Now {
     /// Returns the current instant
@@ -29,16 +27,93 @@ impl Now {
         system_instant()
     }
 
-    pub fn plain_date_time_with_provider(
-        tz: Option<TimeZone>,
-        provider: &impl TzProvider,
-    ) -> TemporalResult<PlainDateTime> {
-        let iso = system_date_time(tz, provider)?;
-        Ok(PlainDateTime::new_unchecked(iso, Calendar::default()))
+    /// Returns the current time zone.
+    pub fn time_zone_id() -> TemporalResult<String> {
+        sys::get_system_tz_identifier()
+    }
+
+    /// Returns the current system time as a `ZonedDateTime` with an ISO8601 calendar.
+    ///
+    /// The time zone will be set to either the `TimeZone` if a value is provided, or
+    /// according to the system timezone if no value is provided.
+    pub fn zoneddatetime_iso(timezone: Option<TimeZone>) -> TemporalResult<ZonedDateTime> {
+        let timezone =
+            timezone.unwrap_or(TimeZone::IanaIdentifier(sys::get_system_tz_identifier()?));
+        let instant = system_instant()?;
+        Ok(ZonedDateTime::new_unchecked(
+            instant,
+            Calendar::default(),
+            timezone,
+        ))
     }
 }
 
-fn system_date_time(
+impl Now {
+    /// Returns the current system time as a `PlainDateTime` with an ISO8601 calendar.
+    ///
+    /// The time zone used to calculate the `PlainDateTime` will be set to either the
+    /// `TimeZone` if a value is provided, or according to the system timezone if no
+    /// value is provided.
+    pub fn plain_datetime_iso_with_provider(
+        timezone: Option<TimeZone>,
+        provider: &impl TzProvider,
+    ) -> TemporalResult<PlainDateTime> {
+        let iso = system_datetime(timezone, provider)?;
+        Ok(PlainDateTime::new_unchecked(iso, Calendar::default()))
+    }
+
+    /// Returns the current system time as a `PlainDate` with an ISO8601 calendar.
+    ///
+    /// The time zone used to calculate the `PlainDate` will be set to either the
+    /// `TimeZone` if a value is provided, or according to the system timezone if no
+    /// value is provided.
+    pub fn plain_date_iso_with_provider(
+        timezone: Option<TimeZone>,
+        provider: &impl TzProvider,
+    ) -> TemporalResult<PlainDate> {
+        let iso = system_datetime(timezone, provider)?;
+        Ok(PlainDate::new_unchecked(iso.date, Calendar::default()))
+    }
+
+    /// Returns the current system time as a `PlainTime` according to an ISO8601 calendar.
+    ///
+    /// The time zone used to calculate the `PlainTime` will be set to either the
+    /// `TimeZone` if a value is provided, or according to the system timezone if no
+    /// value is provided.
+    pub fn plain_time_iso_with_provider(
+        timezone: Option<TimeZone>,
+        provider: &impl TzProvider,
+    ) -> TemporalResult<PlainTime> {
+        let iso = system_datetime(timezone, provider)?;
+        Ok(PlainTime::new_unchecked(iso.time))
+    }
+}
+
+#[cfg(feature = "experimental")]
+impl Now {
+    pub fn plain_datetime_iso(timezone: Option<TimeZone>) -> TemporalResult<PlainDateTime> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        Now::plain_datetime_iso_with_provider(timezone, provider.deref())
+    }
+
+    pub fn plain_date_iso(timezone: Option<TimeZone>) -> TemporalResult<PlainDate> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        Now::plain_date_iso_with_provider(timezone, provider.deref())
+    }
+
+    pub fn plain_time_iso(timezone: Option<TimeZone>) -> TemporalResult<PlainTime> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        Now::plain_time_iso_with_provider(timezone, provider.deref())
+    }
+}
+
+fn system_datetime(
     tz: Option<TimeZone>,
     provider: &impl TzProvider,
 ) -> TemporalResult<IsoDateTime> {
@@ -72,9 +147,9 @@ mod tests {
         let provider = &FsTzdbProvider::default();
         let sleep = 2;
 
-        let before = Now::plain_date_time_with_provider(None, provider).unwrap();
+        let before = Now::plain_datetime_iso_with_provider(None, provider).unwrap();
         thread::sleep(StdDuration::from_secs(sleep));
-        let after = Now::plain_date_time_with_provider(None, provider).unwrap();
+        let after = Now::plain_datetime_iso_with_provider(None, provider).unwrap();
 
         let diff = after.since(&before, DifferenceSettings::default()).unwrap();
 

--- a/src/components/now.rs
+++ b/src/components/now.rs
@@ -15,8 +15,6 @@ use super::{
 
 #[cfg(feature = "experimental")]
 use crate::{components::timezone::TZ_PROVIDER, TemporalError};
-#[cfg(feature = "experimental")]
-use std::ops::Deref;
 
 /// The Temporal Now object.
 pub struct Now;
@@ -95,21 +93,21 @@ impl Now {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        Now::plain_datetime_iso_with_provider(timezone, provider.deref())
+        Now::plain_datetime_iso_with_provider(timezone, &*provider)
     }
 
     pub fn plain_date_iso(timezone: Option<TimeZone>) -> TemporalResult<PlainDate> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        Now::plain_date_iso_with_provider(timezone, provider.deref())
+        Now::plain_date_iso_with_provider(timezone, &*provider)
     }
 
     pub fn plain_time_iso(timezone: Option<TimeZone>) -> TemporalResult<PlainTime> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        Now::plain_time_iso_with_provider(timezone, provider.deref())
+        Now::plain_time_iso_with_provider(timezone, &*provider)
     }
 }
 

--- a/src/components/timezone.rs
+++ b/src/components/timezone.rs
@@ -17,10 +17,7 @@ use crate::{
 #[cfg(feature = "experimental")]
 use crate::tzdb::FsTzdbProvider;
 #[cfg(feature = "experimental")]
-use std::{
-    ops::Deref,
-    sync::{LazyLock, Mutex},
-};
+use std::sync::{LazyLock, Mutex};
 
 #[cfg(feature = "experimental")]
 pub static TZ_PROVIDER: LazyLock<Mutex<FsTzdbProvider>> =
@@ -76,7 +73,7 @@ impl TimeZone {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        Self::try_from_str_with_provider(source, provider.deref())
+        Self::try_from_str_with_provider(source, &*provider)
     }
 
     /// Parses a `TimeZone` from a provided `&str`.

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -26,8 +26,6 @@ use crate::{
 
 #[cfg(feature = "experimental")]
 use crate::components::timezone::TZ_PROVIDER;
-#[cfg(feature = "experimental")]
-use std::ops::Deref;
 
 use super::PlainTime;
 
@@ -374,63 +372,63 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.year_with_provider(provider.deref())
+        self.year_with_provider(&*provider)
     }
 
     pub fn month(&self) -> TemporalResult<u8> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.month_with_provider(provider.deref())
+        self.month_with_provider(&*provider)
     }
 
     pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.month_code_with_provider(provider.deref())
+        self.month_code_with_provider(&*provider)
     }
 
     pub fn day(&self) -> TemporalResult<u8> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.day_with_provider(provider.deref())
+        self.day_with_provider(&*provider)
     }
 
     pub fn hour(&self) -> TemporalResult<u8> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.hour_with_provider(provider.deref())
+        self.hour_with_provider(&*provider)
     }
 
     pub fn minute(&self) -> TemporalResult<u8> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.minute_with_provider(provider.deref())
+        self.minute_with_provider(&*provider)
     }
 
     pub fn second(&self) -> TemporalResult<u8> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.second_with_provider(provider.deref())
+        self.second_with_provider(&*provider)
     }
 
     pub fn millisecond(&self) -> TemporalResult<u16> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.millisecond_with_provider(provider.deref())
+        self.millisecond_with_provider(&*provider)
     }
 
     pub fn microsecond(&self) -> TemporalResult<u16> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.millisecond_with_provider(provider.deref())
+        self.millisecond_with_provider(&*provider)
     }
 
     pub fn nanosecond(&self) -> TemporalResult<u16> {
@@ -438,7 +436,7 @@ impl ZonedDateTime {
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
 
-        self.millisecond_with_provider(provider.deref())
+        self.millisecond_with_provider(&*provider)
     }
 }
 
@@ -450,14 +448,14 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.era_with_provider(provider.deref())
+        self.era_with_provider(&*provider)
     }
 
     pub fn era_year(&self) -> TemporalResult<Option<i32>> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.era_year_with_provider(provider.deref())
+        self.era_year_with_provider(&*provider)
     }
 
     /// Returns the calendar day of week value.
@@ -465,7 +463,7 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.day_of_week_with_provider(provider.deref())
+        self.day_of_week_with_provider(&*provider)
     }
 
     /// Returns the calendar day of year value.
@@ -473,7 +471,7 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.day_of_year_with_provider(provider.deref())
+        self.day_of_year_with_provider(&*provider)
     }
 
     /// Returns the calendar week of year value.
@@ -481,7 +479,7 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.week_of_year_with_provider(provider.deref())
+        self.week_of_year_with_provider(&*provider)
     }
 
     /// Returns the calendar year of week value.
@@ -489,7 +487,7 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.year_of_week_with_provider(provider.deref())
+        self.year_of_week_with_provider(&*provider)
     }
 
     /// Returns the calendar days in week value.
@@ -497,7 +495,7 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.days_in_week_with_provider(provider.deref())
+        self.days_in_week_with_provider(&*provider)
     }
 
     /// Returns the calendar days in month value.
@@ -505,7 +503,7 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.days_in_month_with_provider(provider.deref())
+        self.days_in_month_with_provider(&*provider)
     }
 
     /// Returns the calendar days in year value.
@@ -513,7 +511,7 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.days_in_year_with_provider(provider.deref())
+        self.days_in_year_with_provider(&*provider)
     }
 
     /// Returns the calendar months in year value.
@@ -521,7 +519,7 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.months_in_year_with_provider(provider.deref())
+        self.months_in_year_with_provider(&*provider)
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
@@ -529,7 +527,7 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.in_leap_year_with_provider(provider.deref())
+        self.in_leap_year_with_provider(&*provider)
     }
 }
 
@@ -543,7 +541,7 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.with_plain_time_and_provider(time, provider.deref())
+        self.with_plain_time_and_provider(time, &*provider)
     }
 
     pub fn add(
@@ -558,7 +556,7 @@ impl ZonedDateTime {
         self.add_internal(
             duration,
             overflow.unwrap_or(ArithmeticOverflow::Constrain),
-            provider.deref(),
+            &*provider,
         )
     }
 
@@ -573,7 +571,7 @@ impl ZonedDateTime {
         self.add_internal(
             &duration.negated(),
             overflow.unwrap_or(ArithmeticOverflow::Constrain),
-            provider.deref(),
+            &*provider,
         )
     }
 
@@ -581,28 +579,28 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.start_of_day_with_provider(provider.deref())
+        self.start_of_day_with_provider(&*provider)
     }
 
     pub fn to_plain_date(&self) -> TemporalResult<PlainDate> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.to_plain_date_with_provider(provider.deref())
+        self.to_plain_date_with_provider(&*provider)
     }
 
     pub fn to_plain_time(&self) -> TemporalResult<PlainTime> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.to_plain_time_with_provider(provider.deref())
+        self.to_plain_time_with_provider(&*provider)
     }
 
     pub fn to_plain_datetime(&self) -> TemporalResult<PlainDateTime> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.to_plain_datetime_with_provider(provider.deref())
+        self.to_plain_datetime_with_provider(&*provider)
     }
 
     pub fn from_str(
@@ -613,7 +611,7 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        Self::from_str_with_provider(source, disambiguation, offset_option, provider.deref())
+        Self::from_str_with_provider(source, disambiguation, offset_option, &*provider)
     }
 }
 
@@ -625,7 +623,7 @@ impl ZonedDateTime {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.hours_in_day_with_provider(provider.deref())
+        self.hours_in_day_with_provider(&*provider)
     }
 
     pub fn hours_in_day_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u8> {


### PR DESCRIPTION
This PR implements the remaining methods for `Now`'s API.