### PR TITLE
Fix parsing bugs related to UTC Designator usage

### DIFF
--- a/src/builtins/core/time.rs
+++ b/src/builtins/core/time.rs
@@ -467,6 +467,8 @@ impl FromStr for PlainTime {
 
 #[cfg(test)]
 mod tests {
+    use core::str::FromStr;
+
     use crate::{
         builtins::core::Duration,
         iso::IsoTime,
@@ -796,5 +798,20 @@ mod tests {
             PlainTime::new_with_overflow(3, 34, 56, 987, 654, 500, ArithmeticOverflow::Constrain)
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn invalid_time_from_strs() {
+        // UTC designator case
+        let invalid_cases = [
+            "2019-10-01T09:00:00Z",
+            "2019-10-01T09:00:00Z[UTC]",
+            "09:00:00Z[UTC]",
+            "09:00:00Z",
+        ];
+        for invalid_str in invalid_cases {
+            let err = PlainTime::from_str(&invalid_str);
+            assert!(err.is_err());
+        }
     }
 }

--- a/src/builtins/core/time.rs
+++ b/src/builtins/core/time.rs
@@ -810,7 +810,7 @@ mod tests {
             "09:00:00Z",
         ];
         for invalid_str in invalid_cases {
-            let err = PlainTime::from_str(&invalid_str);
+            let err = PlainTime::from_str(invalid_str);
             assert!(err.is_err());
         }
     }

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -27,7 +27,7 @@ use crate::{
     rounding::{IncrementRounder, Round},
     temporal_assert,
     time::EpochNanoseconds,
-    Sign, TemporalError, TemporalResult,
+    Sign, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
 /// A struct representing a partial `ZonedDateTime`.
@@ -864,12 +864,10 @@ impl ZonedDateTime {
         offset_option: OffsetDisambiguation,
         provider: &impl TimeZoneProvider,
     ) -> TemporalResult<Self> {
-        let parse_result = parsers::parse_date_time(source)?;
+        let parse_result = parsers::parse_zoned_date_time(source)?;
 
-        let Some(annotation) = parse_result.tz else {
-            return Err(TemporalError::r#type()
-                .with_message("Time zone annotation is required for ZonedDateTime string."));
-        };
+        // NOTE (nekevss): `parse_zoned_date_time` guarantees that this value exists.
+        let annotation = parse_result.tz.temporal_unwrap()?;
 
         let timezone = match annotation.tz {
             TimeZoneRecord::Name(s) => {


### PR DESCRIPTION
`DateTime`, `Date`, and `Time` should reject when the UTC designator `Z` is present.