### PR TITLE
API cleanup, visibility updates, and tech debt cleanup

### DIFF
--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -5,7 +5,6 @@
 
 // TODO: It may finally be time to clean up API to use `IsoDate` and `DateDuration` directly.
 
-use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::str::FromStr;
@@ -207,67 +206,6 @@ impl FromStr for Calendar {
     }
 }
 
-// TODO: Potentially dead code.
-/// Designate the type of `CalendarFields` needed
-#[derive(Debug, Clone, Copy)]
-pub enum CalendarFieldsType {
-    /// Whether the Fields should return for a PlainDate.
-    Date,
-    /// Whether the Fields should return for a PlainYearMonth.
-    YearMonth,
-    /// Whether the Fields should return for a PlainMonthDay.
-    MonthDay,
-}
-
-// TODO: Optimize to TinyStr or &str.
-impl From<&[String]> for CalendarFieldsType {
-    fn from(value: &[String]) -> Self {
-        let year_present = value.contains(&"year".to_owned());
-        let day_present = value.contains(&"day".to_owned());
-
-        if year_present && day_present {
-            CalendarFieldsType::Date
-        } else if year_present {
-            CalendarFieldsType::YearMonth
-        } else {
-            CalendarFieldsType::MonthDay
-        }
-    }
-}
-
-/// The `DateLike` objects that can be provided to the `CalendarProtocol`.
-#[derive(Debug)]
-pub enum CalendarDateLike<'a> {
-    /// Represents a `PlainDateTime`.
-    DateTime(&'a PlainDateTime),
-    /// Represents a `PlainDate`.
-    Date(&'a PlainDate),
-    /// Represents a `PlainYearMonth`.
-    YearMonth(&'a PlainYearMonth),
-    /// Represents a `PlainMonthDay`.
-    MonthDay(&'a PlainMonthDay),
-}
-
-impl CalendarDateLike<'_> {
-    /// Retrieves the internal `IsoDate` field.
-    #[inline]
-    #[must_use]
-    pub fn as_iso_date(&self) -> IsoDate {
-        match self {
-            CalendarDateLike::DateTime(dt) => dt.iso.date,
-            CalendarDateLike::Date(d) => d.iso,
-            CalendarDateLike::YearMonth(ym) => ym.iso,
-            CalendarDateLike::MonthDay(md) => md.iso,
-        }
-    }
-}
-
-/// A trait for retrieving an internal calendar slice.
-pub trait GetTemporalCalendar {
-    /// Returns the `TemporalCalendar` value of the implementor.
-    fn get_calendar(&self) -> Calendar;
-}
-
 // ==== Public `CalendarSlot` methods ====
 
 impl Calendar {
@@ -422,73 +360,72 @@ impl Calendar {
     }
 
     /// `CalendarEra`
-    pub fn era(&self, date_like: &CalendarDateLike) -> TemporalResult<Option<TinyAsciiStr<16>>> {
+    pub fn era(&self, iso_date: &IsoDate) -> TemporalResult<Option<TinyAsciiStr<16>>> {
         if self.is_iso() {
             return Ok(None);
         }
-        let calendar_date = self.0.date_from_iso(date_like.as_iso_date().as_icu4x()?);
+        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
         Ok(self.0.year(&calendar_date).standard_era().map(|era| era.0))
     }
 
     /// `CalendarEraYear`
-    pub fn era_year(&self, date_like: &CalendarDateLike) -> TemporalResult<Option<i32>> {
+    pub fn era_year(&self, iso_date: &IsoDate) -> TemporalResult<Option<i32>> {
         if self.is_iso() {
             return Ok(None);
         }
-        let calendar_date = self.0.date_from_iso(date_like.as_iso_date().as_icu4x()?);
+        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
         Ok(self.0.year(&calendar_date).era_year())
     }
 
     /// `CalendarYear`
-    pub fn year(&self, date_like: &CalendarDateLike) -> TemporalResult<i32> {
+    pub fn year(&self, iso_date: &IsoDate) -> TemporalResult<i32> {
         if self.is_iso() {
-            return Ok(date_like.as_iso_date().year);
+            return Ok(iso_date.year);
         }
-        let calendar_date = self.0.date_from_iso(date_like.as_iso_date().as_icu4x()?);
+        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
         Ok(self.0.year(&calendar_date).extended_year)
     }
 
     /// `CalendarMonth`
-    pub fn month(&self, date_like: &CalendarDateLike) -> TemporalResult<u8> {
+    pub fn month(&self, iso_date: &IsoDate) -> TemporalResult<u8> {
         if self.is_iso() {
-            return Ok(date_like.as_iso_date().month);
+            return Ok(iso_date.month);
         }
 
         Err(TemporalError::range().with_message("Not yet implemented."))
     }
 
     /// `CalendarMonthCode`
-    pub fn month_code(&self, date_like: &CalendarDateLike) -> TemporalResult<TinyAsciiStr<4>> {
+    pub fn month_code(&self, iso_date: &IsoDate) -> TemporalResult<TinyAsciiStr<4>> {
         if self.is_iso() {
-            return Ok(date_like.as_iso_date().as_icu4x()?.month().standard_code.0);
+            return Ok(iso_date.as_icu4x()?.month().standard_code.0);
         }
 
         Err(TemporalError::range().with_message("Not yet implemented."))
     }
 
     /// `CalendarDay`
-    pub fn day(&self, date_like: &CalendarDateLike) -> TemporalResult<u8> {
+    pub fn day(&self, iso_date: &IsoDate) -> TemporalResult<u8> {
         if self.is_iso() {
-            return Ok(date_like.as_iso_date().day);
+            return Ok(iso_date.day);
         }
 
         Err(TemporalError::range().with_message("Not yet implemented."))
     }
 
     /// `CalendarDayOfWeek`
-    pub fn day_of_week(&self, date_like: &CalendarDateLike) -> TemporalResult<u16> {
+    pub fn day_of_week(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
         if self.is_iso() {
-            return Ok(date_like.as_iso_date().as_icu4x()?.day_of_week() as u16);
+            return Ok(iso_date.as_icu4x()?.day_of_week() as u16);
         }
 
         Err(TemporalError::range().with_message("Not yet implemented."))
     }
 
     /// `CalendarDayOfYear`
-    pub fn day_of_year(&self, date_like: &CalendarDateLike) -> TemporalResult<u16> {
+    pub fn day_of_year(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
         if self.is_iso() {
-            return Ok(date_like
-                .as_iso_date()
+            return Ok(iso_date
                 .as_icu4x()?
                 .day_of_year_info()
                 .day_of_year);
@@ -497,9 +434,9 @@ impl Calendar {
     }
 
     /// `CalendarWeekOfYear`
-    pub fn week_of_year(&self, date_like: &CalendarDateLike) -> TemporalResult<Option<u16>> {
+    pub fn week_of_year(&self, iso_date: &IsoDate) -> TemporalResult<Option<u16>> {
         if self.is_iso() {
-            let date = date_like.as_iso_date().as_icu4x()?;
+            let date = iso_date.as_icu4x()?;
 
             let week_calculator = WeekCalculator::default();
 
@@ -511,9 +448,9 @@ impl Calendar {
     }
 
     /// `CalendarYearOfWeek`
-    pub fn year_of_week(&self, date_like: &CalendarDateLike) -> TemporalResult<Option<i32>> {
+    pub fn year_of_week(&self, iso_date: &IsoDate) -> TemporalResult<Option<i32>> {
         if self.is_iso() {
-            let date = date_like.as_iso_date().as_icu4x()?;
+            let date = iso_date.as_icu4x()?;
 
             let week_calculator = WeekCalculator::default();
 
@@ -529,7 +466,7 @@ impl Calendar {
     }
 
     /// `CalendarDaysInWeek`
-    pub fn days_in_week(&self, _date_like: &CalendarDateLike) -> TemporalResult<u16> {
+    pub fn days_in_week(&self, _iso_date: &IsoDate) -> TemporalResult<u16> {
         if self.is_iso() {
             return Ok(7);
         }
@@ -537,24 +474,24 @@ impl Calendar {
     }
 
     /// `CalendarDaysInMonth`
-    pub fn days_in_month(&self, date_like: &CalendarDateLike) -> TemporalResult<u16> {
+    pub fn days_in_month(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
         if self.is_iso() {
-            return Ok(date_like.as_iso_date().as_icu4x()?.days_in_month() as u16);
+            return Ok(iso_date.as_icu4x()?.days_in_month() as u16);
         }
         Err(TemporalError::range().with_message("Not yet implemented."))
     }
 
     /// `CalendarDaysInYear`
-    pub fn days_in_year(&self, date_like: &CalendarDateLike) -> TemporalResult<u16> {
+    pub fn days_in_year(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
         if self.is_iso() {
-            return Ok(date_like.as_iso_date().as_icu4x()?.days_in_year());
+            return Ok(iso_date.as_icu4x()?.days_in_year());
         }
 
         Err(TemporalError::range().with_message("Not yet implemented."))
     }
 
     /// `CalendarMonthsInYear`
-    pub fn months_in_year(&self, _date_like: &CalendarDateLike) -> TemporalResult<u16> {
+    pub fn months_in_year(&self, _iso_date: &IsoDate) -> TemporalResult<u16> {
         if self.is_iso() {
             return Ok(12);
         }
@@ -562,9 +499,9 @@ impl Calendar {
     }
 
     /// `CalendarInLeapYear`
-    pub fn in_leap_year(&self, date_like: &CalendarDateLike) -> TemporalResult<bool> {
+    pub fn in_leap_year(&self, iso_date: &IsoDate) -> TemporalResult<bool> {
         if self.is_iso() {
-            return Ok(date_like.as_iso_date().as_icu4x()?.is_in_leap_year());
+            return Ok(iso_date.as_icu4x()?.is_in_leap_year());
         }
         Err(TemporalError::range().with_message("Not yet implemented."))
     }

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -425,10 +425,7 @@ impl Calendar {
     /// `CalendarDayOfYear`
     pub fn day_of_year(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
         if self.is_iso() {
-            return Ok(iso_date
-                .as_icu4x()?
-                .day_of_year_info()
-                .day_of_year);
+            return Ok(iso_date.as_icu4x()?.day_of_year_info().day_of_year);
         }
         Err(TemporalError::range().with_message("Not yet implemented."))?
     }

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -1,11 +1,7 @@
 //! This module implements `Date` and any directly related algorithms.
 
 use crate::{
-    components::{
-        calendar::Calendar,
-        duration::DateDuration,
-        Duration, PlainDateTime,
-    },
+    components::{calendar::Calendar, duration::DateDuration, Duration, PlainDateTime},
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, DisplayCalendar,

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     components::{
-        calendar::{Calendar, CalendarDateLike, GetTemporalCalendar},
+        calendar::Calendar,
         duration::DateDuration,
         Duration, PlainDateTime,
     },
@@ -486,75 +486,75 @@ impl PlainDate {
 impl PlainDate {
     /// Returns the calendar year value.
     pub fn year(&self) -> TemporalResult<i32> {
-        self.calendar.year(&CalendarDateLike::Date(self))
+        self.calendar.year(&self.iso)
     }
 
     /// Returns the calendar month value.
     pub fn month(&self) -> TemporalResult<u8> {
-        self.calendar.month(&CalendarDateLike::Date(self))
+        self.calendar.month(&self.iso)
     }
 
     /// Returns the calendar month code value.
     pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
-        self.calendar.month_code(&CalendarDateLike::Date(self))
+        self.calendar.month_code(&self.iso)
     }
 
     /// Returns the calendar day value.
     pub fn day(&self) -> TemporalResult<u8> {
-        self.calendar.day(&CalendarDateLike::Date(self))
+        self.calendar.day(&self.iso)
     }
 
     /// Returns the calendar day of week value.
     pub fn day_of_week(&self) -> TemporalResult<u16> {
-        self.calendar.day_of_week(&CalendarDateLike::Date(self))
+        self.calendar.day_of_week(&self.iso)
     }
 
     /// Returns the calendar day of year value.
     pub fn day_of_year(&self) -> TemporalResult<u16> {
-        self.calendar.day_of_year(&CalendarDateLike::Date(self))
+        self.calendar.day_of_year(&self.iso)
     }
 
     /// Returns the calendar week of year value.
     pub fn week_of_year(&self) -> TemporalResult<Option<u16>> {
-        self.calendar.week_of_year(&CalendarDateLike::Date(self))
+        self.calendar.week_of_year(&self.iso)
     }
 
     /// Returns the calendar year of week value.
     pub fn year_of_week(&self) -> TemporalResult<Option<i32>> {
-        self.calendar.year_of_week(&CalendarDateLike::Date(self))
+        self.calendar.year_of_week(&self.iso)
     }
 
     /// Returns the calendar days in week value.
     pub fn days_in_week(&self) -> TemporalResult<u16> {
-        self.calendar.days_in_week(&CalendarDateLike::Date(self))
+        self.calendar.days_in_week(&self.iso)
     }
 
     /// Returns the calendar days in month value.
     pub fn days_in_month(&self) -> TemporalResult<u16> {
-        self.calendar.days_in_month(&CalendarDateLike::Date(self))
+        self.calendar.days_in_month(&self.iso)
     }
 
     /// Returns the calendar days in year value.
     pub fn days_in_year(&self) -> TemporalResult<u16> {
-        self.calendar.days_in_year(&CalendarDateLike::Date(self))
+        self.calendar.days_in_year(&self.iso)
     }
 
     /// Returns the calendar months in year value.
     pub fn months_in_year(&self) -> TemporalResult<u16> {
-        self.calendar.months_in_year(&CalendarDateLike::Date(self))
+        self.calendar.months_in_year(&self.iso)
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
     pub fn in_leap_year(&self) -> TemporalResult<bool> {
-        self.calendar.in_leap_year(&CalendarDateLike::Date(self))
+        self.calendar.in_leap_year(&self.iso)
     }
 
     pub fn era(&self) -> TemporalResult<Option<TinyAsciiStr<16>>> {
-        self.calendar.era(&CalendarDateLike::Date(self))
+        self.calendar.era(&self.iso)
     }
 
     pub fn era_year(&self) -> TemporalResult<Option<i32>> {
-        self.calendar.era_year(&CalendarDateLike::Date(self))
+        self.calendar.era_year(&self.iso)
     }
 }
 
@@ -570,13 +570,13 @@ impl PlainDate {
     pub fn to_date_time(&self, time: Option<PlainTime>) -> TemporalResult<PlainDateTime> {
         let time = time.unwrap_or_default();
         let iso = IsoDateTime::new(self.iso, time.iso)?;
-        Ok(PlainDateTime::new_unchecked(iso, self.get_calendar()))
+        Ok(PlainDateTime::new_unchecked(iso, self.calendar().clone()))
     }
 
     /// Converts the current `Date<C>` into a `PlainYearMonth`
     #[inline]
     pub fn to_year_month(&self) -> TemporalResult<PlainYearMonth> {
-        self.get_calendar().year_month_from_partial(
+        self.calendar().year_month_from_partial(
             &PartialDate::default().with_fallback_date(self)?,
             ArithmeticOverflow::Constrain,
         )
@@ -585,7 +585,7 @@ impl PlainDate {
     /// Converts the current `Date<C>` into a `PlainMonthDay`
     #[inline]
     pub fn to_month_day(&self) -> TemporalResult<PlainMonthDay> {
-        self.get_calendar().month_day_from_partial(
+        self.calendar().month_day_from_partial(
             &PartialDate::default().with_fallback_date(self)?,
             ArithmeticOverflow::Constrain,
         )
@@ -601,12 +601,6 @@ impl PlainDate {
 }
 
 // ==== Trait impls ====
-
-impl GetTemporalCalendar for PlainDate {
-    fn get_calendar(&self) -> Calendar {
-        self.calendar.clone()
-    }
-}
 
 impl From<PlainDateTime> for PlainDate {
     fn from(value: PlainDateTime) -> Self {

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -14,7 +14,6 @@ use alloc::string::String;
 use core::{cmp::Ordering, str::FromStr};
 
 use super::{
-    calendar::{CalendarDateLike, GetTemporalCalendar},
     duration::normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
     timezone::NeverProvider,
     Duration, PartialDate, PartialTime, PlainDate, PlainTime,
@@ -504,82 +503,82 @@ impl PlainDateTime {
 impl PlainDateTime {
     /// Returns the calendar year value.
     pub fn year(&self) -> TemporalResult<i32> {
-        self.calendar.year(&CalendarDateLike::DateTime(self))
+        self.calendar.year(&self.iso.date)
     }
 
     /// Returns the calendar month value.
     pub fn month(&self) -> TemporalResult<u8> {
-        self.calendar.month(&CalendarDateLike::DateTime(self))
+        self.calendar.month(&self.iso.date)
     }
 
     /// Returns the calendar month code value.
     pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
-        self.calendar.month_code(&CalendarDateLike::DateTime(self))
+        self.calendar.month_code(&self.iso.date)
     }
 
     /// Returns the calendar day value.
     pub fn day(&self) -> TemporalResult<u8> {
-        self.calendar.day(&CalendarDateLike::DateTime(self))
+        self.calendar.day(&self.iso.date)
     }
 
     /// Returns the calendar day of week value.
     pub fn day_of_week(&self) -> TemporalResult<u16> {
-        self.calendar.day_of_week(&CalendarDateLike::DateTime(self))
+        self.calendar.day_of_week(&self.iso.date)
     }
 
     /// Returns the calendar day of year value.
     pub fn day_of_year(&self) -> TemporalResult<u16> {
-        self.calendar.day_of_year(&CalendarDateLike::DateTime(self))
+        self.calendar.day_of_year(&self.iso.date)
     }
 
     /// Returns the calendar week of year value.
     pub fn week_of_year(&self) -> TemporalResult<Option<u16>> {
         self.calendar
-            .week_of_year(&CalendarDateLike::DateTime(self))
+            .week_of_year(&self.iso.date)
     }
 
     /// Returns the calendar year of week value.
     pub fn year_of_week(&self) -> TemporalResult<Option<i32>> {
         self.calendar
-            .year_of_week(&CalendarDateLike::DateTime(self))
+            .year_of_week(&self.iso.date)
     }
 
     /// Returns the calendar days in week value.
     pub fn days_in_week(&self) -> TemporalResult<u16> {
         self.calendar
-            .days_in_week(&CalendarDateLike::DateTime(self))
+            .days_in_week(&self.iso.date)
     }
 
     /// Returns the calendar days in month value.
     pub fn days_in_month(&self) -> TemporalResult<u16> {
         self.calendar
-            .days_in_month(&CalendarDateLike::DateTime(self))
+            .days_in_month(&self.iso.date)
     }
 
     /// Returns the calendar days in year value.
     pub fn days_in_year(&self) -> TemporalResult<u16> {
         self.calendar
-            .days_in_year(&CalendarDateLike::DateTime(self))
+            .days_in_year(&self.iso.date)
     }
 
     /// Returns the calendar months in year value.
     pub fn months_in_year(&self) -> TemporalResult<u16> {
         self.calendar
-            .months_in_year(&CalendarDateLike::DateTime(self))
+            .months_in_year(&self.iso.date)
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
     pub fn in_leap_year(&self) -> TemporalResult<bool> {
         self.calendar
-            .in_leap_year(&CalendarDateLike::DateTime(self))
+            .in_leap_year(&self.iso.date)
     }
 
     pub fn era(&self) -> TemporalResult<Option<TinyAsciiStr<16>>> {
-        self.calendar.era(&CalendarDateLike::DateTime(self))
+        self.calendar.era(&self.iso.date)
     }
 
     pub fn era_year(&self) -> TemporalResult<Option<i32>> {
-        self.calendar.era_year(&CalendarDateLike::DateTime(self))
+        self.calendar.era_year(&self.iso.date)
     }
 }
 
@@ -653,12 +652,6 @@ impl PlainDateTime {
 }
 
 // ==== Trait impls ====
-
-impl GetTemporalCalendar for PlainDateTime {
-    fn get_calendar(&self) -> Calendar {
-        self.calendar.clone()
-    }
-}
 
 impl From<PlainDate> for PlainDateTime {
     fn from(value: PlainDate) -> Self {

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -533,44 +533,37 @@ impl PlainDateTime {
 
     /// Returns the calendar week of year value.
     pub fn week_of_year(&self) -> TemporalResult<Option<u16>> {
-        self.calendar
-            .week_of_year(&self.iso.date)
+        self.calendar.week_of_year(&self.iso.date)
     }
 
     /// Returns the calendar year of week value.
     pub fn year_of_week(&self) -> TemporalResult<Option<i32>> {
-        self.calendar
-            .year_of_week(&self.iso.date)
+        self.calendar.year_of_week(&self.iso.date)
     }
 
     /// Returns the calendar days in week value.
     pub fn days_in_week(&self) -> TemporalResult<u16> {
-        self.calendar
-            .days_in_week(&self.iso.date)
+        self.calendar.days_in_week(&self.iso.date)
     }
 
     /// Returns the calendar days in month value.
     pub fn days_in_month(&self) -> TemporalResult<u16> {
-        self.calendar
-            .days_in_month(&self.iso.date)
+        self.calendar.days_in_month(&self.iso.date)
     }
 
     /// Returns the calendar days in year value.
     pub fn days_in_year(&self) -> TemporalResult<u16> {
-        self.calendar
-            .days_in_year(&self.iso.date)
+        self.calendar.days_in_year(&self.iso.date)
     }
 
     /// Returns the calendar months in year value.
     pub fn months_in_year(&self) -> TemporalResult<u16> {
-        self.calendar
-            .months_in_year(&self.iso.date)
+        self.calendar.months_in_year(&self.iso.date)
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
     pub fn in_leap_year(&self) -> TemporalResult<bool> {
-        self.calendar
-            .in_leap_year(&self.iso.date)
+        self.calendar.in_leap_year(&self.iso.date)
     }
 
     pub fn era(&self) -> TemporalResult<Option<TinyAsciiStr<16>>> {

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -1,7 +1,7 @@
 //! This module implements `Duration` along with it's methods and components.
 
 use crate::{
-    components::{timezone::TzProvider, PlainDateTime, PlainTime},
+    components::{timezone::TimeZoneProvider, PlainDateTime, PlainTime},
     iso::{IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, RelativeTo, ResolvedRoundingOptions, RoundingOptions, TemporalUnit,
@@ -30,7 +30,6 @@ mod time;
 #[cfg(test)]
 mod tests;
 
-// TODO: Determine visibility.
 #[doc(inline)]
 pub use date::DateDuration;
 #[doc(inline)]
@@ -446,7 +445,7 @@ impl Duration {
         &self,
         options: RoundingOptions,
         relative_to: Option<RelativeTo>,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Self> {
         // NOTE: Steps 1-14 seem to be implementation specific steps.
         // 14. Let roundingIncrement be ? ToTemporalRoundingIncrement(roundTo).

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -6,7 +6,7 @@ use num_traits::{AsPrimitive, Euclid, FromPrimitive};
 
 use crate::{
     components::{
-        timezone::{TimeZone, TzProvider},
+        timezone::{TimeZone, TimeZoneProvider},
         PlainDate, PlainDateTime,
     },
     iso::{IsoDate, IsoDateTime},
@@ -39,7 +39,7 @@ const NANOSECONDS_PER_HOUR: f64 = 60.0 * 60.0 * 1e9;
 
 /// A Normalized `TimeDuration` that represents the current `TimeDuration` in nanoseconds.
 #[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
-pub struct NormalizedTimeDuration(pub(crate) i128);
+pub(crate) struct NormalizedTimeDuration(pub(crate) i128);
 
 impl NormalizedTimeDuration {
     /// Equivalent: 7.5.20 NormalizeTimeDuration ( hours, minutes, seconds, milliseconds, microseconds, nanoseconds )
@@ -302,7 +302,7 @@ impl NormalizedDurationRecord {
         sign: Sign,
         dest_epoch_ns: i128,
         dt: &PlainDateTime,
-        tz: Option<(&TimeZone, &impl TzProvider)>, // ???
+        tz: Option<(&TimeZone, &impl TimeZoneProvider)>, // ???
         options: ResolvedRoundingOptions,
     ) -> TemporalResult<NudgeRecord> {
         // NOTE: r2 may never be used...need to test.
@@ -594,7 +594,7 @@ impl NormalizedDurationRecord {
         dt: &PlainDateTime,
         tz: &TimeZone,
         options: ResolvedRoundingOptions,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<NudgeRecord> {
         let d = Duration::from(self.date());
         // 1.Let start be ? CalendarDateAdd(calendar, isoDateTime.[[ISODate]], duration.[[Date]], constrain).
@@ -762,7 +762,7 @@ impl NormalizedDurationRecord {
         sign: Sign,
         nudge_epoch_ns: i128,
         date_time: &PlainDateTime,
-        tz: Option<(&TimeZone, &impl TzProvider)>,
+        tz: Option<(&TimeZone, &impl TimeZoneProvider)>,
         largest_unit: TemporalUnit,
         smallest_unit: TemporalUnit,
     ) -> TemporalResult<NormalizedDurationRecord> {
@@ -900,7 +900,7 @@ impl NormalizedDurationRecord {
         &self,
         dest_epoch_ns: i128,
         dt: &PlainDateTime,
-        timezone_record: Option<(&TimeZone, &impl TzProvider)>,
+        timezone_record: Option<(&TimeZone, &impl TimeZoneProvider)>,
         options: ResolvedRoundingOptions,
     ) -> TemporalResult<NormalizedDurationRecord> {
         // 1. Let irregularLengthUnit be false.

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -23,7 +23,7 @@ use num_traits::FromPrimitive;
 
 use super::{
     duration::normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
-    timezone::TzProvider,
+    timezone::TimeZoneProvider,
 };
 
 const NANOSECONDS_PER_SECOND: f64 = 1e9;
@@ -277,7 +277,7 @@ impl Instant {
         &self,
         timezone: Option<&TimeZone>,
         options: ToStringRoundingOptions,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<String> {
         let resolved_options = options.resolve()?;
         let round = self.round_instant(ResolvedRoundingOptions::from_to_string_options(

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -30,7 +30,7 @@ pub use date::{PartialDate, PlainDate};
 #[doc(inline)]
 pub use datetime::{PartialDateTime, PlainDateTime};
 #[doc(inline)]
-pub use duration::Duration;
+pub use duration::{Duration, DateDuration, TimeDuration};
 #[doc(inline)]
 pub use instant::{EpochNanoseconds, Instant};
 #[doc(inline)]

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -30,7 +30,7 @@ pub use date::{PartialDate, PlainDate};
 #[doc(inline)]
 pub use datetime::{PartialDateTime, PlainDateTime};
 #[doc(inline)]
-pub use duration::{Duration, DateDuration, TimeDuration};
+pub use duration::{DateDuration, Duration, TimeDuration};
 #[doc(inline)]
 pub use instant::{EpochNanoseconds, Instant};
 #[doc(inline)]

--- a/src/components/month_day.rs
+++ b/src/components/month_day.rs
@@ -9,8 +9,6 @@ use crate::{
     TemporalResult, TemporalUnwrap,
 };
 
-use super::calendar::{CalendarDateLike, GetTemporalCalendar};
-
 /// The native Rust implementation of `Temporal.PlainMonthDay`
 #[non_exhaustive]
 #[derive(Debug, Default, Clone)]
@@ -80,13 +78,7 @@ impl PlainMonthDay {
     /// Returns the `monthCode` value of `MonthDay`.
     #[inline]
     pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
-        self.calendar.month_code(&CalendarDateLike::MonthDay(self))
-    }
-}
-
-impl GetTemporalCalendar for PlainMonthDay {
-    fn get_calendar(&self) -> Calendar {
-        self.calendar.clone()
+        self.calendar.month_code(&self.iso)
     }
 }
 

--- a/src/components/now.rs
+++ b/src/components/now.rs
@@ -9,7 +9,7 @@ use crate::{iso::IsoDateTime, TemporalUnwrap};
 
 use super::{
     calendar::Calendar,
-    timezone::{TimeZone, TzProvider},
+    timezone::{TimeZone, TimeZoneProvider},
     EpochNanoseconds, Instant, PlainDate, PlainDateTime, PlainTime, ZonedDateTime,
 };
 
@@ -54,7 +54,7 @@ impl Now {
     /// value is provided.
     pub fn plain_datetime_iso_with_provider(
         timezone: Option<TimeZone>,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<PlainDateTime> {
         let iso = system_datetime(timezone, provider)?;
         Ok(PlainDateTime::new_unchecked(iso, Calendar::default()))
@@ -67,7 +67,7 @@ impl Now {
     /// value is provided.
     pub fn plain_date_iso_with_provider(
         timezone: Option<TimeZone>,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<PlainDate> {
         let iso = system_datetime(timezone, provider)?;
         Ok(PlainDate::new_unchecked(iso.date, Calendar::default()))
@@ -80,7 +80,7 @@ impl Now {
     /// value is provided.
     pub fn plain_time_iso_with_provider(
         timezone: Option<TimeZone>,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<PlainTime> {
         let iso = system_datetime(timezone, provider)?;
         Ok(PlainTime::new_unchecked(iso.time))
@@ -113,7 +113,7 @@ impl Now {
 
 fn system_datetime(
     tz: Option<TimeZone>,
-    provider: &impl TzProvider,
+    provider: &impl TimeZoneProvider,
 ) -> TemporalResult<IsoDateTime> {
     // 1. If temporalTimeZoneLike is undefined, then
     // a. Let timeZone be SystemTimeZoneIdentifier().

--- a/src/components/timezone.rs
+++ b/src/components/timezone.rs
@@ -39,7 +39,7 @@ pub struct TimeZoneOffset {
 
 // NOTE: It may be a good idea to eventually move this into it's
 // own individual crate rather than having it tied directly into `temporal_rs`
-pub trait TzProvider {
+pub trait TimeZoneProvider {
     fn check_identifier(&self, identifier: &str) -> bool;
 
     fn get_named_tz_epoch_nanoseconds(
@@ -57,7 +57,7 @@ pub trait TzProvider {
 
 pub struct NeverProvider;
 
-impl TzProvider for NeverProvider {
+impl TimeZoneProvider for NeverProvider {
     fn check_identifier(&self, _: &str) -> bool {
         unimplemented!()
     }
@@ -94,7 +94,7 @@ impl TimeZone {
     /// Parses a `TimeZone` from a provided `&str`.
     pub fn try_from_str_with_provider(
         source: &str,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Self> {
         if source == "Z" {
             return Ok(Self::OffsetMinutes(0));
@@ -125,7 +125,7 @@ impl TimeZone {
     pub(crate) fn get_iso_datetime_for(
         &self,
         instant: &Instant,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<IsoDateTime> {
         let nanos = self.get_offset_nanos_for(instant.as_i128(), provider)?;
         IsoDateTime::from_epoch_nanos(&instant.as_i128(), nanos.to_i64().unwrap_or(0))
@@ -137,7 +137,7 @@ impl TimeZone {
     pub fn get_offset_nanos_for(
         &self,
         utc_epoch: i128,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<i128> {
         // 1. Let parseResult be ! ParseTimeZoneIdentifier(timeZone).
         match self {
@@ -154,7 +154,7 @@ impl TimeZone {
         &self,
         iso: IsoDateTime,
         disambiguation: Disambiguation,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<EpochNanoseconds> {
         // 1. Let possibleEpochNs be ? GetPossibleEpochNanoseconds(timeZone, isoDateTime).
         let possible_nanos = self.get_possible_epoch_ns_for(iso, provider)?;
@@ -166,7 +166,7 @@ impl TimeZone {
     pub fn get_possible_epoch_ns_for(
         &self,
         iso: IsoDateTime,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Vec<EpochNanoseconds>> {
         // 1.Let parseResult be ! ParseTimeZoneIdentifier(timeZone).
         let possible_nanoseconds = match self {
@@ -253,7 +253,7 @@ impl TimeZone {
         nanos: Vec<EpochNanoseconds>,
         iso: IsoDateTime,
         disambiguation: Disambiguation,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<EpochNanoseconds> {
         // 1. Let n be possibleEpochNs's length.
         let n = nanos.len();
@@ -382,7 +382,7 @@ impl TimeZone {
     pub(crate) fn get_start_of_day(
         &self,
         iso_date: &IsoDate,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<EpochNanoseconds> {
         // 1. Let isoDateTime be CombineISODateAndTimeRecord(isoDate, MidnightTimeRecord()).
         let iso = IsoDateTime::new_unchecked(*iso_date, IsoTime::default());

--- a/src/components/timezone.rs
+++ b/src/components/timezone.rs
@@ -39,6 +39,8 @@ pub struct TimeZoneOffset {
 
 // NOTE: It may be a good idea to eventually move this into it's
 // own individual crate rather than having it tied directly into `temporal_rs`
+/// The `TimeZoneProvider` trait provides methods required for a provider
+/// to implement in order to source time zone data from that provider.
 pub trait TimeZoneProvider {
     fn check_identifier(&self, identifier: &str) -> bool;
 

--- a/src/components/year_month.rs
+++ b/src/components/year_month.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 
 use super::{
-    calendar::{CalendarDateLike, GetTemporalCalendar},
     Duration, PartialDate,
 };
 
@@ -67,47 +66,47 @@ impl PlainYearMonth {
     }
 
     pub fn year(&self) -> TemporalResult<i32> {
-        self.calendar().year(&CalendarDateLike::YearMonth(self))
+        self.calendar().year(&self.iso)
     }
 
     pub fn month(&self) -> TemporalResult<u8> {
-        self.calendar().month(&CalendarDateLike::YearMonth(self))
+        self.calendar().month(&self.iso)
     }
 
     pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
-        self.get_calendar()
-            .month_code(&CalendarDateLike::YearMonth(self))
+        self.calendar()
+            .month_code(&self.iso)
     }
 
     #[inline]
     #[must_use]
     pub fn in_leap_year(&self) -> bool {
-        self.get_calendar()
-            .in_leap_year(&CalendarDateLike::YearMonth(self))
+        self.calendar()
+            .in_leap_year(&self.iso)
             .is_ok_and(|is_leap_year| is_leap_year)
     }
 
     pub fn get_days_in_year(&self) -> TemporalResult<u16> {
-        self.get_calendar()
-            .days_in_year(&CalendarDateLike::YearMonth(self))
+        self.calendar()
+            .days_in_year(&self.iso)
     }
 
     pub fn get_days_in_month(&self) -> TemporalResult<u16> {
-        self.get_calendar()
-            .days_in_month(&CalendarDateLike::YearMonth(self))
+        self.calendar()
+            .days_in_month(&self.iso)
     }
 
     pub fn get_months_in_year(&self) -> TemporalResult<u16> {
-        self.get_calendar()
-            .months_in_year(&CalendarDateLike::YearMonth(self))
+        self.calendar()
+            .months_in_year(&self.iso)
     }
 
     pub fn era(&self) -> TemporalResult<Option<TinyAsciiStr<16>>> {
-        self.calendar().era(&CalendarDateLike::YearMonth(self))
+        self.calendar().era(&self.iso)
     }
 
     pub fn era_year(&self) -> TemporalResult<Option<i32>> {
-        self.calendar().era_year(&CalendarDateLike::YearMonth(self))
+        self.calendar().era_year(&self.iso)
     }
 }
 
@@ -149,21 +148,14 @@ impl PlainYearMonth {
     ) -> TemporalResult<Self> {
         let partial = PartialDate::try_from_year_month(self)?;
 
-        let mut intermediate_date = self.get_calendar().date_from_partial(&partial, overflow)?;
+        let mut intermediate_date = self.calendar().date_from_partial(&partial, overflow)?;
 
         intermediate_date = intermediate_date.add_date(duration, Some(overflow))?;
 
         let result_fields = PartialDate::default().with_fallback_date(&intermediate_date)?;
 
-        self.get_calendar()
+        self.calendar()
             .year_month_from_partial(&result_fields, overflow)
-    }
-}
-
-impl GetTemporalCalendar for PlainYearMonth {
-    /// Returns a reference to `YearMonth`'s `CalendarSlot`
-    fn get_calendar(&self) -> Calendar {
-        self.calendar.clone()
     }
 }
 

--- a/src/components/year_month.rs
+++ b/src/components/year_month.rs
@@ -10,9 +10,7 @@ use crate::{
     TemporalError, TemporalResult, TemporalUnwrap,
 };
 
-use super::{
-    Duration, PartialDate,
-};
+use super::{Duration, PartialDate};
 
 /// The native Rust implementation of `Temporal.YearMonth`.
 #[non_exhaustive]
@@ -74,8 +72,7 @@ impl PlainYearMonth {
     }
 
     pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
-        self.calendar()
-            .month_code(&self.iso)
+        self.calendar().month_code(&self.iso)
     }
 
     #[inline]
@@ -87,18 +84,15 @@ impl PlainYearMonth {
     }
 
     pub fn get_days_in_year(&self) -> TemporalResult<u16> {
-        self.calendar()
-            .days_in_year(&self.iso)
+        self.calendar().days_in_year(&self.iso)
     }
 
     pub fn get_days_in_month(&self) -> TemporalResult<u16> {
-        self.calendar()
-            .days_in_month(&self.iso)
+        self.calendar().days_in_month(&self.iso)
     }
 
     pub fn get_months_in_year(&self) -> TemporalResult<u16> {
-        self.calendar()
-            .months_in_year(&self.iso)
+        self.calendar().months_in_year(&self.iso)
     }
 
     pub fn era(&self) -> TemporalResult<Option<TinyAsciiStr<16>>> {

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -7,9 +7,8 @@ use tinystr::TinyAsciiStr;
 
 use crate::{
     components::{
-        calendar::CalendarDateLike,
         duration::normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
-        timezone::{parse_offset, TzProvider},
+        timezone::{parse_offset, TimeZoneProvider},
         EpochNanoseconds,
     },
     iso::{IsoDate, IsoDateTime, IsoTime},
@@ -80,7 +79,7 @@ impl ZonedDateTime {
         &self,
         duration: &Duration,
         overflow: ArithmeticOverflow,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Instant> {
         // 1. If DateDurationSign(duration.[[Date]]) = 0, then
         if duration.date().sign() == Sign::Zero {
@@ -119,7 +118,7 @@ impl ZonedDateTime {
         &self,
         duration: &Duration,
         overflow: ArithmeticOverflow,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Self> {
         // 1. Let duration be ? ToTemporalDuration(temporalDurationLike).
         // 2. If operation is subtract, set duration to CreateNegatedTemporalDuration(duration).
@@ -143,7 +142,7 @@ impl ZonedDateTime {
         &self,
         other: &Self,
         resolved_options: ResolvedRoundingOptions,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<NormalizedDurationRecord> {
         // 1. If TemporalUnitCategory(largestUnit) is time, then
         if resolved_options.largest_unit.is_time_unit() {
@@ -177,7 +176,7 @@ impl ZonedDateTime {
         &self,
         other: &Self,
         largest_unit: TemporalUnit,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<NormalizedDurationRecord> {
         // 1. If ns1 = ns2, return CombineDateAndTimeDuration(ZeroDateDuration(), 0).
         if self.epoch_nanoseconds() == other.epoch_nanoseconds() {
@@ -282,7 +281,7 @@ impl ZonedDateTime {
         overflow: Option<ArithmeticOverflow>,
         disambiguation: Option<Disambiguation>,
         offset_option: Option<OffsetDisambiguation>,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Self> {
         let overflow = overflow.unwrap_or(ArithmeticOverflow::Constrain);
         let disambiguation = disambiguation.unwrap_or(Disambiguation::Compatible);
@@ -628,7 +627,7 @@ impl ZonedDateTime {
         self.hours_in_day_with_provider(&*provider)
     }
 
-    pub fn hours_in_day_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u8> {
+    pub fn hours_in_day_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u8> {
         // 1-3. Is engine specific steps
         // 4. Let isoDateTime be GetISODateTimeFor(timeZone, zonedDateTime.[[EpochNanoseconds]]).
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
@@ -654,68 +653,68 @@ impl ZonedDateTime {
 impl ZonedDateTime {
     /// Returns the `year` value for this `ZonedDateTime`.
     #[inline]
-    pub fn year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<i32> {
+    pub fn year_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<i32> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.year(&CalendarDateLike::DateTime(&dt))
+        self.calendar.year(&dt.iso.date)
     }
 
     /// Returns the `month` value for this `ZonedDateTime`.
-    pub fn month_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u8> {
+    pub fn month_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u8> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.month(&CalendarDateLike::DateTime(&dt))
+        self.calendar.month(&dt.iso.date)
     }
 
     /// Returns the `monthCode` value for this `ZonedDateTime`.
     pub fn month_code_with_provider(
         &self,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<TinyAsciiStr<4>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.month_code(&CalendarDateLike::DateTime(&dt))
+        self.calendar.month_code(&dt.iso.date)
     }
 
     /// Returns the `day` value for this `ZonedDateTime`.
-    pub fn day_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u8> {
+    pub fn day_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u8> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.day(&CalendarDateLike::DateTime(&dt))
+        self.calendar.day(&dt.iso.date)
     }
 
     /// Returns the `hour` value for this `ZonedDateTime`.
-    pub fn hour_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u8> {
+    pub fn hour_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u8> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(iso.time.hour)
     }
 
     /// Returns the `minute` value for this `ZonedDateTime`.
-    pub fn minute_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u8> {
+    pub fn minute_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u8> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(iso.time.minute)
     }
 
     /// Returns the `second` value for this `ZonedDateTime`.
-    pub fn second_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u8> {
+    pub fn second_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u8> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(iso.time.second)
     }
 
     /// Returns the `millisecond` value for this `ZonedDateTime`.
-    pub fn millisecond_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+    pub fn millisecond_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(iso.time.millisecond)
     }
 
     /// Returns the `microsecond` value for this `ZonedDateTime`.
-    pub fn microsecond_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+    pub fn microsecond_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(iso.time.millisecond)
     }
 
     /// Returns the `nanosecond` value for this `ZonedDateTime`.
-    pub fn nanosecond_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+    pub fn nanosecond_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(iso.time.nanosecond)
     }
@@ -726,96 +725,96 @@ impl ZonedDateTime {
 impl ZonedDateTime {
     pub fn era_with_provider(
         &self,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Option<TinyAsciiStr<16>>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.era(&CalendarDateLike::DateTime(&pdt))
+        self.calendar.era(&pdt.iso.date)
     }
 
     pub fn era_year_with_provider(
         &self,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Option<i32>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.era_year(&CalendarDateLike::DateTime(&pdt))
+        self.calendar.era_year(&pdt.iso.date)
     }
 
     /// Returns the calendar day of week value.
-    pub fn day_of_week_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+    pub fn day_of_week_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.day_of_week(&CalendarDateLike::DateTime(&pdt))
+        self.calendar.day_of_week(&pdt.iso.date)
     }
 
     /// Returns the calendar day of year value.
-    pub fn day_of_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+    pub fn day_of_year_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.day_of_year(&CalendarDateLike::DateTime(&pdt))
+        self.calendar.day_of_year(&pdt.iso.date)
     }
 
     /// Returns the calendar week of year value.
     pub fn week_of_year_with_provider(
         &self,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Option<u16>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar
-            .week_of_year(&CalendarDateLike::DateTime(&pdt))
+            .week_of_year(&pdt.iso.date)
     }
 
     /// Returns the calendar year of week value.
     pub fn year_of_week_with_provider(
         &self,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Option<i32>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar
-            .year_of_week(&CalendarDateLike::DateTime(&pdt))
+            .year_of_week(&pdt.iso.date)
     }
 
     /// Returns the calendar days in week value.
-    pub fn days_in_week_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+    pub fn days_in_week_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar
-            .days_in_week(&CalendarDateLike::DateTime(&pdt))
+            .days_in_week(&pdt.iso.date)
     }
 
     /// Returns the calendar days in month value.
-    pub fn days_in_month_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+    pub fn days_in_month_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar
-            .days_in_month(&CalendarDateLike::DateTime(&pdt))
+            .days_in_month(&pdt.iso.date)
     }
 
     /// Returns the calendar days in year value.
-    pub fn days_in_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+    pub fn days_in_year_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar
-            .days_in_year(&CalendarDateLike::DateTime(&pdt))
+            .days_in_year(&pdt.iso.date)
     }
 
     /// Returns the calendar months in year value.
-    pub fn months_in_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<u16> {
+    pub fn months_in_year_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar
-            .months_in_year(&CalendarDateLike::DateTime(&pdt))
+            .months_in_year(&pdt.iso.date)
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
-    pub fn in_leap_year_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<bool> {
+    pub fn in_leap_year_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<bool> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar
-            .in_leap_year(&CalendarDateLike::DateTime(&pdt))
+            .in_leap_year(&pdt.iso.date)
     }
 }
 
@@ -827,7 +826,7 @@ impl ZonedDateTime {
     pub fn with_plain_time_and_provider(
         &self,
         time: PlainTime,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Self> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let result_iso = IsoDateTime::new_unchecked(iso.date, time.iso);
@@ -842,7 +841,7 @@ impl ZonedDateTime {
         &self,
         duration: &Duration,
         overflow: Option<ArithmeticOverflow>,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Self> {
         self.add_internal(
             duration,
@@ -856,7 +855,7 @@ impl ZonedDateTime {
         &self,
         duration: &Duration,
         overflow: Option<ArithmeticOverflow>,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Self> {
         self.add_internal(
             &duration.negated(),
@@ -867,7 +866,7 @@ impl ZonedDateTime {
 
     /// Return a `ZonedDateTime` representing the start of the day
     /// for the current `ZonedDateTime`.
-    pub fn start_of_day_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<Self> {
+    pub fn start_of_day_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<Self> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let epoch_nanos = self.tz.get_start_of_day(&iso.date, provider)?;
         Self::try_new(epoch_nanos.0, self.calendar.clone(), self.tz.clone())
@@ -877,7 +876,7 @@ impl ZonedDateTime {
     /// a user defined time zone provider.
     pub fn to_plain_date_with_provider(
         &self,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<PlainDate> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(PlainDate::new_unchecked(iso.date, self.calendar.clone()))
@@ -887,7 +886,7 @@ impl ZonedDateTime {
     /// a user defined time zone provider.
     pub fn to_plain_time_with_provider(
         &self,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<PlainTime> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(PlainTime::new_unchecked(iso.time))
@@ -897,14 +896,14 @@ impl ZonedDateTime {
     /// a user defined time zone provider.
     pub fn to_plain_datetime_with_provider(
         &self,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<PlainDateTime> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(PlainDateTime::new_unchecked(iso, self.calendar.clone()))
     }
 
     /// Creates a default formatted IXDTF (RFC 9557) date/time string for the provided `ZonedDateTime`.
-    pub fn to_string_with_provider(&self, provider: &impl TzProvider) -> TemporalResult<String> {
+    pub fn to_string_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<String> {
         self.to_ixdtf_string_with_provider(
             DisplayOffset::Auto,
             DisplayTimeZone::Auto,
@@ -922,7 +921,7 @@ impl ZonedDateTime {
         display_timezone: DisplayTimeZone,
         display_calendar: DisplayCalendar,
         options: ToStringRoundingOptions,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<String> {
         let resolved_options = options.resolve()?;
         let result =
@@ -952,7 +951,7 @@ impl ZonedDateTime {
         source: &str,
         disambiguation: Disambiguation,
         offset_option: OffsetDisambiguation,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Self> {
         let parse_result = parsers::parse_date_time(source)?;
 
@@ -1052,7 +1051,7 @@ pub(crate) fn interpret_isodatetime_offset(
     disambiguation: Disambiguation,
     offset_option: OffsetDisambiguation,
     match_minutes: bool,
-    provider: &impl TzProvider,
+    provider: &impl TimeZoneProvider,
 ) -> TemporalResult<EpochNanoseconds> {
     // 1.  If time is start-of-day, then
     let Some(time) = time else {

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -627,7 +627,10 @@ impl ZonedDateTime {
         self.hours_in_day_with_provider(&*provider)
     }
 
-    pub fn hours_in_day_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u8> {
+    pub fn hours_in_day_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<u8> {
         // 1-3. Is engine specific steps
         // 4. Let isoDateTime be GetISODateTimeFor(timeZone, zonedDateTime.[[EpochNanoseconds]]).
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
@@ -702,19 +705,28 @@ impl ZonedDateTime {
     }
 
     /// Returns the `millisecond` value for this `ZonedDateTime`.
-    pub fn millisecond_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
+    pub fn millisecond_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(iso.time.millisecond)
     }
 
     /// Returns the `microsecond` value for this `ZonedDateTime`.
-    pub fn microsecond_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
+    pub fn microsecond_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(iso.time.millisecond)
     }
 
     /// Returns the `nanosecond` value for this `ZonedDateTime`.
-    pub fn nanosecond_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
+    pub fn nanosecond_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         Ok(iso.time.nanosecond)
     }
@@ -742,14 +754,20 @@ impl ZonedDateTime {
     }
 
     /// Returns the calendar day of week value.
-    pub fn day_of_week_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
+    pub fn day_of_week_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar.day_of_week(&pdt.iso.date)
     }
 
     /// Returns the calendar day of year value.
-    pub fn day_of_year_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
+    pub fn day_of_year_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar.day_of_year(&pdt.iso.date)
@@ -762,8 +780,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<Option<u16>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar
-            .week_of_year(&pdt.iso.date)
+        self.calendar.week_of_year(&pdt.iso.date)
     }
 
     /// Returns the calendar year of week value.
@@ -773,48 +790,57 @@ impl ZonedDateTime {
     ) -> TemporalResult<Option<i32>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar
-            .year_of_week(&pdt.iso.date)
+        self.calendar.year_of_week(&pdt.iso.date)
     }
 
     /// Returns the calendar days in week value.
-    pub fn days_in_week_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
+    pub fn days_in_week_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar
-            .days_in_week(&pdt.iso.date)
+        self.calendar.days_in_week(&pdt.iso.date)
     }
 
     /// Returns the calendar days in month value.
-    pub fn days_in_month_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
+    pub fn days_in_month_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar
-            .days_in_month(&pdt.iso.date)
+        self.calendar.days_in_month(&pdt.iso.date)
     }
 
     /// Returns the calendar days in year value.
-    pub fn days_in_year_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
+    pub fn days_in_year_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar
-            .days_in_year(&pdt.iso.date)
+        self.calendar.days_in_year(&pdt.iso.date)
     }
 
     /// Returns the calendar months in year value.
-    pub fn months_in_year_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u16> {
+    pub fn months_in_year_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar
-            .months_in_year(&pdt.iso.date)
+        self.calendar.months_in_year(&pdt.iso.date)
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
-    pub fn in_leap_year_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<bool> {
+    pub fn in_leap_year_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<bool> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar
-            .in_leap_year(&pdt.iso.date)
+        self.calendar.in_leap_year(&pdt.iso.date)
     }
 }
 
@@ -866,7 +892,10 @@ impl ZonedDateTime {
 
     /// Return a `ZonedDateTime` representing the start of the day
     /// for the current `ZonedDateTime`.
-    pub fn start_of_day_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<Self> {
+    pub fn start_of_day_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<Self> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let epoch_nanos = self.tz.get_start_of_day(&iso.date, provider)?;
         Self::try_new(epoch_nanos.0, self.calendar.clone(), self.tz.clone())
@@ -903,7 +932,10 @@ impl ZonedDateTime {
     }
 
     /// Creates a default formatted IXDTF (RFC 9557) date/time string for the provided `ZonedDateTime`.
-    pub fn to_string_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<String> {
+    pub fn to_string_with_provider(
+        &self,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<String> {
         self.to_ixdtf_string_with_provider(
             DisplayOffset::Auto,
             DisplayTimeZone::Auto,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,8 +94,8 @@ pub mod time {
 }
 
 pub use crate::components::{
-    calendar::Calendar, timezone::TimeZone, Duration, Instant, PlainDate, PlainDateTime,
-    PlainMonthDay, PlainTime, PlainYearMonth, ZonedDateTime,
+    calendar::Calendar, timezone::{TimeZone, TimeZoneProvider}, Duration, Instant, PlainDate, PlainDateTime,
+    PlainMonthDay, PlainTime, PlainYearMonth, ZonedDateTime, DateDuration, TimeDuration
 };
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,8 +94,10 @@ pub mod time {
 }
 
 pub use crate::components::{
-    calendar::Calendar, timezone::{TimeZone, TimeZoneProvider}, Duration, Instant, PlainDate, PlainDateTime,
-    PlainMonthDay, PlainTime, PlainYearMonth, ZonedDateTime, DateDuration, TimeDuration
+    calendar::Calendar,
+    timezone::{TimeZone, TimeZoneProvider},
+    DateDuration, Duration, Instant, PlainDate, PlainDateTime, PlainMonthDay, PlainTime,
+    PlainYearMonth, TimeDuration, ZonedDateTime,
 };
 
 #[cfg(feature = "std")]

--- a/src/options/relative_to.rs
+++ b/src/options/relative_to.rs
@@ -2,7 +2,7 @@
 
 use alloc::string::String;
 
-use crate::components::{timezone::TzProvider, zoneddatetime::interpret_isodatetime_offset};
+use crate::components::{timezone::TimeZoneProvider, zoneddatetime::interpret_isodatetime_offset};
 use crate::iso::{IsoDate, IsoTime};
 use crate::options::{ArithmeticOverflow, Disambiguation, OffsetDisambiguation};
 use crate::parsers::parse_date_time;
@@ -40,7 +40,7 @@ impl RelativeTo {
     /// is invalid, then an error is returned.
     pub fn try_from_str_with_provider(
         source: &str,
-        provider: &impl TzProvider,
+        provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Self> {
         let result = parse_date_time(source)?;
 

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -49,7 +49,7 @@ use tzif::{
 
 use crate::components::timezone::TimeZoneOffset;
 use crate::{
-    components::{timezone::TzProvider, EpochNanoseconds},
+    components::{timezone::TimeZoneProvider, EpochNanoseconds},
     iso::IsoDateTime,
     utils, TemporalError, TemporalResult,
 };
@@ -602,7 +602,7 @@ impl FsTzdbProvider {
     }
 }
 
-impl TzProvider for FsTzdbProvider {
+impl TimeZoneProvider for FsTzdbProvider {
     fn check_identifier(&self, identifier: &str) -> bool {
         self.get(identifier).is_ok()
     }
@@ -656,7 +656,7 @@ mod tests {
 
     use crate::{
         iso::IsoDateTime,
-        tzdb::{LocalTimeRecord, LocalTimeRecordResult, TzProvider},
+        tzdb::{LocalTimeRecord, LocalTimeRecordResult, TimeZoneProvider},
     };
 
     use super::{FsTzdbProvider, Tzif};


### PR DESCRIPTION
This PR addresses some issues brought up in #166.

The general updates are as follows:

  - `CalendarDateLike` removed in favor of using `IsoDate` directly.
  - `CalendarFieldsType` removed
  - `GetTemporalCalendar` removed
  - `DateDuration` and `TimeDuration` exported from root with the other builtins
  - `TzProvider` renamed to `TimeZoneProvider`