### PR TITLE
Implement support for `to_string` and implement `PlainDate::to_string`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,7 @@ dependencies = [
  "tinystr",
  "tzif",
  "web-time",
+ "writeable",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ combine = { workspace = true, optional = true }
 
 # System time feature
 web-time = { workspace = true, optional =  true }
+writeable = "0.6.0"
 
 [features]
 default = ["now"]

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -1,8 +1,5 @@
 //! This module implements `Date` and any directly related algorithms.
 
-
-use alloc::{format, string::String};
-use core::str::FromStr;
 use crate::{
     components::{
         calendar::{Calendar, CalendarDateLike, GetTemporalCalendar},
@@ -11,13 +8,15 @@ use crate::{
     },
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::{
-        ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions, DisplayCalendar, TemporalUnit
+        ArithmeticOverflow, DifferenceOperation, DifferenceSettings, DisplayCalendar,
+        ResolvedRoundingOptions, TemporalUnit,
     },
     parsers::{parse_date_time, FormattableCalendar, FormattableDate, FormattableIxdtf},
     primitive::FiniteF64,
     Sign, TemporalError, TemporalResult, TemporalUnwrap, TimeZone,
 };
-
+use alloc::{format, string::String};
+use core::str::FromStr;
 
 use super::{
     calendar::{ascii_four_to_integer, month_to_month_code},
@@ -601,8 +600,8 @@ impl PlainDate {
             timezone: None,
             calendar: Some(FormattableCalendar {
                 show: display_calendar,
-                calendar: &self.calendar.identifier()
-            })
+                calendar: self.calendar.identifier(),
+            }),
         };
         ixdtf.to_string()
     }

--- a/src/components/timezone.rs
+++ b/src/components/timezone.rs
@@ -85,7 +85,7 @@ impl TimeZone {
             return Ok(Self::OffsetMinutes(0));
         }
         let mut cursor = source.chars().peekable();
