### PR TITLE
Fixing panics in test262 when running in debug mode

### DIFF
--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -178,7 +178,7 @@ impl Instant {
         let rounded = IncrementRounder::<i128>::from_positive_parts(self.as_i128(), increment)?
             .round_as_positive(resolved_options.rounding_mode);
 
-        Ok(rounded.into())
+        Ok(rounded as i128)
     }
 
     // Utility for converting `Instant` to `i128`.

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -1361,12 +1361,8 @@ mod tests {
     }
 
     #[test]
-    fn with_plain_time() {
-
-    }
+    fn with_plain_time() {}
 
     #[test]
-    fn to_plain_time() {
-
-    }
+    fn to_plain_time() {}
 }

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -967,7 +967,7 @@ impl ZonedDateTime {
             }
             TimeZoneRecord::Offset(offset_record) => {
                 // NOTE: ixdtf parser restricts minute/second to 0..=60
-                let minutes = i16::from((offset_record.hour * 60) + offset_record.minute);
+                let minutes = i16::from(offset_record.hour) * 60 + offset_record.minute as i16;
                 TimeZone::OffsetMinutes(minutes * i16::from(offset_record.sign as i8))
             }
             // TimeZoneRecord is non_exhaustive, but all current branches are matching.
@@ -1358,5 +1358,15 @@ mod tests {
         .unwrap();
 
         assert_eq!(midnight_disambiguated.epoch_milliseconds(), -1601751600000);
+    }
+
+    #[test]
+    fn with_plain_time() {
+
+    }
+
+    #[test]
+    fn to_plain_time() {
+
     }
 }

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -1359,10 +1359,4 @@ mod tests {
 
         assert_eq!(midnight_disambiguated.epoch_milliseconds(), -1601751600000);
     }
-
-    #[test]
-    fn with_plain_time() {}
-
-    #[test]
-    fn to_plain_time() {}
 }

--- a/src/options/relative_to.rs
+++ b/src/options/relative_to.rs
@@ -68,7 +68,7 @@ impl RelativeTo {
             }
             TimeZoneRecord::Offset(offset_record) => {
                 // NOTE: ixdtf parser restricts minute/second to 0..=60
-                let minutes = i16::from((offset_record.hour * 60) + offset_record.minute);
+                let minutes = i16::from(offset_record.hour) * 60 + offset_record.minute as i16;
                 TimeZone::OffsetMinutes(minutes * i16::from(offset_record.sign as i8))
             }
             // TimeZoneRecord is non_exhaustive, but all current branches are matching.

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -91,7 +91,8 @@ impl<T: Roundable> Round for IncrementRounder<T> {
         let rounded =
             apply_unsigned_rounding_mode(self.dividend, self.divisor, unsigned_rounding_mode);
         // TODO: Add unit tests for the below
-        rounded * <u128 as NumCast>::from(self.divisor).expect("increment is representable by a u64")
+        rounded
+            * <u128 as NumCast>::from(self.divisor).expect("increment is representable by a u64")
     }
 }
 


### PR DESCRIPTION
This PR fixes nearly all of the panics that occur when running temporal_rs through the test262 suite using Boa as noted by @jedel1043.