### PR TITLE
Add to_string functionality for timezone identifer

### DIFF
--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -934,7 +934,7 @@ impl ZonedDateTime {
         let offset = self.tz.get_offset_nanos_for(result, provider)?;
         let datetime = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let (sign, hour, minute) = nanoseconds_to_formattable_offset_minutes(offset)?;
-        let timezone_id = self.timezone().id()?;
+        let timezone_id = self.timezone().identifier()?;
 
         let ixdtf_string = IxdtfStringBuilder::default()
             .with_date(datetime.date)


### PR DESCRIPTION
Forgot to implement this alongside all the other to string functionality.