### PR TITLE
implement utility methods on partial structs

### DIFF
--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -134,7 +134,7 @@ impl IcuCalendar for Calendar {
 
 impl Calendar {
     #[warn(clippy::wildcard_enum_match_arm)] // Warns if the calendar kind gets out of sync.
-    pub fn new(kind: AnyCalendarKind) -> Self {
+    pub const fn new(kind: AnyCalendarKind) -> Self {
         let cal = match kind {
             AnyCalendarKind::Buddhist => &AnyCalendar::Buddhist(Buddhist),
             AnyCalendarKind::Chinese => const { &AnyCalendar::Chinese(Chinese::new()) },
@@ -172,7 +172,8 @@ impl Calendar {
             }
             AnyCalendarKind::Persian => &AnyCalendar::Persian(Persian),
             AnyCalendarKind::Roc => &AnyCalendar::Roc(Roc),
-            _ => unreachable!("match must handle all variants of `AnyCalendarKind`"),
+            // NOTE: `unreachable!` is not const, but panic is.
+            _ => panic!("Unreachable: match must handle all variants of `AnyCalendarKind`"),
         };
 
         Self(Ref(cal))

--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -125,6 +125,44 @@ macro_rules! impl_with_fallback_method {
     };
 }
 
+/// Convenience methods for building a `PartialDate`
+impl PartialDate {
+    pub const fn with_era(mut self, era: Option<TinyAsciiStr<19>>) -> Self {
+        self.era = era;
+        self
+    }
+
+    pub const fn with_era_year(mut self, era_year: Option<i32>) -> Self {
+        self.era_year = era_year;
+        self
+    }
+
+    pub const fn with_year(mut self, year: Option<i32>) -> Self {
+        self.year = year;
+        self
+    }
+
+    pub const fn with_month(mut self, month: Option<u8>) -> Self {
+        self.month = month;
+        self
+    }
+
+    pub const fn with_month_code(mut self, month_code: Option<TinyAsciiStr<4>>) -> Self {
+        self.month_code = month_code;
+        self
+    }
+
+    pub const fn with_day(mut self, day: Option<u8>) -> Self {
+        self.day = day;
+        self
+    }
+
+    pub const fn with_calendar(mut self, calendar: Calendar) -> Self {
+        self.calendar = calendar;
+        self
+    }
+}
+
 /// The native Rust implementation of `Temporal.PlainDate`.
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use alloc::{format, string::String};
 use core::{cmp::Ordering, str::FromStr};
+use icu_calendar::AnyCalendarKind;
 
 use super::{
     calendar::month_to_month_code,
@@ -127,6 +128,18 @@ macro_rules! impl_with_fallback_method {
 
 /// Convenience methods for building a `PartialDate`
 impl PartialDate {
+    pub const fn new() -> Self {
+        Self {
+            year: None,
+            month: None,
+            month_code: None,
+            day: None,
+            era: None,
+            era_year: None,
+            calendar: Calendar::new(AnyCalendarKind::Iso),
+        }
+    }
+
     pub const fn with_era(mut self, era: Option<TinyAsciiStr<19>>) -> Self {
         self.era = era;
         self
@@ -147,7 +160,7 @@ impl PartialDate {
         self
     }
 
-    pub const fn with_month_code(mut self, month_code: Option<TinyAsciiStr<4>>) -> Self {
+    pub const fn with_month_code(mut self, month_code: Option<MonthCode>) -> Self {
         self.month_code = month_code;
         self
     }

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -28,6 +28,22 @@ pub struct PartialDateTime {
     pub time: PartialTime,
 }
 
+impl PartialDateTime {
+    pub fn is_empty(&self) -> bool {
+        self.date.is_empty() && self.time.is_empty()
+    }
+
+    pub const fn with_partial_date(mut self, partial_date: PartialDate) -> Self {
+        self.date = partial_date;
+        self
+    }
+
+    pub const fn with_partial_time(mut self, partial_time: PartialTime) -> Self {
+        self.time = partial_time;
+        self
+    }
+}
+
 /// The native Rust implementation of `Temporal.PlainDateTime`
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -318,7 +334,7 @@ impl PlainDateTime {
         partial: PartialDateTime,
         overflow: Option<ArithmeticOverflow>,
     ) -> TemporalResult<Self> {
-        if partial.date.is_empty() && partial.time.is_empty() {
+        if partial.is_empty() {
             return Err(TemporalError::r#type().with_message("PartialDateTime cannot be empty."));
         }
         let date = PlainDate::from_partial(partial.date, overflow)?;

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -33,6 +33,13 @@ impl PartialDateTime {
         self.date.is_empty() && self.time.is_empty()
     }
 
+    pub const fn new() -> Self {
+        Self {
+            date: PartialDate::new(),
+            time: PartialTime::new(),
+        }
+    }
+
     pub const fn with_partial_date(mut self, partial_date: PartialDate) -> Self {
         self.date = partial_date;
         self

--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -353,12 +353,6 @@ impl Duration {
         &self.date
     }
 
-    /// Set this `DurationRecord`'s `TimeDuration`.
-    #[inline]
-    pub fn set_time_duration(&mut self, time: TimeDuration) {
-        self.time = time;
-    }
-
     /// Returns the `years` field of duration.
     #[inline]
     #[must_use]

--- a/src/builtins/core/time.rs
+++ b/src/builtins/core/time.rs
@@ -35,8 +35,41 @@ pub struct PartialTime {
 }
 
 impl PartialTime {
-    pub(crate) fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         *self == Self::default()
+    }
+}
+
+/// Convenience methods for building a `PartialTime`
+impl PartialTime {
+    pub const fn with_hour(mut self, hour: Option<u8>) -> Self {
+        self.hour = hour;
+        self
+    }
+
+    pub const fn with_minute(mut self, minute: Option<u8>) -> Self {
+        self.minute = minute;
+        self
+    }
+
+    pub const fn with_second(mut self, second: Option<u8>) -> Self {
+        self.second = second;
+        self
+    }
+
+    pub const fn with_millisecond(mut self, millisecond: Option<u16>) -> Self {
+        self.millisecond = millisecond;
+        self
+    }
+
+    pub const fn with_microsecond(mut self, microsecond: Option<u16>) -> Self {
+        self.microsecond = microsecond;
+        self
+    }
+
+    pub const fn with_nanosecond(mut self, nanosecond: Option<u16>) -> Self {
+        self.nanosecond = nanosecond;
+        self
     }
 }
 

--- a/src/builtins/core/time.rs
+++ b/src/builtins/core/time.rs
@@ -42,6 +42,17 @@ impl PartialTime {
 
 /// Convenience methods for building a `PartialTime`
 impl PartialTime {
+    pub const fn new() -> Self {
+        Self {
+            hour: None,
+            minute: None,
+            second: None,
+            millisecond: None,
+            microsecond: None,
+            nanosecond: None,
+        }
+    }
+
     pub const fn with_hour(mut self, hour: Option<u8>) -> Self {
         self.hour = hour;
         self

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -43,6 +43,35 @@ pub struct PartialZonedDateTime {
     pub timezone: Option<TimeZone>,
 }
 
+impl PartialZonedDateTime {
+    pub fn is_empty(&self) -> bool {
+        self.date.is_empty()
+            && self.time.is_empty()
+            && self.offset.is_none()
+            && self.timezone.is_none()
+    }
+
+    pub const fn with_date(mut self, partial_date: PartialDate) -> Self {
+        self.date = partial_date;
+        self
+    }
+
+    pub const fn with_time(mut self, partial_time: PartialTime) -> Self {
+        self.time = partial_time;
+        self
+    }
+
+    pub fn with_offset(mut self, offset: Option<String>) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    pub fn with_timezone(mut self, timezone: Option<TimeZone>) -> Self {
+        self.timezone = timezone;
+        self
+    }
+}
+
 /// The native Rust implementation of `Temporal.ZonedDateTime`.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -51,6 +51,15 @@ impl PartialZonedDateTime {
             && self.timezone.is_none()
     }
 
+    pub const fn new() -> Self {
+        Self {
+            date: PartialDate::new(),
+            time: PartialTime::new(),
+            offset: None,
+            timezone: None,
+        }
+    }
+
     pub const fn with_date(mut self, partial_date: PartialDate) -> Self {
         self.date = partial_date;
         self


### PR DESCRIPTION
This PR adds methods with the goal of making Partials structs a bit more ergonomic to work with rather than using only struct expressions.

Before:

```rust
let day = Some(24);
let date = PartialDate {
    day,
    ..Default::default()
};
````

After:

```rust
let day = Some(24);
let date = PartialDate::default().with_day(day);
```

If this doesn't make much sense and it's preferred to keep the current method of `StructExpressions`