### PR TITLE
Add `GetNamedTimeZoneTransition` method to TimeZoneProvider trait

### DIFF
--- a/src/builtins/compiled/zoneddatetime.rs
+++ b/src/builtins/compiled/zoneddatetime.rs
@@ -1,4 +1,5 @@
 use crate::builtins::TZ_PROVIDER;
+use crate::provider::TransitionDirection;
 use crate::ZonedDateTime;
 use crate::{
     options::{
@@ -269,7 +270,10 @@ impl ZonedDateTime {
     }
 
     // TODO: Update direction to correct option
-    pub fn get_time_zone_transition(&self, direction: bool) -> TemporalResult<Self> {
+    pub fn get_time_zone_transition(
+        &self,
+        direction: TransitionDirection,
+    ) -> TemporalResult<Option<Self>> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -457,11 +457,8 @@ impl ZonedDateTime {
         // 10. Else,
         // a. Assert: direction is previous.
         // b. Let transition be GetNamedTimeZonePreviousTransition(timeZone, zonedDateTime.[[EpochNanoseconds]]).
-        let transition = provider.get_named_time_zone_transition(
-            identifier,
-            self.epoch_nanoseconds(),
-            direction,
-        )?;
+        let transition =
+            provider.get_named_tz_transition(identifier, self.epoch_nanoseconds(), direction)?;
 
         // 11. If transition is null, return null.
         // 12. Return ! CreateTemporalZonedDateTime(transition, timeZone, zonedDateTime.[[Calendar]]).

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -70,7 +70,7 @@ pub trait TimeZoneProvider {
     ) -> TemporalResult<TimeZoneOffset>;
 
     // TODO: implement and stabalize
-    fn get_named_time_zone_transition(
+    fn get_named_tz_transition(
         &self,
         identifier: &str,
         epoch_nanoseconds: i128,
@@ -97,7 +97,7 @@ impl TimeZoneProvider for NeverProvider {
         unimplemented!()
     }
 
-    fn get_named_time_zone_transition(
+    fn get_named_tz_transition(
         &self,
         _: &str,
         _: i128,

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -642,7 +642,7 @@ impl TimeZoneProvider for FsTzdbProvider {
         tzif.get(&Seconds(seconds))
     }
 
-    fn get_named_time_zone_transition(
+    fn get_named_tz_transition(
         &self,
         _identifier: &str,
         _epoch_nanoseconds: i128,

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -49,7 +49,7 @@ use tzif::{
 
 use crate::{
     iso::IsoDateTime,
-    provider::{TimeZoneOffset, TimeZoneProvider},
+    provider::{TimeZoneOffset, TimeZoneProvider, TransitionDirection},
     time::EpochNanoseconds,
     utils, TemporalError, TemporalResult,
 };
@@ -640,6 +640,15 @@ impl TimeZoneProvider for FsTzdbProvider {
         let tzif = self.get(identifier)?;
         let seconds = (utc_epoch / 1_000_000_000) as i64;
         tzif.get(&Seconds(seconds))
+    }
+
+    fn get_named_time_zone_transition(
+        &self,
+        _identifier: &str,
+        _epoch_nanoseconds: i128,
+        _direction: TransitionDirection,
+    ) -> TemporalResult<Option<EpochNanoseconds>> {
+        Err(TemporalError::general("Not yet implemented."))
     }
 }
 


### PR DESCRIPTION
This PR adds the stubbed out method to the `TimeZoneProvider` trait, and implements the baseline logic for `ZonedDateTime::get_time_zone_transition`.

This PR also adds the `TransitionDirection` option that lives in the provider module.