### PR TITLE
Cleanup `Now` API in favor of system defined implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,9 +67,9 @@ combine = { workspace = true, optional = true }
 web-time = { workspace = true, optional =  true }
 
 [features]
-default = ["now"]
+default = ["sys"]
 log = ["dep:log"]
 compiled_data = ["tzdb"]
-now = ["std", "dep:web-time"]
+sys = ["std", "dep:web-time"]
 tzdb = ["dep:tzif", "std", "dep:jiff-tzdb", "dep:combine"]
 std = []

--- a/src/builtins/compiled/now.rs
+++ b/src/builtins/compiled/now.rs
@@ -4,6 +4,10 @@ use crate::builtins::{
 };
 use crate::{TemporalError, TemporalResult, TimeZone};
 
+#[cfg(feature = "sys")]
+use crate::sys::DefaultSystemHooks;
+
+#[cfg(feature = "sys")]
 impl Now {
     /// Returns the current system time as a [`PlainDateTime`] with an optional
     /// [`TimeZone`].
@@ -13,7 +17,8 @@ impl Now {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        Now::plain_datetime_iso_with_provider(timezone, &*provider).map(Into::into)
+        Now::plain_datetime_iso_with_hooks_and_provider(timezone, &DefaultSystemHooks, &*provider)
+            .map(Into::into)
     }
 
     /// Returns the current system time as a [`PlainDate`] with an optional
@@ -24,7 +29,8 @@ impl Now {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        Now::plain_date_iso_with_provider(timezone, &*provider).map(Into::into)
+        Now::plain_date_iso_with_hooks_and_provider(timezone, &DefaultSystemHooks, &*provider)
+            .map(Into::into)
     }
 
     /// Returns the current system time as a [`PlainTime`] with an optional
@@ -35,6 +41,7 @@ impl Now {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        Now::plain_time_iso_with_provider(timezone, &*provider).map(Into::into)
+        Now::plain_time_iso_with_hooks_and_provider(timezone, &DefaultSystemHooks, &*provider)
+            .map(Into::into)
     }
 }

--- a/src/builtins/compiled/now.rs
+++ b/src/builtins/compiled/now.rs
@@ -1,14 +1,22 @@
 use crate::builtins::{
-    core::{Now, PlainDate, PlainDateTime, PlainTime},
+    core::{Now, PlainDate, PlainDateTime, PlainTime, ZonedDateTime},
     TZ_PROVIDER,
 };
-use crate::{TemporalError, TemporalResult, TimeZone};
-
-#[cfg(feature = "sys")]
-use crate::sys::DefaultSystemHooks;
+use crate::sys;
+use crate::{time::EpochNanoseconds, TemporalError, TemporalResult, TimeZone};
 
 #[cfg(feature = "sys")]
 impl Now {
+    /// Returns the current system time as a [`PlainDateTime`] with an optional
+    /// [`TimeZone`].
+    pub fn zoneddatetime_iso(timezone: Option<TimeZone>) -> TemporalResult<ZonedDateTime> {
+        let timezone =
+            timezone.unwrap_or(TimeZone::IanaIdentifier(crate::sys::get_system_timezone()?));
+        let system_nanos = sys::get_system_nanoseconds()?;
+        let epoch_nanos = EpochNanoseconds::try_from(system_nanos)?;
+        Now::zoneddatetime_iso_with_system_values(epoch_nanos, timezone)
+    }
+
     /// Returns the current system time as a [`PlainDateTime`] with an optional
     /// [`TimeZone`].
     ///
@@ -17,8 +25,10 @@ impl Now {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        Now::plain_datetime_iso_with_hooks_and_provider(timezone, &DefaultSystemHooks, &*provider)
-            .map(Into::into)
+        let timezone = timezone.unwrap_or(TimeZone::IanaIdentifier(sys::get_system_timezone()?));
+        let system_nanos = sys::get_system_nanoseconds()?;
+        let epoch_nanos = EpochNanoseconds::try_from(system_nanos)?;
+        Now::plain_datetime_iso_with_provider(epoch_nanos, timezone, &*provider)
     }
 
     /// Returns the current system time as a [`PlainDate`] with an optional
@@ -29,8 +39,10 @@ impl Now {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        Now::plain_date_iso_with_hooks_and_provider(timezone, &DefaultSystemHooks, &*provider)
-            .map(Into::into)
+        let timezone = timezone.unwrap_or(TimeZone::IanaIdentifier(sys::get_system_timezone()?));
+        let system_nanos = sys::get_system_nanoseconds()?;
+        let epoch_nanos = EpochNanoseconds::try_from(system_nanos)?;
+        Now::plain_date_iso_with_provider(epoch_nanos, timezone, &*provider)
     }
 
     /// Returns the current system time as a [`PlainTime`] with an optional
@@ -41,7 +53,9 @@ impl Now {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        Now::plain_time_iso_with_hooks_and_provider(timezone, &DefaultSystemHooks, &*provider)
-            .map(Into::into)
+        let timezone = timezone.unwrap_or(TimeZone::IanaIdentifier(sys::get_system_timezone()?));
+        let system_nanos = sys::get_system_nanoseconds()?;
+        let epoch_nanos = EpochNanoseconds::try_from(system_nanos)?;
+        Now::plain_time_iso_with_provider(epoch_nanos, timezone, &*provider)
     }
 }

