### PR TITLE
Fix RoundingMode::truncation to UnsignedRoundingMode mapping

### DIFF
--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -670,17 +670,21 @@ mod tests {
         let earlier = PlainTime::new(3, 12, 34, 123, 456, 789).unwrap();
         let later = PlainTime::new(13, 47, 57, 988, 655, 322).unwrap();
 
-        let mut settings = DifferenceSettings::default();
-        settings.smallest_unit = Some(TemporalUnit::Second);
-        settings.increment = Some(RoundingIncrement::try_new(1).unwrap());
+        let settings = DifferenceSettings {
+            smallest_unit: Some(TemporalUnit::Second),
+            increment: Some(RoundingIncrement::try_new(1).unwrap()),
+            ..Default::default()
+        };
         assert_duration(
             later.since(&earlier, settings).unwrap(),
             (0, 0, 0, 0, 10, 35, 23, 0, 0, 0),
         );
 
-        let mut settings = DifferenceSettings::default();
-        settings.smallest_unit = Some(TemporalUnit::Second);
-        settings.increment = Some(RoundingIncrement::try_new(4).unwrap());
+        let settings = DifferenceSettings {
+            smallest_unit: Some(TemporalUnit::Second),
+            increment: Some(RoundingIncrement::try_new(4).unwrap()),
+            ..Default::default()
+        };
         assert_duration(
             later.since(&earlier, settings).unwrap(),
             (0, 0, 0, 0, 10, 35, 20, 0, 0, 0),

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -484,9 +484,22 @@ mod tests {
         );
     }
 
-    fn assert_duration(result: Duration, values: (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)) {
-        let fields = result.fields().iter().map(|v| v.as_date_value().unwrap()).collect::<alloc::vec::Vec<i32>>();
-        assert_eq!(fields, &[values.0, values.1, values.2, values.3, values.4, values.5, values.6, values.7, values.8, values.9])
+    fn assert_duration(
+        result: Duration,
+        values: (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32),
+    ) {
+        let fields = result
+            .fields()
+            .iter()
+            .map(|v| v.as_date_value().unwrap())
+            .collect::<alloc::vec::Vec<i32>>();
+        assert_eq!(
+            fields,
+            &[
+                values.0, values.1, values.2, values.3, values.4, values.5, values.6, values.7,
+                values.8, values.9
+            ]
+        )
     }
 
     #[test]
@@ -660,12 +673,18 @@ mod tests {
         let mut settings = DifferenceSettings::default();
         settings.smallest_unit = Some(TemporalUnit::Second);
         settings.increment = Some(RoundingIncrement::try_new(1).unwrap());
-        assert_duration(later.since(&earlier, settings).unwrap(), (0, 0, 0, 0, 10, 35, 23, 0, 0, 0));
+        assert_duration(
+            later.since(&earlier, settings).unwrap(),
+            (0, 0, 0, 0, 10, 35, 23, 0, 0, 0),
+        );
 
         let mut settings = DifferenceSettings::default();
         settings.smallest_unit = Some(TemporalUnit::Second);
         settings.increment = Some(RoundingIncrement::try_new(4).unwrap());
-        assert_duration(later.since(&earlier, settings).unwrap(), (0, 0, 0, 0, 10, 35, 20, 0, 0, 0));
+        assert_duration(
+            later.since(&earlier, settings).unwrap(),
+            (0, 0, 0, 0, 10, 35, 20, 0, 0, 0),
+        );
     }
 
     #[test]

--- a/src/options.rs
+++ b/src/options.rs
@@ -660,9 +660,9 @@ impl TemporalRoundingMode {
 
         match self {
             Ceil if is_positive => TemporalUnsignedRoundingMode::Infinity,
-            Ceil => TemporalUnsignedRoundingMode::Zero,
+            Ceil | Trunc => TemporalUnsignedRoundingMode::Zero,
             Floor if is_positive => TemporalUnsignedRoundingMode::Zero,
-            Floor | Trunc | Expand => TemporalUnsignedRoundingMode::Infinity,
+            Floor | Expand => TemporalUnsignedRoundingMode::Infinity,
             HalfCeil if is_positive => TemporalUnsignedRoundingMode::HalfInfinity,
             HalfCeil | HalfTrunc => TemporalUnsignedRoundingMode::HalfZero,
             HalfFloor if is_positive => TemporalUnsignedRoundingMode::HalfZero,


### PR DESCRIPTION
Currently, the mapping of Rounding Mode to Unsigned Rounding Mode is off for truncation. This fixes the issue and adds a test for it based off the failing test262 test.