### PR TITLE
Add Eq and Ord for PlainYearMonth + Eq for PlainMonthDay

### DIFF
--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -127,7 +127,7 @@ macro_rules! impl_with_fallback_method {
 
 /// The native Rust implementation of `Temporal.PlainDate`.
 #[non_exhaustive]
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct PlainDate {
     pub(crate) iso: IsoDate,
     calendar: Calendar,
@@ -139,15 +139,9 @@ impl core::fmt::Display for PlainDate {
     }
 }
 
-impl Ord for PlainDate {
-    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.iso.cmp(&other.iso)
-    }
-}
-
 impl PartialOrd for PlainDate {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        Some(self.cmp(other))
+        Some(self.iso.cmp(&other.iso))
     }
 }
 

--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -641,30 +641,24 @@ mod tests {
         let err = PlainDate::try_new(275_760, 9, 14, Calendar::default());
         assert!(err.is_err());
         let ok = PlainDate::try_new(-271_821, 4, 19, Calendar::default()).unwrap();
-        assert!(
-            ok.equals(
-            &PlainDate {
-                iso: IsoDate {
-                    year: -271_821,
-                    month: 4,
-                    day: 19,
-                },
-                calendar: Calendar::default(),
-            })
-        );
+        assert!(ok.equals(&PlainDate {
+            iso: IsoDate {
+                year: -271_821,
+                month: 4,
+                day: 19,
+            },
+            calendar: Calendar::default(),
+        }));
 
         let ok = PlainDate::try_new(275_760, 9, 13, Calendar::default()).unwrap();
-        assert!(
-            ok.equals(
-            &PlainDate {
-                iso: IsoDate {
-                    year: 275760,
-                    month: 9,
-                    day: 13,
-                },
-                calendar: Calendar::default(),
-            })
-        );
+        assert!(ok.equals(&PlainDate {
+            iso: IsoDate {
+                year: 275760,
+                month: 9,
+                day: 13,
+            },
+            calendar: Calendar::default(),
+        }));
     }
 
     #[test]