-        if cursor.peek().map_or(false, is_ascii_sign) {
+        if cursor.peek().is_some_and(is_ascii_sign) {
             return parse_offset(&mut cursor);
         } else if provider.check_identifier(source) {
             return Ok(Self::IanaIdentifier(source.to_owned()));
@@ -366,7 +366,7 @@ pub(crate) fn parse_offset(chars: &mut Peekable<Chars<'_>>) -> TemporalResult<Ti
     // First offset portion
     let hours = parse_digit_pair(chars)?;
 
-    let sep = chars.peek().map_or(false, |ch| *ch == ':');
+    let sep = chars.peek().is_some_and(|ch| *ch == ':');
     if sep {
         let _ = chars.next();
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -710,8 +710,8 @@ impl fmt::Display for TemporalRoundingMode {
 
 /// values for `CalendarName`, whether to show the calendar in toString() methods
 /// <https://tc39.es/proposal-temporal/#sec-temporal-gettemporalshowcalendarnameoption>
-#[derive(Debug, Clone, Copy)]
-pub enum CalendarName {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DisplayCalendar {
     /// `Auto` option
     Auto,
     /// `Always` option
@@ -722,19 +722,19 @@ pub enum CalendarName {
     Critical,
 }
 
-impl fmt::Display for CalendarName {
+impl fmt::Display for DisplayCalendar {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            CalendarName::Auto => "auto",
-            CalendarName::Always => "always",
-            CalendarName::Never => "never",
-            CalendarName::Critical => "critical",
+            DisplayCalendar::Auto => "auto",
+            DisplayCalendar::Always => "always",
+            DisplayCalendar::Never => "never",
+            DisplayCalendar::Critical => "critical",
         }
         .fmt(f)
     }
 }
 
-impl FromStr for CalendarName {
+impl FromStr for DisplayCalendar {
     type Err = TemporalError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -743,7 +743,69 @@ impl FromStr for CalendarName {
             "always" => Ok(Self::Always),
             "never" => Ok(Self::Never),
             "critical" => Ok(Self::Critical),
-            _ => Err(TemporalError::range().with_message("Invalid CalendarName provided.")),
+            _ => Err(TemporalError::range().with_message("Invalid calendarName provided.")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DisplayOffset {
+    Auto,
+    Never,
+}
+
+impl fmt::Display for DisplayOffset {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DisplayOffset::Auto => "auto",
+            DisplayOffset::Never => "never",
+        }
+        .fmt(f)
+    }
+}
+
+impl FromStr for DisplayOffset {
+    type Err = TemporalError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "auto" => Ok(Self::Auto),
+            "never" => Ok(Self::Never),
+            _ => Err(TemporalError::range().with_message("Invalid offset option provided.")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DisplayTimeZone {
+    /// `Auto` option
+    Auto,
+    /// `Never` option
+    Never,
+    // `Critical` option
+    Critical,
+}
+
+impl fmt::Display for DisplayTimeZone {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DisplayTimeZone::Auto => "auto",
+            DisplayTimeZone::Never => "never",
+            DisplayTimeZone::Critical => "critical",
+        }
+        .fmt(f)
+    }
+}
+
+impl FromStr for DisplayTimeZone {
+    type Err = TemporalError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "auto" => Ok(Self::Auto),
+            "never" => Ok(Self::Never),
+            "critical" => Ok(Self::Critical),
+            _ => Err(TemporalError::range().with_message("Invalid timeZoneName option provided.")),
         }
     }
 }

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -118,7 +118,6 @@ fn write_nanosecond<W: core::fmt::Write + ?Sized>(
 pub fn u32_to_digits(mut value: u32) -> ([u8; 9], usize) {
     let mut output = [0; 9];
     let mut precision = 0;
-    // let mut precision_check = 0;
     let mut i = 9;
     while i != 0 {
         let v = (value % 10) as u8;

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -109,7 +109,7 @@ fn write_nanosecond<W: core::fmt::Write + ?Sized>(
 ) -> core::fmt::Result {
     let (digits, index) = u32_to_digits(nanoseconds);
     let precision = match precision {
-        Precision::Digit(digit) if digit < 9 => digit as usize,
+        Precision::Digit(digit) if digit <= 9 => digit as usize,
         _ => index,
     };
     write_digit_slice_to_precision(digits, 0, precision, sink)
@@ -554,6 +554,16 @@ mod tests {
             include_sep: true,
         };
         assert_writeable_eq!(time, "05:00:00.12305000");
+
+        let time = FormattableTime {
+            hour: 5,
+            minute: 0,
+            second: 00,
+            nanosecond: 123050002,
+            precision: Precision::Digit(9),
+            include_sep: true,
+        };
+        assert_writeable_eq!(time, "05:00:00.123050002");
 
         let time = FormattableTime {
             hour: 5,

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,7 +1,5 @@
 //! This module implements Temporal Date/Time parsing functionality.
 
-use std::str;
-
 use crate::{
     options::{DisplayCalendar, DisplayOffset, DisplayTimeZone},
     Sign, TemporalError, TemporalResult, TemporalUnwrap,

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -96,7 +96,6 @@ impl Writeable for FormattableUtcOffset {
 }
 
 fn write_padded_u8<W: core::fmt::Write + ?Sized>(num: u8, sink: &mut W) -> core::fmt::Result {
-    // NOTE:
     if num < 10 {
         sink.write_char('0')?;
     }
@@ -126,15 +125,9 @@ pub fn write_u32_to_ascii_digits(mut value: u32) -> ([u8; 9], usize) {
     while i != 0 {
         let v = (value % 10) as u8;
         value /= 10;
-        /*
-        if precision_check == 0 && v !=0 {
-            precision = i;
-        }
-        */
         if precision == 0 && v != 0 {
             precision = i;
         }
-        // precision_check += v;
         output[i - 1] = v + 48;
         i -= 1;
     }
@@ -195,13 +188,13 @@ fn write_four_digit_year<W: core::fmt::Write + ?Sized>(
     mut y: i32,
     sink: &mut W,
 ) -> core::fmt::Result {
-    let mut divisor = 1_000;
-    while divisor >= 1 {
-        (y / divisor).write_to(sink)?;
-        y %= divisor;
-        divisor /= 10;
-    }
-    Ok(())
+    (y / 1_000).write_to(sink)?;
+    y %= 1_000;
+    (y / 100).write_to(sink)?;
+    y %= 100;
+    (y / 10).write_to(sink)?;
+    y %= 10;
+    y.write_to(sink)
 }
 
 fn write_extended_year<W: core::fmt::Write + ?Sized>(y: i32, sink: &mut W) -> core::fmt::Result {
@@ -543,6 +536,9 @@ mod tests {
 
     #[test]
     fn date_string() {
+        let date = FormattableDate(2024, 12, 8).to_string();
+        assert_eq!(&date, "2024-12-08");
+
         let date = FormattableDate(987654, 12, 8).to_string();
         assert_eq!(&date, "+987654-12-08");
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,13 +1,327 @@
 //! This module implements Temporal Date/Time parsing functionality.
 
 use alloc::format;
-
-use crate::{TemporalError, TemporalResult, TemporalUnwrap};
-
+use crate::{options::{DisplayCalendar, DisplayOffset, DisplayTimeZone}, Sign, TemporalError, TemporalResult, TemporalUnwrap};
 use ixdtf::parsers::{
     records::{Annotation, DateRecord, IxdtfParseRecord, TimeRecord, UtcOffsetRecordOrZ},
     IxdtfParser,
 };
+use writeable::{impl_display_with_writeable, Writeable};
+
+// TODO: Move `Writeable` functionality to `ixdtf` crate
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Precision {
+    Auto,
+    Minute,
+    Digit(u8),
+}
+
+pub struct FormattableTime {
+    pub hour: u8,
+    pub minute: u8,
+    pub second: u8,
+    pub nanosecond: u32,
+    pub precision: Precision,
+    pub include_sep: bool
+}
+
+impl Writeable for FormattableTime {
+    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
+        write_padded_u8(self.hour, sink)?;
+        if self.include_sep {
+            sink.write_char(':')?;
+        }
+        write_padded_u8(self.minute, sink)?;
+        if self.precision == Precision::Minute {
+            return Ok(())
+        }
+        if self.include_sep {
+            sink.write_char(':')?;
+        }
+        write_padded_u8(self.second, sink)?;
+        if self.nanosecond == 0 {
+            return Ok(());
+        }
+        sink.write_char('.')?;
+        write_nanosecond(self.nanosecond, self.precision, sink)?;
+
+        Ok(())
+    }
+}
+
+pub struct FormattableUtcOffset {
+    pub show: DisplayOffset,
+    pub offset: UtcOffset,
+}
+
+pub enum UtcOffset {
+    Z,
+    Offset(FormattableOffset)
+}
+
+impl Writeable for FormattableUtcOffset {
+    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
+        if self.show == DisplayOffset::Never {
+            return Ok(());
+        }
+        match &self.offset {
+            UtcOffset::Z => sink.write_char('Z'),
+            UtcOffset::Offset(offset) => offset.write_to(sink),
+        }
+    }
+}
+
+fn write_padded_u8<W: core::fmt::Write + ?Sized>(num: u8, sink: &mut W) -> core::fmt::Result {
+    // NOTE:
+    if num < 10 {
+        sink.write_char('0')?;
+    }
+    num.write_to(sink)
+}
+
+fn write_nanosecond<W: core::fmt::Write + ?Sized>(nanoseconds: u32, precision: Precision, sink: &mut W) -> core::fmt::Result {
+    if nanoseconds > 1_000_000_000 {
+        return Err(core::fmt::Error);
+    }
+    match precision {
+        Precision::Digit(digit) => write_nanosecond_to_precision(nanoseconds, digit, sink),
+        _ => write_auto_nanosecond(nanoseconds, sink),
+    }
+}
+
+fn write_auto_nanosecond<W: core::fmt::Write + ?Sized>(mut nanoseconds: u32, sink: &mut W) -> core::fmt::Result {
+    let mut divisor = 100_000_000;
+    while divisor >= 1 && nanoseconds != 0 {
+        (nanoseconds / divisor).write_to(sink)?;
+        nanoseconds %= divisor;
+        divisor /= 10;
+    }
+
+    Ok(())
+}
+
+fn write_nanosecond_to_precision<W: core::fmt::Write + ?Sized>(mut nanoseconds: u32, mut precision: u8, sink: &mut W) -> core::fmt::Result {
+    let mut divisor = 100_000_000;
+    while precision > 0 {
+        (nanoseconds / divisor).write_to(sink)?;
+        nanoseconds %= divisor;
+        divisor /= 10;
+        precision -= 1;
+    }
+
+    Ok(())
+}
+
+pub struct FormattableOffset {
+    pub sign: Sign,
+    pub time: FormattableTime,
+}
+
+impl Writeable for FormattableOffset {
+    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
+        match self.sign {
+            Sign::Negative => sink.write_char('-')?,
+            _ => sink.write_char('+')?,
+        }
+        self.time.write_to(sink)
+    }
+}
+
+impl_display_with_writeable!(FormattableIxdtf<'_>);
+impl_display_with_writeable!(FormattableDate);
+impl_display_with_writeable!(FormattableTime);
+impl_display_with_writeable!(FormattableUtcOffset);
+impl_display_with_writeable!(FormattableOffset);
+impl_display_with_writeable!(FormattableTimeZone<'_>);
+impl_display_with_writeable!(FormattableCalendar<'_>);
+
+pub struct FormattableDate(pub i32, pub u8, pub u8);
+
+impl Writeable for FormattableDate {
+    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
+        if (0..=9999).contains(&self.0) {
+            write_four_digit_year(self.0, sink)?;
+        } else if self.0.abs() <= 999_999 {
+            write_extended_year(self.0, sink)?;
+        } else {
+            return Err(core::fmt::Error)
+        }
+        sink.write_char('-')?;
+        write_padded_u8(self.1, sink)?;
+        sink.write_char('-')?;
+        write_padded_u8(self.2, sink)?;
+        Ok(())
+    }
+}
+
+fn write_four_digit_year<W: core::fmt::Write + ?Sized>(mut y: i32, sink: &mut W) -> core::fmt::Result {
+    let mut divisor = 1_000;
+    while divisor >= 1 {
+        (y / divisor).write_to(sink)?;
+        y %= divisor;
+        divisor /= 10;
+    }
+    Ok(())
+
+}
+
+fn write_extended_year<W: core::fmt::Write + ?Sized>(y: i32, sink: &mut W) -> core::fmt::Result {
+    let sign = if y < 0 {
+        '-'
+    } else {
+        '+'
+    };
+    sink.write_char(sign)?;
+    let mut y = y.abs() as u32;
+    let mut divisor = 100_000;
+    while divisor >= 1 {
+        (y / divisor).write_to(sink)?;
+        y %= divisor;
+        divisor /= 10;
+    }
+    Ok(())
+}
+
+pub struct FormattableTimeZone<'a> {
+    pub show: DisplayTimeZone,
+    pub timezone: &'a str
+}
+
+impl Writeable for FormattableTimeZone<'_> {
+    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
+        if self.show == DisplayTimeZone::Never {
+            return Ok(())
+        }
+        sink.write_char('[')?;
+        if self.show == DisplayTimeZone::Critical {
+            sink.write_char('!')?;
+        }
+        sink.write_str(self.timezone)?;
+        sink.write_char(']')
+    }
+}
+
+pub struct FormattableCalendar<'a> {
+    pub show: DisplayCalendar,
+    pub calendar: &'a str,
+}
+
+impl Writeable for FormattableCalendar<'_> {
+    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
+        if self.show == DisplayCalendar::Never
+            || self.show == DisplayCalendar::Auto && self.calendar == "iso8601" {
+            return Ok(())
+        }
+        sink.write_char('[')?;
+        if self.show == DisplayCalendar::Critical {
+            sink.write_char('!')?;
+        }
+        sink.write_str("u-ca=")?;
+        sink.write_str(self.calendar)?;
+        sink.write_char(']')
+    }
+}
+
+pub struct FormattableIxdtf<'a> {
+    pub date: Option<FormattableDate>,
+    pub time: Option<FormattableTime>,
+    pub utc_offset: Option<FormattableUtcOffset>,
+    pub timezone: Option<FormattableTimeZone<'a>>,
+    pub calendar: Option<FormattableCalendar<'a>>,
+}
+
+impl Writeable for FormattableIxdtf<'_> {
+    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
+        if let Some(date) = &self.date {
+            date.write_to(sink)?;
+        }
+        if let Some(time) = &self.time {
+            if self.date.is_some() {
+                sink.write_char('T')?;
+            }
+            time.write_to(sink)?;
+        }
+        if self.date.is_none() && self.time.is_none() && self.utc_offset.is_some() {
+            return Err(core::fmt::Error)
+        }
+        if let Some(offset)  = &self.utc_offset {
+            offset.write_to(sink)?;
+        }
+        if let Some(timezone) = &self.timezone {
+            timezone.write_to(sink)?;
+        }
+        if let Some(calendar) = &self.calendar {
+            calendar.write_to(sink)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::{FormattableTime, Precision};
+
+    use super::FormattableOffset;
+
+
+    #[test]
+    fn offset_string() {
+        let offset = FormattableOffset {
+            sign: crate::Sign::Positive,
+            time: FormattableTime {
+                hour: 4,
+                minute: 0,
+                second: 0,
+                nanosecond: 0,
+                precision: Precision::Minute,
+                include_sep: true,
+            }
+
+        };
+        assert_eq!(offset.to_string(), "+04:00");
+
+        let offset = FormattableOffset {
+            sign: crate::Sign::Negative,
+            time: FormattableTime {
+                hour: 5,
+                minute: 0,
+                second: 30,
+                nanosecond: 0,
+                precision: Precision::Minute,
+                include_sep: true,
+            }
+        };
+        assert_eq!(offset.to_string(), "-05:00");
+
+        let offset = FormattableOffset {
+            sign: crate::Sign::Negative,
+            time: FormattableTime {
+                hour: 5,
+                minute: 0,
+                second: 30,
+                nanosecond: 0,
+                precision: Precision::Auto,
+                include_sep: true,
+            }
+        };
+        assert_eq!(offset.to_string(), "-05:00:30");
+
+        let offset = FormattableOffset {
+            sign: crate::Sign::Negative,
+            time: FormattableTime {
+                hour: 5,
+                minute: 0,
+                second: 00,
+                nanosecond: 123050000,
+                precision: Precision::Auto,
+                include_sep: true,
+            }
+        };
+        assert_eq!(offset.to_string(), "-05:00:00.12305");
+    }
+}
 
 // TODO: Determine if these should be separate structs, i.e. TemporalDateTimeParser/TemporalInstantParser, or
 // maybe on global `TemporalParser` around `IxdtfParser` that handles the Temporal idiosyncracies.


### PR DESCRIPTION
 This PR implements the underlying code to implement `Display`, `to_string`, and `to_ixdtf_string` methods for nearly all the main built-ins aside from `Duration`, `PlainYearMonth`, and `PlainMonthDay`.

The majority of the backing implementation will most likely need to eventually be moved into the `ixdtf` crate, but until that is complete and worked, this should allow us to move forward with the implementation and testing in Boa against test262.