--- a/src/builtins/compiled/now.rs
+++ b/src/builtins/compiled/now.rs
@@ -1,5 +1,5 @@
 use crate::builtins::{
-    core::{Now, PlainDate, PlainDateTime, PlainTime, ZonedDateTime},
+    core::{Now, PlainDate, PlainDateTime, PlainTime},
     TZ_PROVIDER,
 };
 use crate::sys;
@@ -9,18 +9,8 @@ use crate::{time::EpochNanoseconds, TemporalError, TemporalResult, TimeZone};
 impl Now {
     /// Returns the current system time as a [`PlainDateTime`] with an optional
     /// [`TimeZone`].
-    pub fn zoneddatetime_iso(timezone: Option<TimeZone>) -> TemporalResult<ZonedDateTime> {
-        let timezone =
-            timezone.unwrap_or(TimeZone::IanaIdentifier(crate::sys::get_system_timezone()?));
-        let system_nanos = sys::get_system_nanoseconds()?;
-        let epoch_nanos = EpochNanoseconds::try_from(system_nanos)?;
-        Now::zoneddatetime_iso_with_system_values(epoch_nanos, timezone)
-    }
-
-    /// Returns the current system time as a [`PlainDateTime`] with an optional
-    /// [`TimeZone`].
     ///
-    /// Enable with the `compiled_data` feature flag.
+    /// Enable with the `compiled_data` and `sys` feature flags.
     pub fn plain_datetime_iso(timezone: Option<TimeZone>) -> TemporalResult<PlainDateTime> {
         let provider = TZ_PROVIDER
             .lock()
@@ -34,7 +24,7 @@ impl Now {
     /// Returns the current system time as a [`PlainDate`] with an optional
     /// [`TimeZone`].
     ///
-    /// Enable with the `compiled_data` feature flag.
+    /// Enable with the `compiled_data` and `sys` feature flags.
     pub fn plain_date_iso(timezone: Option<TimeZone>) -> TemporalResult<PlainDate> {
         let provider = TZ_PROVIDER
             .lock()
@@ -48,7 +38,7 @@ impl Now {
     /// Returns the current system time as a [`PlainTime`] with an optional
     /// [`TimeZone`].
     ///
-    /// Enable with the `compiled_data` feature flag.
+    /// Enable with the `compiled_data` and `sys` feature flags.
     pub fn plain_time_iso(timezone: Option<TimeZone>) -> TemporalResult<PlainTime> {
         let provider = TZ_PROVIDER
             .lock()

--- a/src/builtins/core/mod.rs
+++ b/src/builtins/core/mod.rs
@@ -18,10 +18,8 @@ mod time;
 mod year_month;
 pub(crate) mod zoneddatetime;
 
-#[cfg(feature = "now")]
 mod now;
 
-#[cfg(feature = "now")]
 #[doc(inline)]
 pub use now::Now;
 

--- a/src/builtins/core/now.rs
+++ b/src/builtins/core/now.rs
@@ -109,7 +109,7 @@ impl Now {
     ///   1. Resolve user input `TimeZone` with the `SystemTimeZone`.
     ///   2. Get the `SystemNanoseconds`
     ///
-    /// For an example implementation see [`Self::plain_date_time_iso`]
+    /// For an example implementation see [`Self::plain_datetime_iso`]
     pub fn plain_datetime_iso_with_provider(
         epoch_nanos: EpochNanoseconds,
         timezone: TimeZone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,12 @@ pub mod options;
 pub mod parsers;
 pub mod primitive;
 pub mod provider;
-pub mod sys;
 
-mod epoch_nanoseconds;
+#[cfg(feature = "sys")]
+pub(crate) mod sys;
 
 mod builtins;
+mod epoch_nanoseconds;
 
 #[cfg(feature = "tzdb")]
 pub mod tzdb;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,13 +52,11 @@ pub mod options;
 pub mod parsers;
 pub mod primitive;
 pub mod provider;
+pub mod sys;
 
 mod epoch_nanoseconds;
 
 mod builtins;
-
-#[cfg(feature = "now")]
-mod sys;
 
 #[cfg(feature = "tzdb")]
 pub mod tzdb;
@@ -97,12 +95,9 @@ pub mod time {
 }
 
 pub use crate::builtins::{
-    calendar::Calendar, core::timezone::TimeZone, DateDuration, Duration, Instant, PlainDate,
+    calendar::Calendar, core::timezone::TimeZone, DateDuration, Duration, Instant, Now, PlainDate,
     PlainDateTime, PlainMonthDay, PlainTime, PlainYearMonth, TimeDuration, ZonedDateTime,
 };
-
-#[cfg(feature = "now")]
-pub use crate::builtins::Now;
 
 /// A library specific trait for unwrapping assertions.
 pub(crate) trait TemporalUnwrap {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,35 +1,16 @@
 use alloc::string::String;
 
-use crate::{time::EpochNanoseconds, TemporalResult};
+use crate::TemporalResult;
 
-#[cfg(feature = "sys")]
 use crate::TemporalError;
-#[cfg(feature = "sys")]
 use alloc::string::ToString;
-#[cfg(feature = "sys")]
 use web_time::{SystemTime, UNIX_EPOCH};
 
 // TODO: Need to implement SystemTime handling for non_std.
 
-pub trait SystemHooks {
-    /// Returns the current system time in `EpochNanoseconds`.
-    fn get_system_nanoseconds(&self) -> TemporalResult<EpochNanoseconds>;
-    /// Returns the current system IANA Time Zone Identifier.
-    fn get_system_time_zone(&self) -> TemporalResult<String>;
-}
-
-#[cfg(feature = "sys")]
-pub struct DefaultSystemHooks;
-
-#[cfg(feature = "sys")]
-impl SystemHooks for DefaultSystemHooks {
-    fn get_system_nanoseconds(&self) -> TemporalResult<EpochNanoseconds> {
-        EpochNanoseconds::try_from(get_system_nanoseconds()?)
-    }
-
-    fn get_system_time_zone(&self) -> TemporalResult<String> {
-        iana_time_zone::get_timezone().map_err(|e| TemporalError::general(e.to_string()))
-    }
+#[inline]
+pub(crate) fn get_system_timezone() -> TemporalResult<String> {
+    iana_time_zone::get_timezone().map_err(|e| TemporalError::general(e.to_string()))
 }
 
 /// Returns the system time in nanoseconds.

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,21 +1,42 @@
-use alloc::string::{String, ToString};
+use alloc::string::String;
 
-use crate::{TemporalError, TemporalResult};
+use crate::{time::EpochNanoseconds, TemporalResult};
 
+#[cfg(feature = "sys")]
+use crate::TemporalError;
+#[cfg(feature = "sys")]
+use alloc::string::ToString;
+#[cfg(feature = "sys")]
 use web_time::{SystemTime, UNIX_EPOCH};
 
 // TODO: Need to implement SystemTime handling for non_std.
 
+pub trait SystemHooks {
+    /// Returns the current system time in `EpochNanoseconds`.
+    fn get_system_nanoseconds(&self) -> TemporalResult<EpochNanoseconds>;
+    /// Returns the current system IANA Time Zone Identifier.
+    fn get_system_time_zone(&self) -> TemporalResult<String>;
+}
+
+#[cfg(feature = "sys")]
+pub struct DefaultSystemHooks;
+
+#[cfg(feature = "sys")]
+impl SystemHooks for DefaultSystemHooks {
+    fn get_system_nanoseconds(&self) -> TemporalResult<EpochNanoseconds> {
+        EpochNanoseconds::try_from(get_system_nanoseconds()?)
+    }
+
+    fn get_system_time_zone(&self) -> TemporalResult<String> {
+        iana_time_zone::get_timezone().map_err(|e| TemporalError::general(e.to_string()))
+    }
+}
+
 /// Returns the system time in nanoseconds.
-#[cfg(feature = "now")]
+#[cfg(feature = "sys")]
 pub(crate) fn get_system_nanoseconds() -> TemporalResult<u128> {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|e| TemporalError::general(e.to_string()))
         .map(|d| d.as_nanos())
-}
-
-/// Returns the system tz identifier
-pub(crate) fn get_system_tz_identifier() -> TemporalResult<String> {
-    iana_time_zone::get_timezone().map_err(|e| TemporalError::general(e.to_string()))
 }


### PR DESCRIPTION
~~This adds a `SystemHooks` trait for providing system getters for system time and system time zone. It also adjusts the "now" feature to a "sys" feature flag for `DefaultSystemHooks`.~~

This PR provides more generalized methods that can be used in combination with a system hooks.