### PR TITLE
Remove `UnitGroup` addition

### DIFF
--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -183,17 +183,6 @@ impl Calendar {
         Self(Ref(cal))
     }
 
-    /// A less strict `from_str` implementation that will take any valid IXDTF format
-    /// or calendar identifier.
-    pub fn from_temporal_str(s: &str) -> TemporalResult<Self> {
-        if let Some(s) = parse_allowed_calendar_formats(s) {
-            return s
-                .map(Calendar::from_utf8)
-                .unwrap_or(Ok(Calendar::default()));
-        }
-        Calendar::from_utf8(s.as_bytes())
-    }
-
     /// Returns a `Calendar`` from the a slice of UTF-8 encoded bytes.
     pub fn from_utf8(bytes: &[u8]) -> TemporalResult<Self> {
         // NOTE(nekesss): Catch the iso identifier here, as `iso8601` is not a valid ID below.
@@ -214,6 +203,11 @@ impl FromStr for Calendar {
 
     // 13.34 ParseTemporalCalendarString ( string )
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(s) = parse_allowed_calendar_formats(s) {
+            return s
+                .map(Calendar::from_utf8)
+                .unwrap_or(Ok(Calendar::default()));
+        }
         Calendar::from_utf8(s.as_bytes())
     }
 }

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -183,6 +183,17 @@ impl Calendar {
         Self(Ref(cal))
     }
 
+    /// A less strict `from_str` implementation that will take any valid IXDTF format
+    /// or calendar identifier.
+    pub fn from_temporal_str(s: &str) -> TemporalResult<Self> {
+        if let Some(s) = parse_allowed_calendar_formats(s) {
+            return s
+                .map(Calendar::from_utf8)
+                .unwrap_or(Ok(Calendar::default()));
+        }
+        Calendar::from_utf8(s.as_bytes())
+    }
+
     /// Returns a `Calendar`` from the a slice of UTF-8 encoded bytes.
     pub fn from_utf8(bytes: &[u8]) -> TemporalResult<Self> {
         // NOTE(nekesss): Catch the iso identifier here, as `iso8601` is not a valid ID below.
@@ -203,11 +214,6 @@ impl FromStr for Calendar {
 
     // 13.34 ParseTemporalCalendarString ( string )
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some(s) = parse_allowed_calendar_formats(s) {
-            return s
-                .map(Calendar::from_utf8)
-                .unwrap_or(Ok(Calendar::default()));
-        }
         Calendar::from_utf8(s.as_bytes())
     }
 }

--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -5,7 +5,7 @@ use crate::{
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, DisplayCalendar,
-        ResolvedRoundingOptions, TemporalUnit, UnitGroup,
+        ResolvedRoundingOptions, TemporalUnit,
     },
     parsers::{parse_date_time, IxdtfStringBuilder},
     primitive::FiniteF64,
@@ -263,7 +263,6 @@ impl PlainDate {
         let resolved = ResolvedRoundingOptions::from_diff_settings(
             settings,
             op,
-            UnitGroup::Date,
             TemporalUnit::Day,
             TemporalUnit::Day,
         )?;

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -5,7 +5,7 @@ use crate::{
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, DisplayCalendar,
-        ResolvedRoundingOptions, RoundingOptions, TemporalUnit, ToStringRoundingOptions, UnitGroup,
+        ResolvedRoundingOptions, RoundingOptions, TemporalUnit, ToStringRoundingOptions,
     },
     parsers::{parse_date_time, IxdtfStringBuilder},
     temporal_assert, TemporalError, TemporalResult, TemporalUnwrap, TimeZone,
@@ -134,7 +134,6 @@ impl PlainDateTime {
         let options = ResolvedRoundingOptions::from_diff_settings(
             settings,
             op,
-            UnitGroup::DateTime,
             TemporalUnit::Day,
             TemporalUnit::Nanosecond,
         )?;

--- a/src/components/instant.rs
+++ b/src/components/instant.rs
@@ -10,7 +10,7 @@ use crate::{
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, DisplayOffset,
-        ResolvedRoundingOptions, RoundingOptions, TemporalUnit, ToStringRoundingOptions, UnitGroup,
+        ResolvedRoundingOptions, RoundingOptions, TemporalUnit, ToStringRoundingOptions,
     },
     parsers::{parse_instant, IxdtfStringBuilder},
     primitive::FiniteF64,
@@ -123,7 +123,6 @@ impl Instant {
         let resolved_options = ResolvedRoundingOptions::from_diff_settings(
             options,
             op,
-            UnitGroup::Time,
             TemporalUnit::Second,
             TemporalUnit::Nanosecond,
         )?;

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -5,7 +5,7 @@ use crate::{
     iso::IsoTime,
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions,
-        RoundingIncrement, TemporalRoundingMode, TemporalUnit, ToStringRoundingOptions, UnitGroup,
+        RoundingIncrement, TemporalRoundingMode, TemporalUnit, ToStringRoundingOptions,
     },
     parsers::{parse_time, IxdtfStringBuilder},
     primitive::FiniteF64,
@@ -127,7 +127,6 @@ impl PlainTime {
         let resolved = ResolvedRoundingOptions::from_diff_settings(
             settings,
             op,
-            UnitGroup::Time,
             TemporalUnit::Hour,
             TemporalUnit::Nanosecond,
         )?;

--- a/src/components/zoneddatetime.rs
+++ b/src/components/zoneddatetime.rs
@@ -16,7 +16,7 @@ use crate::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, Disambiguation,
         DisplayCalendar, DisplayOffset, DisplayTimeZone, OffsetDisambiguation,
         ResolvedRoundingOptions, RoundingIncrement, TemporalRoundingMode, TemporalUnit,
-        ToStringRoundingOptions, UnitGroup,
+        ToStringRoundingOptions,
     },
     parsers::{self, IxdtfStringBuilder},
     partial::{PartialDate, PartialTime},
@@ -271,7 +271,6 @@ impl ZonedDateTime {
         let resolved_options = ResolvedRoundingOptions::from_diff_settings(
             options,
             op,
-            UnitGroup::DateTime,
             TemporalUnit::Hour,
             TemporalUnit::Nanosecond,
         )?;


### PR DESCRIPTION
This removes `UnitGroup` which doesn't actually need to asserted when determining the difference setting.