### PR TITLE
Implement correct resolving of `getStartOfDay`

### DIFF
--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -47,6 +47,7 @@ use tzif::{
     },
 };
 
+use crate::components::timezone::TimeZoneOffset;
 use crate::{
     components::{timezone::TzProvider, EpochNanoseconds},
     iso::IsoDateTime,
@@ -69,14 +70,14 @@ impl LocalTimeRecord {
     fn from_daylight_savings_time(info: &ZoneVariantInfo) -> Self {
         Self {
             is_dst: true,
-            offset: -info.offset.0,
+            offset: info.offset.0,
         }
     }
 
     fn from_standard_time(info: &ZoneVariantInfo) -> Self {
         Self {
             is_dst: false,
-            offset: -info.offset.0,
+            offset: info.offset.0,
         }
     }
 }
@@ -205,26 +206,30 @@ impl Tzif {
             .ok_or(TemporalError::general("Only Tzif V2+ is supported."))
     }
 
-    pub fn get(&self, epoch_seconds: &Seconds) -> TemporalResult<LocalTimeRecord> {
+    pub fn get(&self, epoch_seconds: &Seconds) -> TemporalResult<TimeZoneOffset> {
         let db = self.get_data_block2()?;
         let result = db.transition_times.binary_search(epoch_seconds);
 
         match result {
-            Ok(idx) => Ok(get_local_record(db, idx - 1).into()),
-            Err(idx) if idx == 0 => Ok(get_local_record(db, idx).into()),
+            Ok(idx) => Ok(get_timezone_offset(db, idx - 1)),
+            Err(idx) if idx == 0 => Ok(get_timezone_offset(db, idx)),
             Err(idx) => {
                 if db.transition_times.len() <= idx {
                     // The transition time provided is beyond the length of
                     // the available transition time, so the time zone is
                     // resolved with the POSIX tz string.
-                    return resolve_posix_tz_string_for_epoch_seconds(
+                    let mut offset = resolve_posix_tz_string_for_epoch_seconds(
                         self.posix_tz_string().ok_or(TemporalError::general(
                             "No POSIX tz string to resolve with.",
                         ))?,
                         epoch_seconds.0,
-                    );
+                    )?;
+                    offset
+                        .transition_epoch
+                        .get_or_insert_with(|| db.transition_times[idx - 1].0);
+                    return Ok(offset);
                 }
-                Ok(get_local_record(db, idx - 1).into())
+                Ok(get_timezone_offset(db, idx - 1))
             }
         }
     }
@@ -302,6 +307,18 @@ impl Tzif {
 }
 
 #[inline]
+fn get_timezone_offset(db: &DataBlock, idx: usize) -> TimeZoneOffset {
+    let transition_epoch = db.transition_times[idx];
+    // NOTE: Transition type can be empty. If no transition_type exists,
+    // then use 0 as the default index of local_time_type_records.
+    let offset = db.local_time_type_records[db.transition_types.get(idx).copied().unwrap_or(0)];
+    TimeZoneOffset {
+        transition_epoch: Some(transition_epoch.0),
+        offset: offset.utoff.0,
+    }
+}
+
+#[inline]
 fn get_local_record(db: &DataBlock, idx: usize) -> LocalTimeTypeRecord {
     // NOTE: Transition type can be empty. If no transition_type exists,
     // then use 0 as the default index of local_time_type_records.
@@ -312,12 +329,13 @@ fn get_local_record(db: &DataBlock, idx: usize) -> LocalTimeTypeRecord {
 fn resolve_posix_tz_string_for_epoch_seconds(
     posix_tz_string: &PosixTzString,
     seconds: i64,
-) -> TemporalResult<LocalTimeRecord> {
+) -> TemporalResult<TimeZoneOffset> {
     let Some(dst_variant) = &posix_tz_string.dst_info else {
         // Regardless of the time, there is one variant and we can return it.
-        return Ok(LocalTimeRecord::from_standard_time(
-            &posix_tz_string.std_info,
-        ));
+        return Ok(TimeZoneOffset {
+            transition_epoch: None,
+            offset: LocalTimeRecord::from_standard_time(&posix_tz_string.std_info).offset,
+        });
     };
 
     let start = &dst_variant.start_date;
@@ -331,14 +349,35 @@ fn resolve_posix_tz_string_for_epoch_seconds(
     let (is_transition_day, transition) =
         cmp_seconds_to_transitions(&start.day, &end.day, seconds)?;
 
-    match compute_tz_for_epoch_seconds(is_transition_day, transition, seconds, dst_variant) {
-        TransitionType::Dst => Ok(LocalTimeRecord::from_daylight_savings_time(
-            &dst_variant.variant_info,
-        )),
-        TransitionType::Std => Ok(LocalTimeRecord::from_standard_time(
-            &posix_tz_string.std_info,
-        )),
-    }
+    let transition =
+        compute_tz_for_epoch_seconds(is_transition_day, transition, seconds, dst_variant);
+    let offset = match transition {
+        TransitionType::Dst => {
+            LocalTimeRecord::from_daylight_savings_time(&dst_variant.variant_info)
+        }
+        TransitionType::Std => LocalTimeRecord::from_standard_time(&posix_tz_string.std_info),
+    };
+    let transition = match transition {
+        TransitionType::Dst => start,
+        TransitionType::Std => end,
+    };
+    let year = utils::epoch_time_to_epoch_year(seconds);
+    let year_epoch = utils::epoch_days_for_year(year) * 86400;
+    let leap_days = utils::mathematical_days_in_year(year) - 365;
+
+    let days = match transition.day {
+        TransitionDay::NoLeap(day) if day > 59 => i32::from(day) - 1 + leap_days,
+        TransitionDay::NoLeap(day) => i32::from(day) - 1,
+        TransitionDay::WithLeap(day) => i32::from(day),
+        TransitionDay::Mwd(_month, _week, _day) => {
+            return Err(TemporalError::general("unimplemented"));
+        }
+    };
+    let transition_epoch = i64::from(year_epoch) + i64::from(days) * 3600 + transition.time.0;
+    Ok(TimeZoneOffset {
+        offset: offset.offset,
+        transition_epoch: Some(transition_epoch),
+    })
 }
 
 /// Resolve the footer of a tzif file.
@@ -472,6 +511,7 @@ fn cmp_seconds_to_transitions(
             };
             (is_transition, is_dst)
         }
+        // TODO: do we need to modify the logic for leap years?
         (TransitionDay::NoLeap(start), TransitionDay::NoLeap(end)) => {
             let day_in_year = utils::epoch_time_to_day_in_year(seconds * 1_000.0) as u16;
             let is_transition = *start == day_in_year || *end == day_in_year;
@@ -484,7 +524,11 @@ fn cmp_seconds_to_transitions(
         }
         // NOTE: The assumption here is that mismatched day types on
         // a POSIX string is an illformed string.
-        _ => return Err(TemporalError::assert()),
+        _ => {
+            return Err(
+                TemporalError::assert().with_message("Mismatched day types on a POSIX string.")
+            )
+        }
     };
 
     match cmp_result {
@@ -575,12 +619,11 @@ impl TzProvider for FsTzdbProvider {
     fn get_named_tz_offset_nanoseconds(
         &self,
         identifier: &str,
-        epoch_nanoseconds: i128,
-    ) -> TemporalResult<i128> {
+        utc_epoch: i128,
+    ) -> TemporalResult<TimeZoneOffset> {
         let tzif = self.get(identifier)?;
-        let seconds = (epoch_nanoseconds / 1_000_000_000) as i64;
-        let local_time_record_result = tzif.get(&Seconds(seconds))?;
-        Ok(local_time_record_result.offset as i128 * 1_000_000_000)
+        let seconds = (utc_epoch / 1_000_000_000) as i64;
+        tzif.get(&Seconds(seconds))
     }
 }
 

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -70,14 +70,14 @@ impl LocalTimeRecord {
     fn from_daylight_savings_time(info: &ZoneVariantInfo) -> Self {
         Self {
             is_dst: true,
-            offset: info.offset.0,
+            offset: -info.offset.0,
         }
     }
 
     fn from_standard_time(info: &ZoneVariantInfo) -> Self {
         Self {
             is_dst: false,
-            offset: info.offset.0,
+            offset: -info.offset.0,
         }
     }
 }


### PR DESCRIPTION
Still unimplemented for the specific case of a month-week-day posix string.