### PR TITLE
Add `UtcOffset` struct for `PartialZonedDateTime`

### DIFF
--- a/src/builtins/core/timezone.rs
+++ b/src/builtins/core/timezone.rs
@@ -30,8 +30,6 @@ pub struct UtcOffset(pub(crate) i16);
 impl UtcOffset {
     pub(crate) fn from_ixdtf_record(record: UtcOffsetRecord) -> Self {
         // NOTE: ixdtf parser restricts minute/second to 0..=60
-        debug_assert!(record.hour <= 60);
-        debug_assert!(record.minute <= 60);
         let minutes = i16::from(record.hour) * 60 + record.minute as i16;
         Self(minutes * i16::from(record.sign as i8))
     }

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -68,7 +68,7 @@ impl PartialZonedDateTime {
         self
     }
 
-    pub fn with_offset(mut self, offset: Option<String>) -> Self {
+    pub const fn with_offset(mut self, offset: Option<UtcOffset>) -> Self {
         self.offset = offset;
         self
     }

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -2,14 +2,14 @@
 
 use alloc::string::String;
 use core::{cmp::Ordering, num::NonZeroU128};
-use ixdtf::parsers::records::{TimeZoneRecord, UtcOffsetRecordOrZ};
+use ixdtf::parsers::records::UtcOffsetRecordOrZ;
 use tinystr::TinyAsciiStr;
 
 use crate::{
     builtins::core::{
         calendar::Calendar,
         duration::normalized::{NormalizedDurationRecord, NormalizedTimeDuration},
-        timezone::TimeZone,
+        timezone::{TimeZone, UtcOffset},
         Duration, Instant, PlainDate, PlainDateTime, PlainTime,
     },
     iso::{IsoDate, IsoDateTime, IsoTime},
@@ -19,9 +19,7 @@ use crate::{
         ResolvedRoundingOptions, RoundingIncrement, TemporalRoundingMode, TemporalUnit,
         ToStringRoundingOptions, UnitGroup,
     },
-    parsers::{
-        self, parse_offset, FormattableOffset, FormattableTime, IxdtfStringBuilder, Precision,
-    },
+    parsers::{self, FormattableOffset, FormattableTime, IxdtfStringBuilder, Precision},
     partial::{PartialDate, PartialTime},
     provider::TimeZoneProvider,
     rounding::{IncrementRounder, Round},
@@ -38,7 +36,7 @@ pub struct PartialZonedDateTime {
     /// The `PartialTime` portion of a `PartialZonedDateTime`
     pub time: PartialTime,
     /// An optional offset string
-    pub offset: Option<String>,
+    pub offset: Option<UtcOffset>,
     /// The time zone value of a partial time zone.
     pub timezone: Option<TimeZone>,
 }
@@ -359,15 +357,9 @@ impl ZonedDateTime {
         };
 
         // Handle time zones
-        let offset = partial
+        let offset_nanos = partial
             .offset
-            .map(|offset| {
-                let mut cursor = offset.chars().peekable();
-                parse_offset(&mut cursor)
-            })
-            .transpose()?;
-
-        let offset_nanos = offset.map(|minutes| i64::from(minutes) * 60_000_000_000);
+            .map(|offset| i64::from(offset.0) * 60_000_000_000);
 
         let timezone = partial.timezone.unwrap_or_default();
 
@@ -882,18 +874,7 @@ impl ZonedDateTime {
         // NOTE (nekevss): `parse_zoned_date_time` guarantees that this value exists.
         let annotation = parse_result.tz.temporal_unwrap()?;
 
-        let timezone = match annotation.tz {
-            TimeZoneRecord::Name(s) => {
-                TimeZone::IanaIdentifier(String::from_utf8_lossy(s).into_owned())
-            }
-            TimeZoneRecord::Offset(offset_record) => {
-                // NOTE: ixdtf parser restricts minute/second to 0..=60
-                let minutes = i16::from(offset_record.hour) * 60 + offset_record.minute as i16;
-                TimeZone::OffsetMinutes(minutes * i16::from(offset_record.sign as i8))
-            }
-            // TimeZoneRecord is non_exhaustive, but all current branches are matching.
-            _ => return Err(TemporalError::assert()),
-        };
+        let timezone = TimeZone::from_time_zone_record(annotation.tz)?;
 
         let (offset_nanos, is_exact) = parse_result
             .offset

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,8 +96,10 @@ pub mod time {
 }
 
 pub use crate::builtins::{
-    calendar::Calendar, core::timezone::TimeZone, DateDuration, Duration, Instant, Now, PlainDate,
-    PlainDateTime, PlainMonthDay, PlainTime, PlainYearMonth, TimeDuration, ZonedDateTime,
+    calendar::Calendar,
+    core::timezone::{TimeZone, UtcOffset},
+    DateDuration, Duration, Instant, Now, PlainDate, PlainDateTime, PlainMonthDay, PlainTime,
+    PlainYearMonth, TimeDuration, ZonedDateTime,
 };
 
 /// A library specific trait for unwrapping assertions.

--- a/src/options/relative_to.rs
+++ b/src/options/relative_to.rs
@@ -1,16 +1,14 @@
 //! RelativeTo rounding option
 
-use alloc::string::String;
-
 use crate::builtins::core::zoneddatetime::interpret_isodatetime_offset;
 use crate::builtins::core::{calendar::Calendar, timezone::TimeZone, PlainDate, ZonedDateTime};
 use crate::iso::{IsoDate, IsoTime};
 use crate::options::{ArithmeticOverflow, Disambiguation, OffsetDisambiguation};
 use crate::parsers::parse_date_time;
 use crate::provider::TimeZoneProvider;
-use crate::{TemporalError, TemporalResult, TemporalUnwrap};
+use crate::{TemporalResult, TemporalUnwrap};
 
-use ixdtf::parsers::records::{TimeZoneRecord, UtcOffsetRecordOrZ};
+use ixdtf::parsers::records::UtcOffsetRecordOrZ;
 
 // ==== RelativeTo Object ====
 
@@ -62,18 +60,7 @@ impl RelativeTo {
             .into());
         };
 
-        let timezone = match annotation.tz {
-            TimeZoneRecord::Name(s) => {
-                TimeZone::IanaIdentifier(String::from_utf8_lossy(s).into_owned())
-            }
-            TimeZoneRecord::Offset(offset_record) => {
-                // NOTE: ixdtf parser restricts minute/second to 0..=60
-                let minutes = i16::from(offset_record.hour) * 60 + offset_record.minute as i16;
-                TimeZone::OffsetMinutes(minutes * i16::from(offset_record.sign as i8))
-            }
-            // TimeZoneRecord is non_exhaustive, but all current branches are matching.
-            _ => return Err(TemporalError::assert()),
-        };
+        let timezone = TimeZone::from_time_zone_record(annotation.tz)?;
 
         let (offset_nanos, is_exact) = result
             .offset


### PR DESCRIPTION
This PR introduces to `UtcOffset` parse for use with `PartialZonedDateTime`.

The goal ultimately is providing the tools / API for [PrepareCalendarFields](https://tc39.es/proposal-temporal/#sec-temporal-preparecalendarfields) to be implemented, specifically the ToOffsetString conversion, while also better representing the general invariant of `PartialZonedDateTime`'s offset.