### PR TITLE
Build out stubs for remaining unimplemented methods

### DIFF
--- a/src/builtins/compiled/duration.rs
+++ b/src/builtins/compiled/duration.rs
@@ -1,6 +1,6 @@
 use crate::{
     builtins::TZ_PROVIDER,
-    options::{RelativeTo, RoundingOptions},
+    options::{RelativeTo, RoundingOptions, TemporalUnit},
     Duration, TemporalError, TemporalResult,
 };
 
@@ -38,5 +38,16 @@ impl Duration {
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
         self.compare_with_provider(two, relative_to, &*provider)
+    }
+
+    pub fn total(
+        &self,
+        unit: TemporalUnit,
+        relative_to: Option<RelativeTo>,
+    ) -> TemporalResult<i64> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.total_with_provider(unit, relative_to, &*provider)
     }
 }

--- a/src/builtins/compiled/zoneddatetime.rs
+++ b/src/builtins/compiled/zoneddatetime.rs
@@ -268,6 +268,14 @@ impl ZonedDateTime {
         self.in_leap_year_with_provider(&*provider)
     }
 
+    // TODO: Update direction to correct option
+    pub fn get_time_zone_transition(&self, direction: bool) -> TemporalResult<Self> {
+        let provider = TZ_PROVIDER
+            .lock()
+            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
+        self.get_time_zone_transition_with_provider(direction, &*provider)
+    }
+
     /// Returns the hours in the day.
     ///
     /// Enable with the `compiled_data` feature flag.

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -626,6 +626,10 @@ impl PlainDateTime {
         Ok(Self::new_unchecked(result, self.calendar.clone()))
     }
 
+    pub fn to_plain_time(&self) -> TemporalResult<PlainTime> {
+        Err(TemporalError::general("Not yet implemented."))
+    }
+
     pub fn to_ixdtf_string(
         &self,
         options: ToStringRoundingOptions,

--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -692,6 +692,17 @@ impl Duration {
         }
     }
 