@@ -717,17 +711,14 @@ mod tests {
 
         let max = PlainDate::try_new(275_760, 9, 12, Calendar::default()).unwrap();
         let result = max.add(&Duration::from_str("P1D").unwrap(), None).unwrap();
-        assert!(
-            result.equals(
-            &PlainDate {
-                iso: IsoDate {
-                    year: 275760,
-                    month: 9,
-                    day: 13
-                },
-                calendar: Calendar::default(),
-            })
-        );
+        assert!(result.equals(&PlainDate {
+            iso: IsoDate {
+                year: 275760,
+                month: 9,
+                day: 13
+            },
+            calendar: Calendar::default(),
+        }));
 
         let min = PlainDate::try_new(-271_821, 4, 19, Calendar::default()).unwrap();
         let result = min.add(&Duration::from_str("-P1D").unwrap(), None);
@@ -735,17 +726,14 @@ mod tests {
 
         let min = PlainDate::try_new(-271_821, 4, 20, Calendar::default()).unwrap();
         let result = min.add(&Duration::from_str("-P1D").unwrap(), None).unwrap();
-        assert!(
-            result.equals(
-            &PlainDate {
-                iso: IsoDate {
-                    year: -271_821,
-                    month: 4,
-                    day: 19
-                },
-                calendar: Calendar::default(),
-            })
-        );
+        assert!(result.equals(&PlainDate {
+            iso: IsoDate {
+                year: -271_821,
+                month: 4,
+                day: 19
+            },
+            calendar: Calendar::default(),
+        }));
     }
 
     #[test]

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -30,7 +30,7 @@ pub struct PartialDateTime {
 
 /// The native Rust implementation of `Temporal.PlainDateTime`
 #[non_exhaustive]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PlainDateTime {
     pub(crate) iso: IsoDateTime,
     calendar: Calendar,
@@ -563,15 +563,17 @@ impl PlainDateTime {
 }
 
 impl PlainDateTime {
+    /// Compares one `PlainDateTime` to another `PlainDateTime` using their
+    /// `IsoDate` representation.
+    ///
+    /// # Note on Ordering.
+    ///
+    /// `temporal_rs` does not implement `PartialOrd`/`Ord` as `PlainDateTime` does
+    /// not fulfill all the conditions required to implement the traits. However,
+    /// it is possible to compare `PlainDate`'s as their `IsoDate` representation.
     #[inline]
     #[must_use]
-    pub fn equals(&self, other: &Self) -> bool {
-        self.compare(other) == Ordering::Equal && self.calendar == other.calendar
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn compare(&self, other: &Self) -> Ordering {
+    pub fn compare_iso(&self, other: &Self) -> Ordering {
         self.iso.cmp(&other.iso)
     }
 
@@ -735,31 +737,37 @@ mod tests {
         assert!(negative_limit.is_err());
         let positive_limit = pdt_from_date(275_760, 9, 14);
         assert!(positive_limit.is_err());
-        let within_negative_limit = pdt_from_date(-271_821, 4, 20).unwrap();
-        assert!(within_negative_limit.equals(&PlainDateTime {
-            iso: IsoDateTime {
-                date: IsoDate {
-                    year: -271_821,
-                    month: 4,
-                    day: 20,
+        let within_negative_limit = pdt_from_date(-271_821, 4, 20);
+        assert_eq!(
+            within_negative_limit,
+            Ok(PlainDateTime {
+                iso: IsoDateTime {
+                    date: IsoDate {
+                        year: -271_821,
+                        month: 4,
+                        day: 20,
+                    },
+                    time: IsoTime::default(),
                 },
-                time: IsoTime::default(),
-            },
-            calendar: Calendar::default(),
-        }));
+                calendar: Calendar::default(),
+            })
+        );
 
-        let within_positive_limit = pdt_from_date(275_760, 9, 13).unwrap();
-        assert!(within_positive_limit.equals(&PlainDateTime {
-            iso: IsoDateTime {
-                date: IsoDate {
-                    year: 275_760,
-                    month: 9,
-                    day: 13,
+        let within_positive_limit = pdt_from_date(275_760, 9, 13);
+        assert_eq!(
+            within_positive_limit,
+            Ok(PlainDateTime {
+                iso: IsoDateTime {
+                    date: IsoDate {
+                        year: 275_760,
+                        month: 9,
+                        day: 13,
+                    },
+                    time: IsoTime::default(),
                 },
-                time: IsoTime::default(),
-            },
-            calendar: Calendar::default(),
-        }));
+                calendar: Calendar::default(),
+            })
+        );
     }
 
     #[test]

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -30,7 +30,7 @@ pub struct PartialDateTime {
 
 /// The native Rust implementation of `Temporal.PlainDateTime`
 #[non_exhaustive]
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone)]
 pub struct PlainDateTime {
     pub(crate) iso: IsoDateTime,
     calendar: Calendar,
@@ -42,12 +42,6 @@ impl core::fmt::Display for PlainDateTime {
             .to_ixdtf_string(ToStringRoundingOptions::default(), DisplayCalendar::Auto)
             .expect("ixdtf default configuration should not fail.");
         f.write_str(&ixdtf_str)
-    }
-}
-
-impl PartialOrd for PlainDateTime {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.iso.cmp(&other.iso))
     }
 }
 
@@ -570,6 +564,18 @@ impl PlainDateTime {
 
 impl PlainDateTime {
     #[inline]
+    #[must_use]
+    pub fn equals(&self, other: &Self) -> bool {
+        self.compare(other) == Ordering::Equal && self.calendar == other.calendar
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn compare(&self, other: &Self) -> Ordering {
+        self.iso.cmp(&other.iso)
+    }
+
+    #[inline]
     /// Adds a `Duration` to the current `DateTime`.
     pub fn add(
         &self,
@@ -729,10 +735,10 @@ mod tests {
         assert!(negative_limit.is_err());
         let positive_limit = pdt_from_date(275_760, 9, 14);
         assert!(positive_limit.is_err());
-        let within_negative_limit = pdt_from_date(-271_821, 4, 20);
-        assert_eq!(
-            within_negative_limit,
-            Ok(PlainDateTime {
+        let within_negative_limit = pdt_from_date(-271_821, 4, 20).unwrap();
+        assert!(
+            within_negative_limit.equals(
+            &PlainDateTime {
                 iso: IsoDateTime {
                     date: IsoDate {
                         year: -271_821,
@@ -745,10 +751,10 @@ mod tests {
             })
         );
 
-        let within_positive_limit = pdt_from_date(275_760, 9, 13);
-        assert_eq!(
-            within_positive_limit,
-            Ok(PlainDateTime {
+        let within_positive_limit = pdt_from_date(275_760, 9, 13).unwrap();
+        assert!(
+            within_positive_limit.equals(
+            &PlainDateTime {
                 iso: IsoDateTime {
                     date: IsoDate {
                         year: 275_760,

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -30,7 +30,7 @@ pub struct PartialDateTime {
 
 /// The native Rust implementation of `Temporal.PlainDateTime`
 #[non_exhaustive]
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct PlainDateTime {
     pub(crate) iso: IsoDateTime,
     calendar: Calendar,
@@ -45,15 +45,9 @@ impl core::fmt::Display for PlainDateTime {
     }
 }
 
-impl Ord for PlainDateTime {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.iso.cmp(&other.iso)
-    }
-}
-
 impl PartialOrd for PlainDateTime {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
+        Some(self.iso.cmp(&other.iso))
     }
 }
 

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -736,36 +736,30 @@ mod tests {
         let positive_limit = pdt_from_date(275_760, 9, 14);
         assert!(positive_limit.is_err());
         let within_negative_limit = pdt_from_date(-271_821, 4, 20).unwrap();
-        assert!(
-            within_negative_limit.equals(
-            &PlainDateTime {
-                iso: IsoDateTime {
-                    date: IsoDate {
-                        year: -271_821,
-                        month: 4,
-                        day: 20,
-                    },
-                    time: IsoTime::default(),
+        assert!(within_negative_limit.equals(&PlainDateTime {
+            iso: IsoDateTime {
+                date: IsoDate {
+                    year: -271_821,
+                    month: 4,
+                    day: 20,
                 },
-                calendar: Calendar::default(),
-            })
-        );
+                time: IsoTime::default(),
+            },
+            calendar: Calendar::default(),
+        }));
 
         let within_positive_limit = pdt_from_date(275_760, 9, 13).unwrap();
-        assert!(
-            within_positive_limit.equals(
-            &PlainDateTime {
-                iso: IsoDateTime {
-                    date: IsoDate {
-                        year: 275_760,
-                        month: 9,
-                        day: 13,
-                    },
-                    time: IsoTime::default(),
+        assert!(within_positive_limit.equals(&PlainDateTime {
+            iso: IsoDateTime {
+                date: IsoDate {
+                    year: 275_760,
+                    month: 9,
+                    day: 13,
                 },
-                calendar: Calendar::default(),
-            })
-        );
+                time: IsoTime::default(),
+            },
+            calendar: Calendar::default(),
+        }));
     }
 
     #[test]

--- a/src/builtins/core/month_day.rs
+++ b/src/builtins/core/month_day.rs
@@ -14,7 +14,7 @@ use crate::{
 
 /// The native Rust implementation of `Temporal.PlainMonthDay`
 #[non_exhaustive]
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct PlainMonthDay {
     pub iso: IsoDate,
     calendar: Calendar,

--- a/src/builtins/core/month_day.rs
+++ b/src/builtins/core/month_day.rs
@@ -1,7 +1,7 @@
 //! This module implements `MonthDay` and any directly related algorithms.
 
 use alloc::string::String;
-use core::str::FromStr;
+use core::{cmp::Ordering, str::FromStr};
 
 use tinystr::TinyAsciiStr;
 
@@ -14,7 +14,7 @@ use crate::{
 
 /// The native Rust implementation of `Temporal.PlainMonthDay`
 #[non_exhaustive]
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone)]
 pub struct PlainMonthDay {
     pub iso: IsoDate,
     calendar: Calendar,
@@ -88,6 +88,11 @@ impl PlainMonthDay {
     #[inline]
     pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
         self.calendar.month_code(&self.iso)
+    }
+
+    #[inline]
+    pub fn equals(&self, other: &Self) -> bool {
+        self.iso.cmp(&other.iso) == Ordering::Equal && self.calendar == other.calendar
     }
 
     pub fn to_ixdtf_string(&self, display_calendar: DisplayCalendar) -> String {

--- a/src/builtins/core/month_day.rs
+++ b/src/builtins/core/month_day.rs
@@ -1,7 +1,7 @@
 //! This module implements `MonthDay` and any directly related algorithms.
 
 use alloc::string::String;
-use core::{cmp::Ordering, str::FromStr};
+use core::str::FromStr;
 
 use tinystr::TinyAsciiStr;
 
@@ -14,7 +14,7 @@ use crate::{
 
 /// The native Rust implementation of `Temporal.PlainMonthDay`
 #[non_exhaustive]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PlainMonthDay {
     pub iso: IsoDate,
     calendar: Calendar,
@@ -88,11 +88,6 @@ impl PlainMonthDay {
     #[inline]
     pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
         self.calendar.month_code(&self.iso)
-    }
-
-    #[inline]
-    pub fn equals(&self, other: &Self) -> bool {
-        self.iso.cmp(&other.iso) == Ordering::Equal && self.calendar == other.calendar
     }
 
     pub fn to_ixdtf_string(&self, display_calendar: DisplayCalendar) -> String {

--- a/src/builtins/core/month_day.rs
+++ b/src/builtins/core/month_day.rs
@@ -14,7 +14,7 @@ use crate::{
 
 /// The native Rust implementation of `Temporal.PlainMonthDay`
 #[non_exhaustive]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PlainMonthDay {
     pub iso: IsoDate,
     calendar: Calendar,

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -17,7 +17,7 @@ use super::{Duration, PartialDate};
 
 /// The native Rust implementation of `Temporal.YearMonth`.
 #[non_exhaustive]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PlainYearMonth {
     pub(crate) iso: IsoDate,
     calendar: Calendar,
@@ -137,15 +137,17 @@ impl PlainYearMonth {
         self.calendar.identifier()
     }
 
+    /// Compares one `PlainYearMonth` to another `PlainYearMonth` using their
+    /// `IsoDate` representation.
+    ///
+    /// # Note on Ordering.
+    ///
+    /// `temporal_rs` does not implement `PartialOrd`/`Ord` as `PlainYearMonth` does
+    /// not fulfill all the conditions required to implement the traits. However,
+    /// it is possible to compare `PlainDate`'s as their `IsoDate` representation.
     #[inline]
     #[must_use]
-    pub fn equals(&self, other: &Self) -> bool {
-        self.compare(other) == Ordering::Equal && self.calendar == other.calendar
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn compare(&self, other: &Self) -> Ordering {
+    pub fn compare_iso(&self, other: &Self) -> Ordering {
         self.iso.cmp(&other.iso)
     }
 

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -17,7 +17,7 @@ use super::{Duration, PartialDate};
 
 /// The native Rust implementation of `Temporal.YearMonth`.
 #[non_exhaustive]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PlainYearMonth {
     pub(crate) iso: IsoDate,
     calendar: Calendar,
@@ -26,6 +26,18 @@ pub struct PlainYearMonth {
 impl core::fmt::Display for PlainYearMonth {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(&self.to_ixdtf_string(DisplayCalendar::Auto))
+    }
+}
+
+impl Ord for PlainYearMonth {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.iso.cmp(&other.iso)
+    }
+}
+
+impl PartialOrd for PlainYearMonth {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -17,7 +17,7 @@ use super::{Duration, PartialDate};
 
 /// The native Rust implementation of `Temporal.YearMonth`.
 #[non_exhaustive]
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct PlainYearMonth {
     pub(crate) iso: IsoDate,
     calendar: Calendar,
@@ -29,15 +29,9 @@ impl core::fmt::Display for PlainYearMonth {
     }
 }
 
-impl Ord for PlainYearMonth {
-    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.iso.cmp(&other.iso)
-    }
-}
-
 impl PartialOrd for PlainYearMonth {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        Some(self.cmp(other))
+        Some(self.iso.cmp(&other.iso))
     }
 }
 

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -43,22 +43,16 @@ pub struct PartialZonedDateTime {
 
 /// The native Rust implementation of `Temporal.ZonedDateTime`.
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ZonedDateTime {
     instant: Instant,
     calendar: Calendar,
     tz: TimeZone,
 }
 
-impl Ord for ZonedDateTime {
-    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.instant.cmp(&other.instant)
-    }
-}
-
 impl PartialOrd for ZonedDateTime {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        Some(self.cmp(other))
+        Some(self.instant.cmp(&other.instant))
     }
 }
 

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -1,7 +1,7 @@
 //! This module implements `ZonedDateTime` and any directly related algorithms.
 
 use alloc::string::String;
-use core::num::NonZeroU128;
+use core::{cmp::Ordering, num::NonZeroU128};
 use ixdtf::parsers::records::{TimeZoneRecord, UtcOffsetRecordOrZ};
 use tinystr::TinyAsciiStr;
 
@@ -29,7 +29,7 @@ use crate::{
 };
 
 /// A struct representing a partial `ZonedDateTime`.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone)]
 pub struct PartialZonedDateTime {
     /// The `PartialDate` portion of a `PartialZonedDateTime`
     pub date: PartialDate,
@@ -48,12 +48,6 @@ pub struct ZonedDateTime {
     instant: Instant,
     calendar: Calendar,
     tz: TimeZone,
-}
-
-impl PartialOrd for ZonedDateTime {
-    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        Some(self.instant.cmp(&other.instant))
-    }
 }
 
 // ==== Private API ====
@@ -425,6 +419,20 @@ impl ZonedDateTime {
     /// combined with the provided `Calendar`.
     pub fn with_calendar(&self, calendar: Calendar) -> TemporalResult<Self> {
         Self::try_new(self.epoch_nanoseconds(), calendar, self.tz.clone())
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn equals(&self, other: &Self) -> bool {
+        self.compare(other) == Ordering::Equal
+            && self.tz == other.tz
+            && self.calendar == other.calendar
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn compare(&self, other: &Self) -> Ordering {
+        self.instant.cmp(&other.instant)
     }
 }
 

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 
 /// A struct representing a partial `ZonedDateTime`.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct PartialZonedDateTime {
     /// The `PartialDate` portion of a `PartialZonedDateTime`
     pub date: PartialDate,
@@ -43,7 +43,7 @@ pub struct PartialZonedDateTime {
 
 /// The native Rust implementation of `Temporal.ZonedDateTime`.
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ZonedDateTime {
     instant: Instant,
     calendar: Calendar,
@@ -421,17 +421,17 @@ impl ZonedDateTime {
         Self::try_new(self.epoch_nanoseconds(), calendar, self.tz.clone())
     }
 
+    /// Compares one `ZonedDateTime` to another `ZonedDateTime` using their
+    /// `Instant` representation.
+    ///
+    /// # Note on Ordering.
+    ///
+    /// `temporal_rs` does not implement `PartialOrd`/`Ord` as `ZonedDateTime` does
+    /// not fulfill all the conditions required to implement the traits. However,
+    /// it is possible to compare `PlainDate`'s as their `IsoDate` representation.
     #[inline]
     #[must_use]
-    pub fn equals(&self, other: &Self) -> bool {
-        self.compare(other) == Ordering::Equal
-            && self.tz == other.tz
-            && self.calendar == other.calendar
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn compare(&self, other: &Self) -> Ordering {
+    pub fn compare_instant(&self, other: &Self) -> Ordering {
         self.instant.cmp(&other.instant)
     }
 }

--- a/temporal_capi/src/plain_year_month.rs
+++ b/temporal_capi/src/plain_year_month.rs
@@ -64,13 +64,13 @@ pub mod ffi {
             self.0.in_leap_year()
         }
         pub fn days_in_month(&self) -> Result<u16, TemporalError> {
-            self.0.get_days_in_month().map_err(Into::into)
+            self.0.days_in_month().map_err(Into::into)
         }
         pub fn days_in_year(&self) -> Result<u16, TemporalError> {
-            self.0.get_days_in_year().map_err(Into::into)
+            self.0.days_in_year().map_err(Into::into)
         }
         pub fn months_in_year(&self) -> Result<u16, TemporalError> {
-            self.0.get_months_in_year().map_err(Into::into)
+            self.0.months_in_year().map_err(Into::into)
         }
         // Writes an empty string for no era
         pub fn era(&self, write: &mut DiplomatWrite) -> Result<(), TemporalError> {


### PR DESCRIPTION
This PR adds `Eq` and `Ord` trait implementations for `PlainYearMonth` and an `Eq` trait impl for `PlainMonthDay` to enable implementing `Temporal.PlainYearMonth.compare`, `Temporal.PlainYearMonth.prototype.equals` and `Temporal.PlainMonthDay.prototype.equals`.