### PR TITLE
Implement `ZonedDateTime::offset` and `ZonedDateTime::offset_nanoseconds`

### DIFF
--- a/src/builtins/compiled/zoneddatetime.rs
+++ b/src/builtins/compiled/zoneddatetime.rs
@@ -5,6 +5,7 @@ use crate::{
         ArithmeticOverflow, DifferenceSettings, Disambiguation, DisplayCalendar, DisplayOffset,
         DisplayTimeZone, OffsetDisambiguation, ToStringRoundingOptions,
     },
+    time::EpochNanoseconds,
     Duration, PlainDate, PlainDateTime, PlainTime, TemporalError, TemporalResult,
 };
 use alloc::string::String;
@@ -124,6 +125,22 @@ impl ZonedDateTime {
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
 
         self.millisecond_with_provider(&*provider)
+    }
+
+    /// Returns the current offset as a formatted offset string.
+    pub fn offset(&self) -> TemporalResult<String> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.offset_with_provider(&*provider)
+    }
+
+    /// Returns the current offset in nanoseconds
+    pub fn offset_nanoseconds(&self) -> TemporalResult<i64> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.offset_nanoseconds_with_provider(&*provider)
     }
 }
 

--- a/src/builtins/compiled/zoneddatetime.rs
+++ b/src/builtins/compiled/zoneddatetime.rs
@@ -5,7 +5,6 @@ use crate::{
         ArithmeticOverflow, DifferenceSettings, Disambiguation, DisplayCalendar, DisplayOffset,
         DisplayTimeZone, OffsetDisambiguation, ToStringRoundingOptions,
     },
-    time::EpochNanoseconds,
     Duration, PlainDate, PlainDateTime, PlainTime, TemporalError, TemporalResult,
 };
 use alloc::string::String;


### PR DESCRIPTION
Per title, this implements the accessor methods for returning `ZonedDateTime`'s offset and offsetNanoseconds values.