### PR TITLE
Fix handling of leap seconds in parsing

### DIFF
--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -671,9 +671,7 @@ impl FromStr for PlainDateTime {
 
         let time = parse_record
             .time
-            .map(|time| {
-                IsoTime::from_components(time.hour, time.minute, time.second, time.nanosecond)
-            })
+            .map(IsoTime::from_time_record)
             .transpose()?
             .unwrap_or_default();
 

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -298,7 +298,7 @@ impl FromStr for Instant {
             ixdtf_record.date.day.into(),
             ixdtf_record.time.hour.into(),
             ixdtf_record.time.minute.into(),
-            ixdtf_record.time.second.into(),
+            ixdtf_record.time.second.clamp(0, 59).into(),
             millisecond.into(),
             microsecond.into(),
             nanosecond as i64 - offset,

--- a/src/builtins/core/time.rs
+++ b/src/builtins/core/time.rs
@@ -458,10 +458,7 @@ impl FromStr for PlainTime {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let result = parse_time(s)?;
-
-        let iso =
-            IsoTime::from_components(result.hour, result.minute, result.second, result.nanosecond)?;
-
+        let iso = IsoTime::from_time_record(result)?;
         Ok(Self::new_unchecked(iso))
     }
 }

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -914,9 +914,7 @@ impl ZonedDateTime {
 
         let time = parse_result
             .time
-            .map(|time| {
-                IsoTime::from_components(time.hour, time.minute, time.second, time.nanosecond)
-            })
+            .map(IsoTime::from_time_record)
             .transpose()?;
 
         let Some(parsed_date) = parse_result.date else {

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -23,6 +23,7 @@
 //! An `IsoDateTime` has the internal slots of both an `IsoDate` and `IsoTime`.
 
 use alloc::string::ToString;
+use ixdtf::parsers::records::TimeRecord;
 use core::num::NonZeroU128;
 
 use crate::{
@@ -625,18 +626,16 @@ impl IsoTime {
     }
 
     /// Returns an `IsoTime` based off parse components.
-    pub(crate) fn from_components(
-        hour: u8,
-        minute: u8,
-        second: u8,
-        fraction: u32,
+    pub(crate) fn from_time_record(
+        time_record: TimeRecord,
     ) -> TemporalResult<Self> {
-        let (millisecond, rem) = fraction.div_rem_euclid(&1_000_000);
+        let second = time_record.second.clamp(0, 59);
+        let (millisecond, rem) = time_record.nanosecond.div_rem_euclid(&1_000_000);
         let (micros, nanos) = rem.div_rem_euclid(&1_000);
 
         Self::new(
-            hour,
-            minute,
+            time_record.hour,
+            time_record.minute,
             second,
             millisecond as u16,
             micros as u16,

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -23,8 +23,8 @@
 //! An `IsoDateTime` has the internal slots of both an `IsoDate` and `IsoTime`.
 
 use alloc::string::ToString;
-use ixdtf::parsers::records::TimeRecord;
 use core::num::NonZeroU128;
+use ixdtf::parsers::records::TimeRecord;
 
 use crate::{
     builtins::core::{
@@ -626,9 +626,7 @@ impl IsoTime {
     }
 
     /// Returns an `IsoTime` based off parse components.
-    pub(crate) fn from_time_record(
-        time_record: TimeRecord,
-    ) -> TemporalResult<Self> {
+    pub(crate) fn from_time_record(time_record: TimeRecord) -> TemporalResult<Self> {
         let second = time_record.second.clamp(0, 59);
         let (millisecond, rem) = time_record.nanosecond.div_rem_euclid(&1_000_000);
         let (micros, nanos) = rem.div_rem_euclid(&1_000);

--- a/src/options/relative_to.rs
+++ b/src/options/relative_to.rs
@@ -103,10 +103,7 @@ impl RelativeTo {
             .transpose()?
             .unwrap_or_default();
 
-        let time = result
-            .time
-            .map(IsoTime::from_time_record)
-            .transpose()?;
+        let time = result.time.map(IsoTime::from_time_record).transpose()?;
 
         let date = result.date.temporal_unwrap()?;
         let iso = IsoDate::new_with_overflow(

--- a/src/options/relative_to.rs
+++ b/src/options/relative_to.rs
@@ -105,9 +105,7 @@ impl RelativeTo {
 
         let time = result
             .time
-            .map(|time| {
-                IsoTime::from_components(time.hour, time.minute, time.second, time.nanosecond)
-            })
+            .map(IsoTime::from_time_record)
             .transpose()?;
 
         let date = result.date.temporal_unwrap()?;


### PR DESCRIPTION
This fixes the handling of leap seconds, which need to be clamped from 60 to 59 according to the specification.