### PR TITLE
Update unit group validation to handle rounding options

### DIFF
--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -1117,6 +1117,26 @@ mod tests {
         assert_datetime(result, (1976, 11, 18, 14, 23, 30, 123, 456, 790));
     }
 
+    #[test]
+    fn datetime_round_options() {
+        let dt =
+            PlainDateTime::try_new(1976, 11, 18, 14, 23, 30, 123, 456, 789, Calendar::default())
+                .unwrap();
+
+        let bad_options = RoundingOptions {
+            largest_unit: None,
+            smallest_unit: None,
+            rounding_mode: Some(TemporalRoundingMode::Ceil),
+            increment: Some(RoundingIncrement::ONE),
+        };
+
+        let err = dt.round(bad_options);
+        assert!(err.is_err());
+
+        let err = dt.round(RoundingOptions::default());
+        assert!(err.is_err());
+    }
+
     // Mapped from fractionaldigits-number.js
     #[test]
     fn to_string_precision_digits() {

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -612,7 +612,7 @@ impl PlainDateTime {
 
     /// Rounds the current datetime based on provided options.
     pub fn round(&self, options: RoundingOptions) -> TemporalResult<Self> {
-        let resolved = ResolvedRoundingOptions::from_dt_options(options)?;
+        let resolved = ResolvedRoundingOptions::from_datetime_options(options)?;
 
         if resolved.is_noop() {
             return Ok(self.clone());

--- a/src/options.rs
+++ b/src/options.rs
@@ -183,7 +183,7 @@ impl ResolvedRoundingOptions {
     ) -> TemporalResult<Self> {
         // 4. Let resolvedOptions be ? SnapshotOwnProperties(? GetOptionsObject(options), null).
         // 5. Let settings be ? GetDifferenceSettings(operation, resolvedOptions, DATE, « », "day", "day").
-        unit_group.validate_unit(options.largest_unit)?;
+        unit_group.validate_unit(options.largest_unit, None)?;
         let increment = options.increment.unwrap_or_default();
         let rounding_mode = match operation {
             DifferenceOperation::Since => options
@@ -240,6 +240,8 @@ impl ResolvedRoundingOptions {
         // 15. Let roundingMode be ? ToTemporalRoundingMode(roundTo, "halfExpand").
         let rounding_mode = options.rounding_mode.unwrap_or_default();
         // 16. Let smallestUnit be ? GetTemporalUnit(roundTo, "smallestUnit", DATETIME, undefined).
+        UnitGroup::DateTime.validate_unit(options.largest_unit, Some(TemporalUnit::Auto))?;
+        UnitGroup::DateTime.validate_unit(options.smallest_unit, None)?;
         // 17. If smallestUnit is undefined, then
         // a. Set smallestUnitPresent to false.
         // b. Set smallestUnit to "nanosecond".
@@ -286,10 +288,11 @@ impl ResolvedRoundingOptions {
     }
 
     // NOTE: Should the GetTemporalUnitValuedOption check be integrated into these validations.
-    pub(crate) fn from_dt_options(options: RoundingOptions) -> TemporalResult<Self> {
+    pub(crate) fn from_datetime_options(options: RoundingOptions) -> TemporalResult<Self> {
         let increment = options.increment.unwrap_or_default();
         let rounding_mode = options.rounding_mode.unwrap_or_default();
-        let smallest_unit = options.smallest_unit.unwrap_or(TemporalUnit::Day);
+        let smallest_unit = UnitGroup::Time
+            .validate_required_unit(options.smallest_unit, Some(TemporalUnit::Day))?;
         let (maximum, inclusive) = if smallest_unit == TemporalUnit::Day {
             (1, true)
         } else {
@@ -312,10 +315,7 @@ impl ResolvedRoundingOptions {
     pub(crate) fn from_instant_options(options: RoundingOptions) -> TemporalResult<Self> {
         let increment = options.increment.unwrap_or_default();
         let rounding_mode = options.rounding_mode.unwrap_or_default();
-        let Some(smallest_unit) = options.smallest_unit else {
-            return Err(TemporalError::range()
-                .with_message("smallestUnit is required for an Instant.round operation."));
-        };
+        let smallest_unit = UnitGroup::Time.validate_required_unit(options.smallest_unit, None)?;
         let maximum = match smallest_unit {
             TemporalUnit::Hour => 24u64,
             TemporalUnit::Minute => 24 * 60,
@@ -350,18 +350,36 @@ pub enum UnitGroup {
 }
 
 impl UnitGroup {
-    pub fn validate_unit(self, unit: Option<TemporalUnit>) -> TemporalResult<()> {
+    pub fn validate_required_unit(
+        self,
+        unit: Option<TemporalUnit>,
+        extra_unit: Option<TemporalUnit>,
+    ) -> TemporalResult<TemporalUnit> {
+        let Some(unit) = unit else {
+            return Err(TemporalError::range().with_message("Unit is required."));
+        };
+        self.validate_unit(Some(unit), extra_unit)?;
+        Ok(unit)
+    }
+
+    pub fn validate_unit(
+        self,
+        unit: Option<TemporalUnit>,
+        extra_unit: Option<TemporalUnit>,
+    ) -> TemporalResult<()> {
         // TODO: Determine proper handling of Auto.
         match self {
             UnitGroup::Date => match unit {
                 Some(unit) if !unit.is_time_unit() => Ok(()),
                 None => Ok(()),
+                _ if unit == extra_unit => Ok(()),
                 _ => Err(TemporalError::range()
                     .with_message("Unit was not part of the date unit group.")),
             },
             UnitGroup::Time => match unit {
                 Some(unit) if unit.is_time_unit() => Ok(()),
                 None => Ok(()),
+                _ if unit == extra_unit => Ok(()),
                 _ => Err(TemporalError::range()
                     .with_message("Unit was not part of the time unit group.")),
             },


### PR DESCRIPTION
This PR requires a little more testing, but posting as a draft in the meantime.

The changes made are related to adding validation details in boa-dev/boa#4164 into `temporal_rs`'s unit validations, which is incredibly important for `PlainDateTime::round` conformance.

TODO:

  - [x] Test in Boa
  - [x] Add unit tests