### PR TITLE
Bug fixes to address test failures + removing unused API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "bitflags"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,12 +328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
-
-[[package]]
 name = "serde"
 version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,7 +385,6 @@ dependencies = [
 name = "temporal_rs"
 version = "0.0.4"
 dependencies = [
- "bitflags",
  "combine",
  "iana-time-zone",
  "icu_calendar",
@@ -405,7 +392,6 @@ dependencies = [
  "jiff-tzdb",
  "log",
  "num-traits",
- "rustc-hash",
  "tinystr",
  "tzif",
  "web-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,11 +49,10 @@ exclude.workspace = true
 [dependencies]
 tinystr.workspace = true
 icu_calendar = { workspace = true, features = ["compiled_data"] }
-rustc-hash = { workspace = true, features = ["std"] }
-bitflags.workspace = true
 num-traits.workspace = true
 ixdtf = { workspace = true, features = ["duration"]}
 iana-time-zone.workspace = true
+writeable = "0.6.0"
 
 # log feature
 log = { workspace = true, optional = true }
@@ -65,7 +64,6 @@ combine = { workspace = true, optional = true }
 
 # System time feature
 web-time = { workspace = true, optional =  true }
-writeable = "0.6.0"
 
 [features]
 default = ["now"]

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -145,7 +145,7 @@ impl NormalizedTimeDuration {
                 // a. Let fractionalDays be days + DivideNormalizedTimeDuration(norm, nsPerDay).
                 let fractional_days = days.checked_add(&FiniteF64(self.as_fractional_days()))?;
                 // b. Set days to RoundNumberToIncrement(fractionalDays, increment, roundingMode).
-                let days = IncrementRounder::from_potentially_negative_parts(
+                let days = IncrementRounder::from_signed_num(
                     fractional_days.0,
                     options.increment.as_extended_increment(),
                 )?
@@ -204,8 +204,7 @@ impl NormalizedTimeDuration {
         increment: NonZeroU128,
         mode: TemporalRoundingMode,
     ) -> TemporalResult<Self> {
-        let rounded = IncrementRounder::<i128>::from_potentially_negative_parts(self.0, increment)?
-            .round(mode);
+        let rounded = IncrementRounder::<i128>::from_signed_num(self.0, increment)?.round(mode);
         if rounded.abs() > MAX_TIME_DURATION {
             return Err(TemporalError::range()
                 .with_message("normalizedTimeDuration exceeds maxTimeDuration."));
@@ -311,7 +310,7 @@ impl NormalizedDurationRecord {
             // 1. If unit is "year", then
             TemporalUnit::Year => {
                 // a. Let years be RoundNumberToIncrement(duration.[[Years]], increment, "trunc").
-                let years = IncrementRounder::from_potentially_negative_parts(
+                let years = IncrementRounder::from_signed_num(
                     self.date().years.0,
                     options.increment.as_extended_increment(),
                 )?
@@ -343,7 +342,7 @@ impl NormalizedDurationRecord {
             // 2. Else if unit is "month", then
             TemporalUnit::Month => {
                 // a. Let months be RoundNumberToIncrement(duration.[[Months]], increment, "trunc").
-                let months = IncrementRounder::from_potentially_negative_parts(
+                let months = IncrementRounder::from_signed_num(
                     self.date().months.0,
                     options.increment.as_extended_increment(),
                 )?
@@ -416,7 +415,7 @@ impl NormalizedDurationRecord {
                     weeks_start.internal_diff_date(&weeks_end, TemporalUnit::Week)?;
 
                 // h. Let weeks be RoundNumberToIncrement(duration.[[Weeks]] + untilResult.[[Weeks]], increment, "trunc").
-                let weeks = IncrementRounder::from_potentially_negative_parts(
+                let weeks = IncrementRounder::from_signed_num(
                     self.date().weeks.checked_add(&until_result.weeks())?.0,
                     options.increment.as_extended_increment(),
                 )?
@@ -450,7 +449,7 @@ impl NormalizedDurationRecord {
                 // 4. Else,
                 // a. Assert: unit is "day".
                 // b. Let days be RoundNumberToIncrement(duration.[[Days]], increment, "trunc").
-                let days = IncrementRounder::from_potentially_negative_parts(
+                let days = IncrementRounder::from_signed_num(
                     self.date().days.0,
                     options.increment.as_extended_increment(),
                 )?
@@ -550,11 +549,9 @@ impl NormalizedDurationRecord {
         // This division can be implemented as if constructing Normalized Time Duration Records for the denominator
         // and numerator of total and performing one division operation with a floating-point result.
         // 15. Let roundedUnit be ApplyUnsignedRoundingMode(total, r1, r2, unsignedRoundingMode).
-        let rounded_unit = IncrementRounder::from_potentially_negative_parts(
-            total,
-            options.increment.as_extended_increment(),
-        )?
-        .round(options.rounding_mode);
+        let rounded_unit =
+            IncrementRounder::from_signed_num(total, options.increment.as_extended_increment())?
+                .round(options.rounding_mode);
 
         // 16. If roundedUnit - total < 0, let roundedSign be -1; else let roundedSign be 1.
         // 19. Return Duration Nudge Result Record { [[Duration]]: resultDuration, [[Total]]: total, [[NudgedEpochNs]]: nudgedEpochNs, [[DidExpandCalendarUnit]]: didExpandCalendarUnit }.

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -175,9 +175,8 @@ impl Instant {
             return Err(TemporalError::range().with_message("Increment exceeded a valid range."));
         };
 
-        let rounded =
-            IncrementRounder::<i128>::from_potentially_negative_parts(self.as_i128(), increment)?
-                .round(resolved_options.rounding_mode);
+        let rounded = IncrementRounder::<i128>::from_signed_num(self.as_i128(), increment)?
+            .round(resolved_options.rounding_mode);
 
         Ok(rounded)
     }

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -358,14 +358,12 @@ impl FromStr for Instant {
 
 #[cfg(test)]
 mod tests {
-    use core::str::FromStr;
 
     use crate::{
         components::{duration::TimeDuration, Instant},
         options::{DifferenceSettings, TemporalRoundingMode, TemporalUnit},
-        partial::PartialDuration,
         primitive::FiniteF64,
-        Duration, NS_MAX_INSTANT, NS_MIN_INSTANT,
+        NS_MAX_INSTANT, NS_MIN_INSTANT,
     };
 
     #[test]
@@ -568,7 +566,11 @@ mod tests {
     #[cfg(feature = "tzdb")]
     #[test]
     fn instant_add_across_epoch() {
-        use crate::{options::ToStringRoundingOptions, tzdb::FsTzdbProvider};
+        use crate::{
+            options::ToStringRoundingOptions, partial::PartialDuration, tzdb::FsTzdbProvider,
+            Duration,
+        };
+        use core::str::FromStr;
 
         let instant = Instant::from_str("1969-12-25T12:23:45.678901234Z").unwrap();
         let one = instant

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -175,10 +175,11 @@ impl Instant {
             return Err(TemporalError::range().with_message("Increment exceeded a valid range."));
         };
 
-        let rounded = IncrementRounder::<i128>::from_positive_parts(self.as_i128(), increment)?
-            .round_as_positive(resolved_options.rounding_mode);
+        let rounded =
+            IncrementRounder::<i128>::from_potentially_negative_parts(self.as_i128(), increment)?
+                .round(resolved_options.rounding_mode);
 
-        Ok(rounded as i128)
+        Ok(rounded)
     }
 
     // Utility for converting `Instant` to `i128`.
@@ -357,11 +358,14 @@ impl FromStr for Instant {
 
 #[cfg(test)]
 mod tests {
+    use core::str::FromStr;
+
     use crate::{
         components::{duration::TimeDuration, Instant},
         options::{DifferenceSettings, TemporalRoundingMode, TemporalUnit},
+        partial::PartialDuration,
         primitive::FiniteF64,
-        NS_MAX_INSTANT, NS_MIN_INSTANT,
+        Duration, NS_MAX_INSTANT, NS_MIN_INSTANT,
     };
 
     #[test]
@@ -558,5 +562,79 @@ mod tests {
             negative_result.time(),
             (-376435.0, -23.0, -8.0, -148.0, -529.0, -500.0),
         );
+    }
+
+    // /test/built-ins/Temporal/Instant/prototype/add/cross-epoch.js
+    #[cfg(feature = "tzdb")]
+    #[test]
+    fn instant_add_across_epoch() {
+        use crate::{options::ToStringRoundingOptions, tzdb::FsTzdbProvider};
+
+        let instant = Instant::from_str("1969-12-25T12:23:45.678901234Z").unwrap();
+        let one = instant
+            .subtract(
+                Duration::from_partial_duration(PartialDuration {
+                    hours: Some(240.into()),
+                    nanoseconds: Some(800.into()),
+                    ..Default::default()
+                })
+                .unwrap(),
+            )
+            .unwrap();
+        let two = instant
+            .add(
+                Duration::from_partial_duration(PartialDuration {
+                    hours: Some(240.into()),
+                    nanoseconds: Some(800.into()),
+                    ..Default::default()
+                })
+                .unwrap(),
+            )
+            .unwrap();
+        let three = two
+            .subtract(
+                Duration::from_partial_duration(PartialDuration {
+                    hours: Some(480.into()),
+                    nanoseconds: Some(1600.into()),
+                    ..Default::default()
+                })
+                .unwrap(),
+            )
+            .unwrap();
+        let four = one
+            .add(
+                Duration::from_partial_duration(PartialDuration {
+                    hours: Some(480.into()),
+                    nanoseconds: Some(1600.into()),
+                    ..Default::default()
+                })
+                .unwrap(),
+            )
+            .unwrap();
+
+        let one_comp = Instant::from_str("1969-12-15T12:23:45.678900434Z").unwrap();
+        let two_comp = Instant::from_str("1970-01-04T12:23:45.678902034Z").unwrap();
+
+        // Assert the comparisons all hold.
+        assert_eq!(one, one_comp);
+        assert_eq!(two, two_comp);
+        assert_eq!(three, one);
+        assert_eq!(four, two);
+
+        // Assert the to_string is valid.
+        let provider = &FsTzdbProvider::default();
+        let inst_string = instant
+            .to_ixdtf_string_with_provider(None, ToStringRoundingOptions::default(), provider)
+            .unwrap();
+        let one_string = one
+            .to_ixdtf_string_with_provider(None, ToStringRoundingOptions::default(), provider)
+            .unwrap();
+        let two_string = two
+            .to_ixdtf_string_with_provider(None, ToStringRoundingOptions::default(), provider)
+            .unwrap();
+
+        assert_eq!(&inst_string, "1969-12-25T12:23:45.678901234Z");
+        assert_eq!(&one_string, "1969-12-15T12:23:45.678900434Z");
+        assert_eq!(&two_string, "1970-01-04T12:23:45.678902034Z");
     }
 }

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -1116,7 +1116,7 @@ pub(crate) fn interpret_isodatetime_offset(
                 // c. If matchBehaviour is match-minutes, then
                 if match_minutes {
                     // i. Let roundedCandidateNanoseconds be RoundNumberToIncrement(candidateOffset, 60 × 10**9, half-expand).
-                    let rounded_candidate = IncrementRounder::from_potentially_negative_parts(
+                    let rounded_candidate = IncrementRounder::from_signed_num(
                         candidate_offset,
                         NonZeroU128::new(60_000_000_000).expect("cannot be zero"), // TODO: Add back const { } after MSRV can be bumped
                     )?
@@ -1159,7 +1159,7 @@ pub(crate) fn nanoseconds_to_formattable_offset_minutes(
     nanoseconds: i128,
 ) -> TemporalResult<(Sign, u8, u8)> {
     // Per 11.1.7 this should be rounding
-    let nanoseconds = IncrementRounder::from_potentially_negative_parts(nanoseconds, unsafe {
+    let nanoseconds = IncrementRounder::from_signed_num(nanoseconds, unsafe {
         NonZeroU128::new_unchecked(NS_PER_MINUTE as u128)
     })?
     .round(TemporalRoundingMode::HalfExpand);

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -85,7 +85,7 @@ impl IsoDateTime {
         })?;
 
         // 2. Let remainderNs be epochNanoseconds modulo 10^6.
-        let remainder_nanos = mathematical_nanos % 1_000_000;
+        let remainder_nanos = mathematical_nanos.rem_euclid(1_000_000);
 
         // 3. Let epochMilliseconds be 𝔽((epochNanoseconds - remainderNs) / 10^6).
         let epoch_millis = (mathematical_nanos - remainder_nanos) / 1_000_000;
@@ -95,20 +95,20 @@ impl IsoDateTime {
         let day = utils::epoch_time_to_date(epoch_millis as f64);
 
         // 7. Let hour be ℝ(! HourFromTime(epochMilliseconds)).
-        let hour = (epoch_millis / 3_600_000) % 24;
-        // 8. Let minute be ℝ(! MinFromTime(epochMilliseconds)).
-        let minute = (epoch_millis / 60_000) % 60;
+        let hour = epoch_millis.div_euclid(3_600_000).rem_euclid(24);
+        // 8. Let minute be ℝ(! MinFromTime(epochMilliserhs)conds)).
+        let minute = epoch_millis.div_euclid(60_000).rem_euclid(60);
         // 9. Let second be ℝ(! SecFromTime(epochMilliseconds)).
-        let second = (epoch_millis / 1000) % 60;
+        let second = epoch_millis.div_euclid(1000).rem_euclid(60);
         // 10. Let millisecond be ℝ(! msFromTime(epochMilliseconds)).
-        let millis = (epoch_millis % 1000) % 1000;
+        let millis = epoch_millis.rem_euclid(1000);
 
         // 11. Let microsecond be floor(remainderNs / 1000).
-        let micros = remainder_nanos / 1000;
+        let micros = remainder_nanos.div_euclid(1000);
         // 12. Assert: microsecond < 1000.
         temporal_assert!(micros < 1000);
         // 13. Let nanosecond be remainderNs modulo 1000.
-        let nanos = remainder_nanos % 1000;
+        let nanos = remainder_nanos.rem_euclid(1000);
 
         Ok(Self::balance(
             year,

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -787,10 +787,9 @@ impl IsoTime {
             .ok_or(TemporalError::range().with_message("increment exceeded valid range."))?;
 
         // 8. Let result be RoundNumberToIncrement(quantity, increment × unitLength, roundingMode) / unitLength.
-        let result =
-            IncrementRounder::<i128>::from_potentially_negative_parts(quantity, increment)?
-                .round(resolved_options.rounding_mode)
-                / length.get() as i128;
+        let result = IncrementRounder::<i128>::from_signed_num(quantity, increment)?
+            .round(resolved_options.rounding_mode)
+            / length.get() as i128;
 
         let result_i64 = i64::from_i128(result)
             .ok_or(TemporalError::range().with_message("round result valid range."))?;

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -42,10 +42,7 @@ pub(crate) struct IncrementRounder<T: Roundable> {
 
 impl<T: Roundable> IncrementRounder<T> {
     #[inline]
-    pub(crate) fn from_potentially_negative_parts(
-        number: T,
-        increment: NonZeroU128,
-    ) -> TemporalResult<Self> {
+    pub(crate) fn from_signed_num(number: T, increment: NonZeroU128) -> TemporalResult<Self> {
         let increment = <T as NumCast>::from(increment.get()).temporal_unwrap()?;
         Ok(Self {
             sign: number >= T::ZERO,
@@ -182,53 +179,38 @@ mod tests {
 
     #[test]
     fn neg_i128_rounding() {
-        let result = IncrementRounder::<i128>::from_potentially_negative_parts(
-            -9,
-            NonZeroU128::new(2).unwrap(),
-        )
-        .unwrap()
-        .round(TemporalRoundingMode::Ceil);
+        let result = IncrementRounder::<i128>::from_signed_num(-9, NonZeroU128::new(2).unwrap())
+            .unwrap()
+            .round(TemporalRoundingMode::Ceil);
         assert_eq!(result, -8);
 
-        let result = IncrementRounder::<i128>::from_potentially_negative_parts(
-            -9,
-            NonZeroU128::new(2).unwrap(),
-        )
-        .unwrap()
-        .round(TemporalRoundingMode::Floor);
+        let result = IncrementRounder::<i128>::from_signed_num(-9, NonZeroU128::new(2).unwrap())
+            .unwrap()
+            .round(TemporalRoundingMode::Floor);
         assert_eq!(result, -10);
 
-        let result = IncrementRounder::<i128>::from_potentially_negative_parts(
-            -14,
-            NonZeroU128::new(3).unwrap(),
-        )
-        .unwrap()
-        .round(TemporalRoundingMode::HalfExpand);
+        let result = IncrementRounder::<i128>::from_signed_num(-14, NonZeroU128::new(3).unwrap())
+            .unwrap()
+            .round(TemporalRoundingMode::HalfExpand);
         assert_eq!(result, -15);
     }
 
     #[test]
     fn neg_f64_rounding() {
-        let result = IncrementRounder::<f64>::from_potentially_negative_parts(
-            -8.5,
-            NonZeroU128::new(1).unwrap(),
-        )
-        .unwrap()
-        .round(TemporalRoundingMode::Ceil);
+        let result = IncrementRounder::<f64>::from_signed_num(-8.5, NonZeroU128::new(1).unwrap())
+            .unwrap()
+            .round(TemporalRoundingMode::Ceil);
         assert_eq!(result, -8);
 
-        let result = IncrementRounder::<f64>::from_potentially_negative_parts(
-            -8.5,
-            NonZeroU128::new(1).unwrap(),
-        )
-        .unwrap()
-        .round(TemporalRoundingMode::Floor);
+        let result = IncrementRounder::<f64>::from_signed_num(-8.5, NonZeroU128::new(1).unwrap())
+            .unwrap()
+            .round(TemporalRoundingMode::Floor);
         assert_eq!(result, -9);
     }
 
     #[test]
     fn dt_since_basic_rounding() {
-        let result = IncrementRounder::<i128>::from_potentially_negative_parts(
+        let result = IncrementRounder::<i128>::from_signed_num(
             -84082624864197532,
             NonZeroU128::new(1800000000000).unwrap(),
         )


### PR DESCRIPTION
This PR fixes both an assertion bug from caused by `IncrementRounder`'s as_positive path. Since this was the only use case in the specification that seemed to be using the "as_positive" path, I completely removed the methods.

This also fixes some other bugs caused from using non_euclidean operations in `IsoDateTime::from_epoch_nanos`