### PR TITLE
Fix calendar parsing on `from_str` implementation

### DIFF
--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -679,6 +679,7 @@ impl From<PlainYearMonth> for Calendar {
 #[cfg(test)]
 mod tests {
     use crate::{iso::IsoDate, options::TemporalUnit};
+    use core::str::FromStr;
 
     use super::Calendar;
 
@@ -691,6 +692,15 @@ mod tests {
         let cal_str = "iSO8601";
         let calendar = Calendar::from_utf8(cal_str.as_bytes()).unwrap();
         assert_eq!(calendar, Calendar::default());
+    }
+
+    #[test]
+    fn calendar_invalid_ascii_value() {
+        let cal_str = "İSO8601";
+        let _err = Calendar::from_str(cal_str).unwrap_err();
+
+        let cal_str = "\u{0130}SO8601";
+        let _err = Calendar::from_str(cal_str).unwrap_err();
     }
 
     #[test]

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -203,12 +203,11 @@ impl FromStr for Calendar {
 
     // 13.34 ParseTemporalCalendarString ( string )
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some(s) = parse_allowed_calendar_formats(s) {
-            return s
-                .map(Calendar::from_utf8)
-                .unwrap_or(Ok(Calendar::default()));
+        match parse_allowed_calendar_formats(s) {
+            Some([]) => Ok(Calendar::default()),
+            Some(result) => Calendar::from_utf8(result),
+            None => Calendar::from_utf8(s.as_bytes()),
         }
-        Calendar::from_utf8(s.as_bytes())
     }
 }
 
@@ -700,6 +699,10 @@ mod tests {
         let _err = Calendar::from_str(cal_str).unwrap_err();
 
         let cal_str = "\u{0130}SO8601";
+        let _err = Calendar::from_str(cal_str).unwrap_err();
+
+        // Verify that an empty calendar is an error.
+        let cal_str = "2025-02-07T01:24:00-06:00[u-ca=]";
         let _err = Calendar::from_str(cal_str).unwrap_err();
     }
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -767,15 +767,15 @@ pub(crate) fn parse_time(source: &str) -> TemporalResult<TimeRecord> {
 }
 
 #[inline]
-pub(crate) fn parse_allowed_calendar_formats(s: &str) -> Option<Option<&[u8]>> {
+pub(crate) fn parse_allowed_calendar_formats(s: &str) -> Option<&[u8]> {
     if let Ok(r) = parse_ixdtf(s, ParseVariant::DateTime).map(|r| r.calendar) {
-        return Some(r);
+        return Some(r.unwrap_or(&[]));
     } else if let Ok(r) = IxdtfParser::from_str(s).parse_time().map(|r| r.calendar) {
-        return Some(r);
+        return Some(r.unwrap_or(&[]));
     } else if let Ok(r) = parse_ixdtf(s, ParseVariant::YearMonth).map(|r| r.calendar) {
-        return Some(r);
+        return Some(r.unwrap_or(&[]));
     } else if let Ok(r) = parse_ixdtf(s, ParseVariant::MonthDay).map(|r| r.calendar) {
-        return Some(r);
+        return Some(r.unwrap_or(&[]));
     }
     None
 }

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -777,7 +777,7 @@ pub(crate) fn parse_allowed_calendar_formats(s: &str) -> Option<Option<&[u8]>> {
     } else if let Ok(r) = parse_ixdtf(s, ParseVariant::MonthDay).map(|r| r.calendar) {
         return Some(r);
     }
-    Some(None)
+    None
 }
 
 // TODO: ParseTimeZoneString, ParseZonedDateTimeString


### PR DESCRIPTION
`parse_allowed_calendar_formats` was returning `Some(None)` instead of `None`. This was preventing calendar ids from correctly moving to `Calendar::from_utf8`