+    /// Returns the total of the `Duration`
+    pub fn total_with_provider(
+        &self,
+        _unit: TemporalUnit,
+        _relative_to: Option<RelativeTo>,
+        _provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<i64> {
+        Err(TemporalError::general("Not yet implemented"))
+    }
+
+    /// Returns the `Duration` as a formatted string
     pub fn as_temporal_string(&self, options: ToStringRoundingOptions) -> TemporalResult<String> {
         if options.smallest_unit == Some(TemporalUnit::Hour)
             || options.smallest_unit == Some(TemporalUnit::Minute)

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -25,7 +25,7 @@ use num_traits::Euclid;
 
 use super::{
     duration::normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
-    DateDuration,
+    DateDuration, ZonedDateTime,
 };
 
 const NANOSECONDS_PER_SECOND: i64 = 1_000_000_000;
@@ -233,6 +233,11 @@ impl Instant {
     #[must_use]
     pub fn epoch_nanoseconds(&self) -> i128 {
         self.as_i128()
+    }
+
+    // TODO: May need to be moved from a provider API during impl
+    pub fn to_zoned_date_time_iso(&self, _time_zone: TimeZone) -> TemporalResult<ZonedDateTime> {
+        Err(TemporalError::general("Not yet implemented"))
     }
 }
 

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -235,7 +235,7 @@ impl Instant {
         self.as_i128()
     }
 
-    // TODO: May need to be moved from a provider API during impl
+    // TODO: May end up needing a provider API during impl
     pub fn to_zoned_date_time_iso(&self, _time_zone: TimeZone) -> TemporalResult<ZonedDateTime> {
         Err(TemporalError::general("Not yet implemented"))
     }

--- a/src/builtins/core/month_day.rs
+++ b/src/builtins/core/month_day.rs
@@ -12,6 +12,8 @@ use crate::{
     Calendar, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
+use super::{PartialDate, PlainDate};
+
 /// The native Rust implementation of `Temporal.PlainMonthDay`
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -47,6 +49,14 @@ impl PlainMonthDay {
         // 1972 is the first leap year in the Unix epoch (needed to cover all dates)
         let iso = IsoDate::new_with_overflow(ry, month, day, overflow)?;
         Ok(Self::new_unchecked(iso, calendar))
+    }
+
+    pub fn with(
+        &self,
+        _partial: PartialDate,
+        _overflow: ArithmeticOverflow,
+    ) -> TemporalResult<Self> {
+        Err(TemporalError::general("Not yet implemented."))
     }
 
     /// Returns the iso day value of `MonthDay`.
@@ -88,6 +98,10 @@ impl PlainMonthDay {
     #[inline]
     pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
         self.calendar.month_code(&self.iso)
+    }
+
+    pub fn to_plain_date(&self) -> TemporalResult<PlainDate> {
+        Err(TemporalError::general("Not yet implemented"))
     }
 
     pub fn to_ixdtf_string(&self, display_calendar: DisplayCalendar) -> String {

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -408,6 +408,10 @@ impl ZonedDateTime {
         self.instant
     }
 
+    pub fn with(&self, _partial: PartialZonedDateTime) -> TemporalResult<Self> {
+        Err(TemporalError::general("Not yet implemented"))
+    }
+
     /// Creates a new `ZonedDateTime` from the current `ZonedDateTime`
     /// combined with the provided `TimeZone`.
     pub fn with_timezone(&self, timezone: TimeZone) -> TemporalResult<Self> {
@@ -438,6 +442,15 @@ impl ZonedDateTime {
 // ==== HoursInDay accessor method implementation ====
 
 impl ZonedDateTime {
+    // TODO: Add direction parameter to either zoneddatetime.rs or option.rs
+    pub fn get_time_zone_transition_with_provider(
+        &self,
+        _direction: bool,
+        _provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<Self> {
+        Err(TemporalError::general("Not yet implemented"))
+    }
+
     pub fn hours_in_day_with_provider(
         &self,
         provider: &impl TimeZoneProvider,

--- a/temporal_capi/src/duration.rs
+++ b/temporal_capi/src/duration.rs
@@ -228,6 +228,7 @@ pub mod ffi {
         }
 
         // TODO round_with_provider (needs time zone stuff)
+        // TODO total_with_provider (needs time zone stuff)
     }
 }
 

--- a/temporal_capi/src/plain_date_time.rs
+++ b/temporal_capi/src/plain_date_time.rs
@@ -251,6 +251,13 @@ pub mod ffi {
                 .map_err(Into::into)
         }
 
+        pub fn to_plain_time(&self) -> Result<Box<PlainTime>, TemporalError> {
+            self.0
+                .to_plain_time()
+                .map(|x| Box::new(PlainTime(x)))
+                .map_err(Into::into)
+        }
+
         pub fn to_ixdtf_string(
             &self,
             options: ToStringRoundingOptions,

--- a/temporal_capi/src/plain_month_day.rs
+++ b/temporal_capi/src/plain_month_day.rs
@@ -6,6 +6,7 @@ pub mod ffi {
     use crate::error::ffi::TemporalError;
 
     use crate::options::ffi::ArithmeticOverflow;
+    use crate::plain_date::ffi::{PartialDate, PlainDate};
 
     use diplomat_runtime::DiplomatWrite;
     use std::fmt::Write;
@@ -32,6 +33,17 @@ pub mod ffi {
             .map_err(Into::into)
         }
 
+        pub fn with(
+            &self,
+            partial: PartialDate,
+            overflow: ArithmeticOverflow,
+        ) -> Result<Box<PlainMonthDay>, TemporalError> {
+            self.0
+                .with(partial.try_into()?, overflow.into())
+                .map(|x| Box::new(PlainMonthDay(x)))
+                .map_err(Into::into)
+        }
+
         pub fn iso_year(&self) -> i32 {
             self.0.iso_year()
         }
@@ -51,6 +63,13 @@ pub mod ffi {
             // throw away the error, this should always succeed
             let _ = write.write_str(&code);
             Ok(())
+        }
+
+        pub fn to_plain_date(&self) -> Result<Box<PlainDate>, TemporalError> {
+            self.0
+                .to_plain_date()
+                .map(|x| Box::new(PlainDate(x)))
+                .map_err(Into::into)
         }
     }
 }

--- a/temporal_capi/src/plain_year_month.rs
+++ b/temporal_capi/src/plain_year_month.rs
@@ -6,7 +6,8 @@ pub mod ffi {
     use crate::duration::ffi::Duration;
     use crate::error::ffi::TemporalError;
 
-    use crate::options::ffi::ArithmeticOverflow;
+    use crate::options::ffi::{ArithmeticOverflow, DifferenceSettings};
+    use crate::plain_date::ffi::{PartialDate, PlainDate};
     use diplomat_runtime::DiplomatWrite;
     use std::fmt::Write;
 
@@ -30,6 +31,17 @@ pub mod ffi {
             )
             .map(|x| Box::new(PlainYearMonth(x)))
             .map_err(Into::into)
+        }
+
+        pub fn with(
+            &self,
+            partial: PartialDate,
+            overflow: ArithmeticOverflow,
+        ) -> Result<Box<Self>, TemporalError> {
+            self.0
+                .with(partial.try_into()?, overflow.into())
+                .map(|x| Box::new(Self(x)))
+                .map_err(Into::into)
         }
 
         pub fn iso_year(&self) -> i32 {
@@ -95,7 +107,7 @@ pub mod ffi {
             overflow: ArithmeticOverflow,
         ) -> Result<Box<Self>, TemporalError> {
             self.0
-                .add_duration(&duration.0, overflow.into())
+                .add(&duration.0, overflow.into())
                 .map(|x| Box::new(Self(x)))
                 .map_err(Into::into)
         }
@@ -105,8 +117,34 @@ pub mod ffi {
             overflow: ArithmeticOverflow,
         ) -> Result<Box<Self>, TemporalError> {
             self.0
-                .subtract_duration(&duration.0, overflow.into())
+                .subtract(&duration.0, overflow.into())
                 .map(|x| Box::new(Self(x)))
+                .map_err(Into::into)
+        }
+        pub fn until(
+            &self,
+            other: &Self,
+            settings: DifferenceSettings,
+        ) -> Result<Box<Duration>, TemporalError> {
+            self.0
+                .until(&other.0, settings.try_into()?)
+                .map(|x| Box::new(Duration(x)))
+                .map_err(Into::into)
+        }
+        pub fn since(
+            &self,
+            other: &Self,
+            settings: DifferenceSettings,
+        ) -> Result<Box<Duration>, TemporalError> {
+            self.0
+                .since(&other.0, settings.try_into()?)
+                .map(|x| Box::new(Duration(x)))
+                .map_err(Into::into)
+        }
+        pub fn to_plain_date(&self) -> Result<Box<PlainDate>, TemporalError> {
+            self.0
+                .to_plain_date()
+                .map(|x| Box::new(PlainDate(x)))
                 .map_err(Into::into)
         }
     }


### PR DESCRIPTION
Unimplemented methods not being stubbed came up today in the ICU4X call. This implements stubs for the remaining unimplemented methods that I'm currently aware of nobody working on (in order to minimize any conflicts with ongoing work).

This PR also takes a stab at adding the `temporal_capi` methods.

CC: @Manishearth 