### PR TITLE
Reimplement Unit Group with different approach

### DIFF
--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -7,7 +7,7 @@ use crate::{
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, DisplayCalendar,
-        ResolvedRoundingOptions, TemporalUnit,
+        ResolvedRoundingOptions, TemporalUnit, UnitGroup,
     },
     parsers::{parse_date_time, IxdtfStringBuilder},
     primitive::FiniteF64,
@@ -265,6 +265,7 @@ impl PlainDate {
         let resolved = ResolvedRoundingOptions::from_diff_settings(
             settings,
             op,
+            UnitGroup::Date,
             TemporalUnit::Day,
             TemporalUnit::Day,
         )?;

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -9,7 +9,7 @@ use crate::{
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, DisplayCalendar,
-        ResolvedRoundingOptions, RoundingOptions, TemporalUnit, ToStringRoundingOptions,
+        ResolvedRoundingOptions, RoundingOptions, TemporalUnit, ToStringRoundingOptions, UnitGroup,
     },
     parsers::{parse_date_time, IxdtfStringBuilder},
     provider::NeverProvider,
@@ -133,6 +133,7 @@ impl PlainDateTime {
         let options = ResolvedRoundingOptions::from_diff_settings(
             settings,
             op,
+            UnitGroup::DateTime,
             TemporalUnit::Day,
             TemporalUnit::Nanosecond,
         )?;

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -10,7 +10,7 @@ use crate::{
     iso::IsoDateTime,
     options::{
         DifferenceOperation, DifferenceSettings, DisplayOffset, ResolvedRoundingOptions,
-        RoundingOptions, TemporalUnit, ToStringRoundingOptions,
+        RoundingOptions, TemporalUnit, ToStringRoundingOptions, UnitGroup,
     },
     parsers::{parse_instant, IxdtfStringBuilder},
     primitive::FiniteF64,
@@ -88,6 +88,7 @@ impl Instant {
         let resolved_options = ResolvedRoundingOptions::from_diff_settings(
             options,
             op,
+            UnitGroup::Time,
             TemporalUnit::Second,
             TemporalUnit::Nanosecond,
         )?;

--- a/src/builtins/core/time.rs
+++ b/src/builtins/core/time.rs
@@ -5,7 +5,7 @@ use crate::{
     iso::IsoTime,
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions,
-        RoundingIncrement, TemporalRoundingMode, TemporalUnit, ToStringRoundingOptions,
+        RoundingIncrement, TemporalRoundingMode, TemporalUnit, ToStringRoundingOptions, UnitGroup,
     },
     parsers::{parse_time, IxdtfStringBuilder},
     primitive::FiniteF64,
@@ -127,6 +127,7 @@ impl PlainTime {
         let resolved = ResolvedRoundingOptions::from_diff_settings(
             settings,
             op,
+            UnitGroup::Time,
             TemporalUnit::Hour,
             TemporalUnit::Nanosecond,
         )?;

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -17,7 +17,7 @@ use crate::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, Disambiguation,
         DisplayCalendar, DisplayOffset, DisplayTimeZone, OffsetDisambiguation,
         ResolvedRoundingOptions, RoundingIncrement, TemporalRoundingMode, TemporalUnit,
-        ToStringRoundingOptions,
+        ToStringRoundingOptions, UnitGroup,
     },
     parsers::{self, IxdtfStringBuilder},
     partial::{PartialDate, PartialTime},
@@ -271,6 +271,7 @@ impl ZonedDateTime {
         let resolved_options = ResolvedRoundingOptions::from_diff_settings(
             options,
             op,
+            UnitGroup::DateTime,
             TemporalUnit::Hour,
             TemporalUnit::Nanosecond,
         )?;


### PR DESCRIPTION
This PR reimplements the UnitGroup enum with a different approach to validation. Previously this was implemented, but it broke quite a few tests in Boa. I think that was partially due to a flawed implementation and a host of bugs that were previously present.

Those appear to have all been fixed with recent bug changes, and this reimplementation is primarily to address the broken tests in boa-dev/boa#4142 that require unit groups to be implemented.

The tests that the unit groups specifically address specifically are tests like: [largestunit-invalid-string.js](https://github.com/tc39/test262/blob/main/test/built-ins/Temporal/Instant/prototype/since/largestunit-invalid-string.js).
