### PR TITLE
Implement `ZonedDateTime::since` and `ZonedDateTime::until`

### DIFF
--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -14,7 +14,11 @@ use crate::{
     components::{
         duration::{DateDuration, TimeDuration},
         Duration, PlainDate, PlainDateTime, PlainMonthDay, PlainYearMonth,
-    }, iso::IsoDate, options::{ArithmeticOverflow, TemporalUnit}, parsers::parse_allowed_calendar_formats, TemporalError, TemporalResult
+    },
+    iso::IsoDate,
+    options::{ArithmeticOverflow, TemporalUnit},
+    parsers::parse_allowed_calendar_formats,
+    TemporalError, TemporalResult,
 };
 
 use icu_calendar::{
@@ -200,7 +204,9 @@ impl FromStr for Calendar {
     // 13.34 ParseTemporalCalendarString ( string )
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some(s) = parse_allowed_calendar_formats(s) {
-            return s.map(Calendar::from_utf8).unwrap_or(Ok(Calendar::default()))
+            return s
+                .map(Calendar::from_utf8)
+                .unwrap_or(Ok(Calendar::default()));
         }
         Calendar::from_utf8(s.as_bytes())
     }

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -14,10 +14,7 @@ use crate::{
     components::{
         duration::{DateDuration, TimeDuration},
         Duration, PlainDate, PlainDateTime, PlainMonthDay, PlainYearMonth,
-    },
-    iso::IsoDate,
-    options::{ArithmeticOverflow, TemporalUnit},
-    TemporalError, TemporalResult,
+    }, iso::IsoDate, options::{ArithmeticOverflow, TemporalUnit}, parsers::parse_allowed_calendar_formats, TemporalError, TemporalResult
 };
 
 use icu_calendar::{
@@ -200,8 +197,11 @@ impl Calendar {
 impl FromStr for Calendar {
     type Err = TemporalError;
 
-    // 13.39 ParseTemporalCalendarString ( string )
+    // 13.34 ParseTemporalCalendarString ( string )
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(s) = parse_allowed_calendar_formats(s) {
+            return s.map(Calendar::from_utf8).unwrap_or(Ok(Calendar::default()))
+        }
         Calendar::from_utf8(s.as_bytes())
     }
 }

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -5,11 +5,11 @@ use crate::{
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, DisplayCalendar,
-        ResolvedRoundingOptions, TemporalUnit,
+        ResolvedRoundingOptions, TemporalUnit, UnitGroup,
     },
     parsers::{parse_date_time, IxdtfStringBuilder},
     primitive::FiniteF64,
-    Sign, TemporalError, TemporalResult, TemporalUnwrap, TimeZone,
+    TemporalError, TemporalResult, TemporalUnwrap, TimeZone,
 };
 use alloc::{format, string::String};
 use core::str::FromStr;
@@ -260,9 +260,10 @@ impl PlainDate {
 
         // 4. Let resolvedOptions be ? SnapshotOwnProperties(? GetOptionsObject(options), null).
         // 5. Let settings be ? GetDifferenceSettings(operation, resolvedOptions, DATE, « », "day", "day").
-        let (sign, resolved) = ResolvedRoundingOptions::from_diff_settings(
+        let resolved = ResolvedRoundingOptions::from_diff_settings(
             settings,
             op,
+            UnitGroup::Date,
             TemporalUnit::Day,
             TemporalUnit::Day,
         )?;
@@ -303,9 +304,9 @@ impl PlainDate {
         }
         let result = Duration::from_normalized(duration, TemporalUnit::Day)?;
         // 13. Return ! CreateTemporalDuration(sign × duration.[[Years]], sign × duration.[[Months]], sign × duration.[[Weeks]], sign × duration.[[Days]], 0, 0, 0, 0, 0, 0).
-        match sign {
-            Sign::Positive | Sign::Zero => Ok(result),
-            Sign::Negative => Ok(result.negated()),
+        match op {
+            DifferenceOperation::Until => Ok(result),
+            DifferenceOperation::Since => Ok(result.negated()),
         }
     }
 }

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -5,10 +5,10 @@ use crate::{
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, DisplayCalendar,
-        ResolvedRoundingOptions, RoundingOptions, TemporalUnit, ToStringRoundingOptions,
+        ResolvedRoundingOptions, RoundingOptions, TemporalUnit, ToStringRoundingOptions, UnitGroup,
     },
     parsers::{parse_date_time, IxdtfStringBuilder},
-    temporal_assert, Sign, TemporalError, TemporalResult, TemporalUnwrap, TimeZone,
+    temporal_assert, TemporalError, TemporalResult, TemporalUnwrap, TimeZone,
 };
 use alloc::string::String;
 use core::{cmp::Ordering, str::FromStr};
