### PR TITLE
Add an MSRV check to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
       # Get the rust_version from the Cargo.toml
       - name: Get rust_version
         id: rust_version
-        run: echo "rust_version=$(grep '^rust-version' Cargo.toml | cut -d' ' -f3 | tr -d '"')" >> $GITHUB_OUTPUT
+        run: echo "rust_version=$(grep '^rust-version' Cargo.toml -m 1 | cut -d' ' -f3 | tr -d '"')" >> $GITHUB_OUTPUT
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,27 @@ jobs:
     - name: Check clippy (No features)
       run: cargo ws exec cargo clippy --no-default-features --all-targets
 
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Get the rust_version from the Cargo.toml
+      - name: Get rust_version
+        id: rust_version
+        run: echo "rust_version=$(grep '^rust-version' Cargo.toml | cut -d' ' -f3 | tr -d '"')" >> $GITHUB_OUTPUT
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_version.outputs.rust_version }}
+
+      - name: Check compilation
+        run: cargo check --all-features --all-targets
+
   build-test:
     name: Test (${{ matrix.rust.name }}, ${{ matrix.os }})
     strategy:
@@ -64,6 +85,7 @@ jobs:
         run: cargo build --quiet --all-features
       - name: Test --all-features
         run: cargo test --all-features
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 version = "0.0.4"
-rust-version = "1.80"
+rust-version = "1.82.0"
 authors = ["boa-dev"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/boa-dev/temporal"

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -1118,7 +1118,7 @@ pub(crate) fn interpret_isodatetime_offset(
                     // i. Let roundedCandidateNanoseconds be RoundNumberToIncrement(candidateOffset, 60 × 10**9, half-expand).
                     let rounded_candidate = IncrementRounder::from_potentially_negative_parts(
                         candidate_offset,
-                        const { NonZeroU128::new(60_000_000_000).expect("cannot be zero") },
+                        NonZeroU128::new(60_000_000_000).expect("cannot be zero"), // TODO: Add back const { } after MSRV can be bumped
                     )?
                     .round(TemporalRoundingMode::HalfExpand);
                     // ii. If roundedCandidateNanoseconds = offsetNanoseconds, then


### PR DESCRIPTION
This adds an MSRV check to CI so that changes to `temporal_rs` are hopefully always inline with Boa's MSRV.