@@ -131,9 +131,10 @@ impl PlainDateTime {
         }
 
         // 5. Let settings be ? GetDifferenceSettings(operation, resolvedOptions, datetime, « », "nanosecond", "day").
-        let (sign, options) = ResolvedRoundingOptions::from_diff_settings(
+        let options = ResolvedRoundingOptions::from_diff_settings(
             settings,
             op,
+            UnitGroup::DateTime,
             TemporalUnit::Day,
             TemporalUnit::Nanosecond,
         )?;
@@ -149,9 +150,9 @@ impl PlainDateTime {
         let result = Duration::from_normalized(norm_record, options.largest_unit)?;
 
         // Step 12
-        match sign {
-            Sign::Positive | Sign::Zero => Ok(result),
-            Sign::Negative => Ok(result.negated()),
+        match op {
+            DifferenceOperation::Until => Ok(result),
+            DifferenceOperation::Since => Ok(result.negated()),
         }
     }
 

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -256,8 +256,9 @@ impl NormalizedDurationRecord {
     /// Equivalent: `CreateNormalizedDurationRecord` & `CombineDateAndNormalizedTimeDuration`.
     pub(crate) fn new(date: DateDuration, norm: NormalizedTimeDuration) -> TemporalResult<Self> {
         if date.sign() != Sign::Zero && norm.sign() != Sign::Zero && date.sign() != norm.sign() {
-            return Err(TemporalError::range()
-                .with_message("DateDuration and NormalizedTimeDuration must agree if both are not zero."));
+            return Err(TemporalError::range().with_message(
+                "DateDuration and NormalizedTimeDuration must agree if both are not zero.",
+            ));
         }
         Ok(Self { date, norm })
     }

--- a/src/components/duration/normalized.rs
+++ b/src/components/duration/normalized.rs
@@ -257,7 +257,7 @@ impl NormalizedDurationRecord {
     pub(crate) fn new(date: DateDuration, norm: NormalizedTimeDuration) -> TemporalResult<Self> {
         if date.sign() != Sign::Zero && norm.sign() != Sign::Zero && date.sign() != norm.sign() {
             return Err(TemporalError::range()
-                .with_message("DateDuration and NormalizedTimeDuration must agree."));
+                .with_message("DateDuration and NormalizedTimeDuration must agree if both are not zero."));
         }
         Ok(Self { date, norm })
     }
@@ -778,18 +778,18 @@ impl NormalizedDurationRecord {
         // 4. Let largestUnitIndex be the ordinal index of the row of Table 22 whose "Singular" column contains largestUnit.
         // 5. Let smallestUnitIndex be the ordinal index of the row of Table 22 whose "Singular" column contains smallestUnit.
         // 6. Let unitIndex be smallestUnitIndex - 1.
-        let mut unit = smallest_unit + 1;
+        let mut smallest_unit = smallest_unit + 1;
         // 7. Let done be false.
         // 8. Repeat, while unitIndex ≤ largestUnitIndex and done is false,
-        while unit != TemporalUnit::Auto && unit <= largest_unit {
+        while smallest_unit != TemporalUnit::Auto && largest_unit < smallest_unit {
             // a. Let unit be the value in the "Singular" column of Table 22 in the row whose ordinal index is unitIndex.
             // b. If unit is not "week", or largestUnit is "week", then
-            if unit == TemporalUnit::Week || largest_unit != TemporalUnit::Week {
-                unit = unit + 1;
+            if smallest_unit == TemporalUnit::Week || largest_unit != TemporalUnit::Week {
+                smallest_unit = smallest_unit + 1;
                 continue;
             }
 
-            let end_duration = match unit {
+            let end_duration = match smallest_unit {
                 // i. If unit is "year", then
                 TemporalUnit::Year => {
                     // 1. Let years be duration.[[Years]] + sign.
@@ -887,7 +887,7 @@ impl NormalizedDurationRecord {
                 break;
             }
             // c. Set unitIndex to unitIndex - 1.
-            unit = unit + 1;
+            smallest_unit = smallest_unit + 1;
         }
 
         Ok(duration)

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -23,7 +23,8 @@ use num_traits::FromPrimitive;
 
 use super::{
     duration::normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
-    timezone::TimeZoneProvider, DateDuration,
+    timezone::TimeZoneProvider,
+    DateDuration,
 };
 
 const NANOSECONDS_PER_SECOND: i128 = 1_000_000_000;
@@ -99,7 +100,10 @@ impl Instant {
         let diff =
             NormalizedTimeDuration::from_nanosecond_difference(other.as_i128(), self.as_i128())?;
         let (round_record, _) = diff.round(FiniteF64::default(), resolved_options)?;
-        NormalizedDurationRecord::new(DateDuration::default(), round_record.normalized_time_duration())
+        NormalizedDurationRecord::new(
+            DateDuration::default(),
+            round_record.normalized_time_duration(),
+        )
     }
 
     // TODO: Add test for `diff_instant`.

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -5,11 +5,11 @@ use crate::{
     iso::IsoTime,
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions,
-        RoundingIncrement, TemporalRoundingMode, TemporalUnit, ToStringRoundingOptions,
+        RoundingIncrement, TemporalRoundingMode, TemporalUnit, ToStringRoundingOptions, UnitGroup,
     },
     parsers::{parse_time, IxdtfStringBuilder},
     primitive::FiniteF64,
-    Sign, TemporalError, TemporalResult,
+    TemporalError, TemporalResult,
 };
 use alloc::string::String;
 use core::str::FromStr;
@@ -124,9 +124,10 @@ impl PlainTime {
         // 2. Set other to ? ToTemporalTime(other).
         // 3. Let resolvedOptions be ? SnapshotOwnProperties(? GetOptionsObject(options), null).
         // 4. Let settings be ? GetDifferenceSettings(operation, resolvedOptions, TIME, « », "nanosecond", "hour").
-        let (sign, resolved) = ResolvedRoundingOptions::from_diff_settings(
+        let resolved = ResolvedRoundingOptions::from_diff_settings(
             settings,
             op,
+            UnitGroup::Time,
             TemporalUnit::Hour,
             TemporalUnit::Nanosecond,
         )?;
@@ -151,9 +152,9 @@ impl PlainTime {
         let result = TimeDuration::from_normalized(normalized_time, resolved.largest_unit)?.1;
 
         // 8. Return ! CreateTemporalDuration(0, 0, 0, 0, sign × result.[[Hours]], sign × result.[[Minutes]], sign × result.[[Seconds]], sign × result.[[Milliseconds]], sign × result.[[Microseconds]], sign × result.[[Nanoseconds]]).
-        match sign {
-            Sign::Positive | Sign::Zero => Ok(Duration::from(result)),
-            Sign::Negative => Ok(Duration::from(result.negated())),
+        match op {
+            DifferenceOperation::Until => Ok(Duration::from(result)),
+            DifferenceOperation::Since => Ok(Duration::from(result.negated())),
         }
     }
 }

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -13,9 +13,7 @@ use crate::{
     },
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::{
-        ArithmeticOverflow, Disambiguation, DisplayCalendar, DisplayOffset, DisplayTimeZone,
-        OffsetDisambiguation, ResolvedRoundingOptions, RoundingIncrement, TemporalRoundingMode,
-        TemporalUnit, ToStringRoundingOptions,
+        ArithmeticOverflow, DifferenceOperation, DifferenceSettings, Disambiguation, DisplayCalendar, DisplayOffset, DisplayTimeZone, OffsetDisambiguation, ResolvedRoundingOptions, RoundingIncrement, TemporalRoundingMode, TemporalUnit, ToStringRoundingOptions, UnitGroup
     },
     parsers::{self, IxdtfStringBuilder},
     partial::{PartialDate, PartialTime},
@@ -248,6 +246,59 @@ impl ZonedDateTime {
             self.calendar()
                 .date_until(&start.date, &intermediate_dt.date, date_largest)?;
         NormalizedDurationRecord::new(*date_diff.date(), time_duration)
+    }
+
+    /// `temporal_rs` equivalent to `DifferenceTemporalZonedDateTime`.
+    pub(crate) fn diff_internal_with_provider(&self, op: DifferenceOperation, other: &Self, options: DifferenceSettings, provider: &impl TimeZoneProvider) -> TemporalResult<Duration> {
+        // NOTE: for order of operations, this should be asserted prior to this point
+        // by implementors any engine implementors, but asserting out of caution.
+        if self.calendar != other.calendar {
+            return Err(TemporalError::range()
+                .with_message("Calendar must be the same when diffing two ZonedDateTimes"));
+        }
+
+        // 4. Set settings be ? GetDifferenceSettings(operation, resolvedOptions, datetime, « », nanosecond, hour).
+        let resolved_options = ResolvedRoundingOptions::from_diff_settings(options, op, UnitGroup::DateTime, TemporalUnit::Hour, TemporalUnit::Nanosecond)?;
+
+        // 5. If TemporalUnitCategory(settings.[[LargestUnit]]) is time, then
+        if resolved_options.largest_unit.is_time_unit() {
+            // a. Let internalDuration be DifferenceInstant(zonedDateTime.[[EpochNanoseconds]], other.[[EpochNanoseconds]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
+            let internal = self.instant.diff_instant_internal(&other.instant, resolved_options)?;
+            // b. Let result be ! TemporalDurationFromInternal(internalDuration, settings.[[LargestUnit]]).
+            let result = Duration::from_normalized(internal, resolved_options.largest_unit)?;
+            // c. If operation is since, set result to CreateNegatedTemporalDuration(result).
+            // d. Return result.
+            match op {
+                DifferenceOperation::Since => return Ok(result.negated()),
+                DifferenceOperation::Until => return Ok(result),
+            }
+        }
+
+        // 6. NOTE: To calculate differences in two different time zones,
+        // settings.[[LargestUnit]] must be a time unit, because day lengths
+        // can vary between time zones due to DST and other UTC offset shifts.
+        // 7. If TimeZoneEquals(zonedDateTime.[[TimeZone]], other.[[TimeZone]]) is false, then
+        if self.tz == other.tz {
+            // a. Throw a RangeError exception.
+            return Err(TemporalError::range().with_message("Time zones cannot be different if unit is a date unit."))
+        }
+
+        // 8. If zonedDateTime.[[EpochNanoseconds]] = other.[[EpochNanoseconds]], then
+        if self.instant == other.instant {
+            // a. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
+            return Ok(Duration::default())
+        }
+
+        // 9. Let internalDuration be ? DifferenceZonedDateTimeWithRounding(zonedDateTime.[[EpochNanoseconds]], other.[[EpochNanoseconds]], zonedDateTime.[[TimeZone]], zonedDateTime.[[Calendar]], settings.[[LargestUnit]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
+        let internal = self.diff_with_rounding(other, resolved_options, provider)?;
+        // 10. Let result be ! TemporalDurationFromInternal(internalDuration, hour).
+        let result = Duration::from_normalized(internal, resolved_options.largest_unit)?;
+        // 11. If operation is since, set result to CreateNegatedTemporalDuration(result).
+        // 12. Return result.
+        match op {
+            DifferenceOperation::Since => return Ok(result.negated()),
+            DifferenceOperation::Until => return Ok(result),
+        }
     }
 }
 
@@ -888,6 +939,26 @@ impl ZonedDateTime {
             overflow.unwrap_or(ArithmeticOverflow::Constrain),
             provider,
         )
+    }
+
+    /// Returns a [`Duration`] representing the period of time from this `ZonedDateTime` since the other `ZonedDateTime`.
+    pub fn since_with_provider(
+        &self,
+        other: &Self,
+        options: DifferenceSettings,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<Duration> {
+        self.diff_internal_with_provider(DifferenceOperation::Since, other, options, provider)
+    }
+
+    /// Returns a [`Duration`] representing the period of time from this `ZonedDateTime` since the other `ZonedDateTime`.
+    pub fn until_with_provider(
+        &self,
+        other: &Self,
+        options: DifferenceSettings,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<Duration> {
+        self.diff_internal_with_provider(DifferenceOperation::Until, other, options, provider)
     }
 
     /// Return a `ZonedDateTime` representing the start of the day

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -1496,7 +1496,7 @@ mod tests {
             .until(
                 &midnight_disambiguated.instant,
                 DifferenceSettings {
-                    largest_unit: Some(TemporalUnit::Year),
+                    largest_unit: Some(TemporalUnit::Hour),
                     smallest_unit: Some(TemporalUnit::Nanosecond),
                     ..Default::default()
                 },

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -261,7 +261,7 @@ impl ZonedDateTime {
         provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Duration> {
         // NOTE: for order of operations, this should be asserted prior to this point
-        // by implementors any engine implementors, but asserting out of caution.
+        // by any engine implementors, but asserting out of caution.
         if self.calendar != other.calendar {
             return Err(TemporalError::range()
                 .with_message("Calendar must be the same when diffing two ZonedDateTimes"));

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -10,12 +10,19 @@ use crate::{
         duration::normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
         timezone::{parse_offset, TimeZoneProvider},
         EpochNanoseconds,
-    }, iso::{IsoDate, IsoDateTime, IsoTime}, options::{
+    },
+    iso::{IsoDate, IsoDateTime, IsoTime},
+    options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, Disambiguation,
         DisplayCalendar, DisplayOffset, DisplayTimeZone, OffsetDisambiguation,
         ResolvedRoundingOptions, RoundingIncrement, TemporalRoundingMode, TemporalUnit,
         ToStringRoundingOptions, UnitGroup,
-    }, parsers::{self, IxdtfStringBuilder}, partial::{PartialDate, PartialTime}, rounding::{IncrementRounder, Round}, temporal_assert, Calendar, Duration, Instant, PlainDate, PlainDateTime, PlainTime, Sign, TemporalError, TemporalResult, TimeZone
+    },
+    parsers::{self, IxdtfStringBuilder},
+    partial::{PartialDate, PartialTime},
+    rounding::{IncrementRounder, Round},
+    temporal_assert, Calendar, Duration, Instant, PlainDate, PlainDateTime, PlainTime, Sign,
+    TemporalError, TemporalResult, TimeZone,
 };
 
 #[cfg(feature = "experimental")]
@@ -308,8 +315,8 @@ impl ZonedDateTime {
         // 11. If operation is since, set result to CreateNegatedTemporalDuration(result).
         // 12. Return result.
         match op {
-            DifferenceOperation::Since => return Ok(result.negated()),
-            DifferenceOperation::Until => return Ok(result),
+            DifferenceOperation::Since => Ok(result.negated()),
+            DifferenceOperation::Until => Ok(result),
         }
     }
 }

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -929,8 +929,8 @@ fn utc_epoch_nanos(date: IsoDate, time: &IsoTime) -> TemporalResult<EpochNanosec
 #[inline]
 fn to_unchecked_epoch_nanoseconds(date: IsoDate, time: &IsoTime) -> i128 {
     let ms = time.to_epoch_ms();
-    let epoch_ms = utils::epoch_days_to_epoch_ms(date.to_epoch_days(), ms) as i128;
-    epoch_ms * 1_000_000 + time.microsecond as i128 * 1_000 + time.nanosecond as i128
+    let epoch_ms = utils::epoch_days_to_epoch_ms(date.to_epoch_days(), ms);
+    (epoch_ms * 1_000_000.0) as i128 + time.microsecond as i128 * 1_000 + time.nanosecond as i128
 }
 
 // ==== `IsoDate` specific utiltiy functions ====

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -465,6 +465,11 @@ impl IsoDate {
                     i32::from(intermediate.1) + i32::from(sign),
                 );
             }
+
+            if largest_unit == TemporalUnit::Month {
+                months += years * 12;
+                years = 0;
+            }
         }
 
         // 9. Set intermediate to BalanceISOYearMonth(y1 + years, m1 + months).
@@ -924,13 +929,8 @@ fn utc_epoch_nanos(date: IsoDate, time: &IsoTime) -> TemporalResult<EpochNanosec
 #[inline]
 fn to_unchecked_epoch_nanoseconds(date: IsoDate, time: &IsoTime) -> i128 {
     let ms = time.to_epoch_ms();
-    let epoch_ms = utils::epoch_days_to_epoch_ms(date.to_epoch_days(), ms);
-
-    let epoch_nanos = epoch_ms.mul_add(
-        1_000_000f64,
-        f64::from(time.microsecond).mul_add(1_000f64, f64::from(time.nanosecond)),
-    );
-    epoch_nanos as i128
+    let epoch_ms = utils::epoch_days_to_epoch_ms(date.to_epoch_days(), ms) as i128;
+    epoch_ms * 1_000_000 + time.microsecond as i128 * 1_000 + time.nanosecond as i128
 }
 
 // ==== `IsoDate` specific utiltiy functions ====

--- a/src/options.rs
+++ b/src/options.rs
@@ -182,24 +182,24 @@ impl ResolvedRoundingOptions {
         fallback_smallest: TemporalUnit,
     ) -> TemporalResult<Self> {
         // 4. Let resolvedOptions be ? SnapshotOwnProperties(? GetOptionsObject(options), null).
-        let largest_unit = options.largest_unit.map(|unit|{
-            unit.assert_unit_group(unit_group)
-        }).transpose()?;
+        let largest_unit = options
+            .largest_unit
+            .map(|unit| unit.assert_unit_group(unit_group))
+            .transpose()?;
         // 5. Let settings be ? GetDifferenceSettings(operation, resolvedOptions, DATE, « », "day", "day").
         let increment = options.increment.unwrap_or_default();
         let rounding_mode = match operation {
-            DifferenceOperation::Since => {
-                options
-                    .rounding_mode
-                    .unwrap_or(TemporalRoundingMode::Trunc)
-                    .negate()
+            DifferenceOperation::Since => options
+                .rounding_mode
+                .unwrap_or(TemporalRoundingMode::Trunc)
+                .negate(),
+            DifferenceOperation::Until => {
+                options.rounding_mode.unwrap_or(TemporalRoundingMode::Trunc)
             }
-            DifferenceOperation::Until => options.rounding_mode.unwrap_or(TemporalRoundingMode::Trunc),
         };
         let smallest_unit = options.smallest_unit.unwrap_or(fallback_smallest);
         // Use the defaultlargestunit which is max smallestlargestdefault and smallestunit
-        let largest_unit = largest_unit
-            .unwrap_or(smallest_unit.max(fallback_largest));
+        let largest_unit = largest_unit.unwrap_or(smallest_unit.max(fallback_largest));
 
         // 11. If LargerOfTwoTemporalUnits(largestUnit, smallestUnit) is not largestUnit, throw a RangeError exception.
         // 12. Let maximum be MaximumTemporalDurationRoundingIncrement(smallestUnit).
@@ -446,8 +446,12 @@ impl TemporalUnit {
     #[inline]
     pub fn assert_unit_group(self, group: UnitGroup) -> TemporalResult<Self> {
         match group {
-            UnitGroup::Date if !self.is_calendar_unit() || self != TemporalUnit::Day => Err(TemporalError::range().with_message("Unit must be a date unit.")),
-            UnitGroup::Time if !self.is_time_unit() => Err(TemporalError::range().with_message("Unit must be a time unit.")),
+            UnitGroup::Date if !self.is_calendar_unit() || self != TemporalUnit::Day => {
+                Err(TemporalError::range().with_message("Unit must be a date unit."))
+            }
+            UnitGroup::Time if !self.is_time_unit() => {
+                Err(TemporalError::range().with_message("Unit must be a time unit."))
+            }
             _ => Ok(self),
         }
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,7 +4,7 @@
 //! operation may be completed.
 
 use crate::parsers::Precision;
-use crate::{Sign, TemporalError, TemporalResult, MS_PER_DAY, NS_PER_DAY};
+use crate::{TemporalError, TemporalResult, MS_PER_DAY, NS_PER_DAY};
 use core::ops::Add;
 use core::{fmt, str::FromStr};
 
@@ -177,29 +177,28 @@ impl ResolvedRoundingOptions {
     pub(crate) fn from_diff_settings(
         options: DifferenceSettings,
         operation: DifferenceOperation,
+        unit_group: UnitGroup,
         fallback_largest: TemporalUnit,
         fallback_smallest: TemporalUnit,
-    ) -> TemporalResult<(Sign, Self)> {
+    ) -> TemporalResult<Self> {
         // 4. Let resolvedOptions be ? SnapshotOwnProperties(? GetOptionsObject(options), null).
+        let largest_unit = options.largest_unit.map(|unit|{
+            unit.assert_unit_group(unit_group)
+        }).transpose()?;
         // 5. Let settings be ? GetDifferenceSettings(operation, resolvedOptions, DATE, « », "day", "day").
         let increment = options.increment.unwrap_or_default();
-        let (sign, rounding_mode) = match operation {
+        let rounding_mode = match operation {
             DifferenceOperation::Since => {
-                let mode = options
+                options
                     .rounding_mode
                     .unwrap_or(TemporalRoundingMode::Trunc)
-                    .negate();
-                (Sign::Negative, mode)
+                    .negate()
             }
-            DifferenceOperation::Until => (
-                Sign::Positive,
-                options.rounding_mode.unwrap_or(TemporalRoundingMode::Trunc),
-            ),
+            DifferenceOperation::Until => options.rounding_mode.unwrap_or(TemporalRoundingMode::Trunc),
         };
         let smallest_unit = options.smallest_unit.unwrap_or(fallback_smallest);
         // Use the defaultlargestunit which is max smallestlargestdefault and smallestunit
-        let largest_unit = options
-            .largest_unit
+        let largest_unit = largest_unit
             .unwrap_or(smallest_unit.max(fallback_largest));
 
         // 11. If LargerOfTwoTemporalUnits(largestUnit, smallestUnit) is not largestUnit, throw a RangeError exception.
@@ -223,7 +222,7 @@ impl ResolvedRoundingOptions {
             rounding_mode,
         };
 
-        Ok((sign, resolved))
+        Ok(resolved)
     }
 
     pub(crate) fn from_duration_options(
@@ -345,6 +344,12 @@ impl ResolvedRoundingOptions {
 
 // ==== Options enums and methods ====
 
+pub enum UnitGroup {
+    Date,
+    Time,
+    DateTime,
+}
+
 /// The relevant unit that should be used for the operation that
 /// this option is provided as a value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -436,6 +441,15 @@ impl TemporalUnit {
             self,
             Hour | Minute | Second | Millisecond | Microsecond | Nanosecond
         )
+    }
+
+    #[inline]
+    pub fn assert_unit_group(self, group: UnitGroup) -> TemporalResult<Self> {
+        match group {
+            UnitGroup::Date if !self.is_calendar_unit() || self != TemporalUnit::Day => Err(TemporalError::range().with_message("Unit must be a date unit.")),
+            UnitGroup::Time if !self.is_time_unit() => Err(TemporalError::range().with_message("Unit must be a time unit.")),
+            _ => Ok(self),
+        }
     }
 }
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -766,6 +766,21 @@ pub(crate) fn parse_time(source: &str) -> TemporalResult<TimeRecord> {
     }
 }
 
+#[inline]
+pub(crate) fn parse_allowed_calendar_formats<'a>(s: &'a str) -> Option<Option<&'a [u8]>> {
+    if let Some(r) = parse_ixdtf(s, ParseVariant::DateTime).map(|r| r.calendar).ok() {
+        return Some(r);
+    } else if let Some(r) = IxdtfParser::from_str(s).parse_time().map(|r| r.calendar).ok() {
+        return Some(r);
+    } else if let Some(r) = parse_ixdtf(s, ParseVariant::YearMonth).map(|r| r.calendar).ok() {
+        return Some(r);
+    } else if let Some(r) = parse_ixdtf(s, ParseVariant::MonthDay).map(|r| r.calendar).ok() {
+        return Some(r);
+    }
+    Some(None)
+}
+
+
 // TODO: ParseTimeZoneString, ParseZonedDateTimeString
 
 #[cfg(test)]

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -767,19 +767,18 @@ pub(crate) fn parse_time(source: &str) -> TemporalResult<TimeRecord> {
 }
 
 #[inline]
-pub(crate) fn parse_allowed_calendar_formats<'a>(s: &'a str) -> Option<Option<&'a [u8]>> {
-    if let Some(r) = parse_ixdtf(s, ParseVariant::DateTime).map(|r| r.calendar).ok() {
+pub(crate) fn parse_allowed_calendar_formats(s: &str) -> Option<Option<&[u8]>> {
+    if let Ok(r) = parse_ixdtf(s, ParseVariant::DateTime).map(|r| r.calendar) {
         return Some(r);
-    } else if let Some(r) = IxdtfParser::from_str(s).parse_time().map(|r| r.calendar).ok() {
+    } else if let Ok(r) = IxdtfParser::from_str(s).parse_time().map(|r| r.calendar) {
         return Some(r);
-    } else if let Some(r) = parse_ixdtf(s, ParseVariant::YearMonth).map(|r| r.calendar).ok() {
+    } else if let Ok(r) = parse_ixdtf(s, ParseVariant::YearMonth).map(|r| r.calendar) {
         return Some(r);
-    } else if let Some(r) = parse_ixdtf(s, ParseVariant::MonthDay).map(|r| r.calendar).ok() {
+    } else if let Ok(r) = parse_ixdtf(s, ParseVariant::MonthDay).map(|r| r.calendar) {
         return Some(r);
     }
     Some(None)
 }
-
 
 // TODO: ParseTimeZoneString, ParseZonedDateTimeString
 

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -56,7 +56,11 @@ impl FiniteF64 {
     }
 
     pub fn copysign(&self, other: f64) -> Self {
-        Self(self.0.copysign(other))
+        if !self.is_zero() {
+            Self(self.0.copysign(other))
+        } else {
+            *self
+        }
     }
 
     pub(crate) fn as_date_value(&self) -> TemporalResult<i32> {


### PR DESCRIPTION
This PR implements the `since` and `until` methods for `ZonedDateTime`.

It also has a host of various bug fixes that I came across from implementing the methods in Boa and running the test suite. As a result, each method has a ~80% conformance rating (since 72/90 and until 70/88).