### PR TITLE
Integrate `MonthCode` into public API and related adjustments

### DIFF
--- a/src/builtins/compiled/zoneddatetime.rs
+++ b/src/builtins/compiled/zoneddatetime.rs
@@ -5,7 +5,7 @@ use crate::{
         ArithmeticOverflow, DifferenceSettings, Disambiguation, DisplayCalendar, DisplayOffset,
         DisplayTimeZone, OffsetDisambiguation, ToStringRoundingOptions,
     },
-    Duration, PlainDate, PlainDateTime, PlainTime, TemporalError, TemporalResult,
+    Duration, MonthCode, PlainDate, PlainDateTime, PlainTime, TemporalError, TemporalResult,
 };
 use alloc::string::String;
 use tinystr::TinyAsciiStr;
@@ -58,7 +58,7 @@ impl ZonedDateTime {
     /// Returns the `ZonedDateTime`'s calendar month code.
     ///
     /// Enable with the `compiled_data` feature flag.
-    pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
+    pub fn month_code(&self) -> TemporalResult<MonthCode> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -40,8 +40,8 @@ use super::{PartialDate, ZonedDateTime};
 mod era;
 mod types;
 
-pub use types::ResolvedCalendarFields;
-pub(crate) use types::{ascii_four_to_integer, month_to_month_code};
+pub(crate) use types::month_to_month_code;
+pub use types::{MonthCode, ResolvedCalendarFields};
 
 use era::EraInfo;
 
@@ -232,7 +232,7 @@ impl Calendar {
             // Resolve month and monthCode;
             return PlainDate::new_with_overflow(
                 resolved_fields.era_year.year,
-                resolved_fields.month_code.as_iso_month_integer()?,
+                resolved_fields.month_code.to_month_integer(),
                 resolved_fields.day,
                 self.clone(),
                 overflow,
@@ -267,7 +267,7 @@ impl Calendar {
         let resolved_fields = ResolvedCalendarFields::try_from_partial(partial, overflow)?;
         if self.is_iso() {
             return PlainMonthDay::new_with_overflow(
-                resolved_fields.month_code.as_iso_month_integer()?,
+                resolved_fields.month_code.to_month_integer(),
                 resolved_fields.day,
                 self.clone(),
                 overflow,
@@ -290,7 +290,7 @@ impl Calendar {
         if self.is_iso() {
             return PlainYearMonth::new_with_overflow(
                 resolved_fields.era_year.year,
-                resolved_fields.month_code.as_iso_month_integer()?,
+                resolved_fields.month_code.to_month_integer(),
                 Some(resolved_fields.day),
                 self.clone(),
                 overflow,
@@ -401,9 +401,10 @@ impl Calendar {
     }
 
     /// `CalendarMonthCode`
-    pub fn month_code(&self, iso_date: &IsoDate) -> TemporalResult<TinyAsciiStr<4>> {
+    pub fn month_code(&self, iso_date: &IsoDate) -> TemporalResult<MonthCode> {
         if self.is_iso() {
-            return Ok(iso_date.as_icu4x()?.month().standard_code.0);
+            let mc = iso_date.as_icu4x()?.month().standard_code.0;
+            return Ok(MonthCode(mc));
         }
 
         Err(TemporalError::range().with_message("Not yet implemented."))

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -9,7 +9,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::str::FromStr;
 use icu_calendar::types::{Era as IcuEra, MonthCode as IcuMonthCode, MonthInfo, YearInfo};
-use types::ResolveType;
+use types::ResolutionType;
 
 use crate::{
     builtins::core::{
@@ -228,7 +228,7 @@ impl Calendar {
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<PlainDate> {
         let resolved_fields =
-            ResolvedCalendarFields::try_from_partial(partial, overflow, ResolveType::Date)?;
+            ResolvedCalendarFields::try_from_partial(partial, overflow, ResolutionType::Date)?;
 
         if self.is_iso() {
             // Resolve month and monthCode;
@@ -267,7 +267,7 @@ impl Calendar {
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<PlainMonthDay> {
         let resolved_fields =
-            ResolvedCalendarFields::try_from_partial(partial, overflow, ResolveType::MonthDay)?;
+            ResolvedCalendarFields::try_from_partial(partial, overflow, ResolutionType::MonthDay)?;
         if self.is_iso() {
             return PlainMonthDay::new_with_overflow(
                 resolved_fields.month_code.to_month_integer(),
@@ -290,7 +290,7 @@ impl Calendar {
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<PlainYearMonth> {
         let resolved_fields =
-            ResolvedCalendarFields::try_from_partial(partial, overflow, ResolveType::YearMonth)?;
+            ResolvedCalendarFields::try_from_partial(partial, overflow, ResolutionType::YearMonth)?;
         if self.is_iso() {
             return PlainYearMonth::new_with_overflow(
                 resolved_fields.era_year.year,

--- a/src/builtins/core/calendar/types.rs
+++ b/src/builtins/core/calendar/types.rs
@@ -303,11 +303,11 @@ fn are_month_and_month_code_resolvable(month: u8, mc: &MonthCode) -> TemporalRes
 }
 
 // Potentially greedy. Need to verify for all calendars that
-// the code interger aligns with the month integer, which
+// the month code integer aligns with the month integer, which
 // may require calendar info
 pub(crate) fn ascii_four_to_integer(mc: TinyAsciiStr<4>) -> u8 {
     let bytes = mc.all_bytes();
-    // Invariant: first and second character are ascii digits.
+    // Invariant: second and third character (index 1 and 2) are ascii digits.
     debug_assert!(bytes[1].is_ascii_digit());
     debug_assert!(bytes[2].is_ascii_digit());
     let first = ascii_digit_to_int(bytes[1]) * 10;

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     parsers::{parse_date_time, IxdtfStringBuilder},
     provider::NeverProvider,
-    temporal_assert, TemporalError, TemporalResult, TemporalUnwrap, TimeZone,
+    temporal_assert, MonthCode, TemporalError, TemporalResult, TemporalUnwrap, TimeZone,
 };
 use alloc::string::String;
 use core::{cmp::Ordering, str::FromStr};
@@ -503,7 +503,7 @@ impl PlainDateTime {
     }
 
     /// Returns the calendar month code value.
-    pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
+    pub fn month_code(&self) -> TemporalResult<MonthCode> {
         self.calendar.month_code(&self.iso.date)
     }
 
@@ -711,7 +711,7 @@ mod tests {
         },
         parsers::Precision,
         primitive::FiniteF64,
-        TemporalResult,
+        MonthCode, TemporalResult,
     };
 
     fn assert_datetime(
@@ -720,7 +720,7 @@ mod tests {
     ) {
         assert_eq!(dt.year().unwrap(), fields.0);
         assert_eq!(dt.month().unwrap(), fields.1);
-        assert_eq!(dt.month_code().unwrap(), fields.2);
+        assert_eq!(dt.month_code().unwrap(), MonthCode(fields.2));
         assert_eq!(dt.day().unwrap(), fields.3);
         assert_eq!(dt.hour(), fields.4);
         assert_eq!(dt.minute(), fields.5);
@@ -813,7 +813,7 @@ mod tests {
         // Test monthCode
         let partial = PartialDateTime {
             date: PartialDate {
-                month_code: Some(tinystr!(4, "M05")),
+                month_code: Some(MonthCode(tinystr!(4, "M05"))),
                 ..Default::default()
             },
             time: PartialTime::default(),

--- a/src/builtins/core/month_day.rs
+++ b/src/builtins/core/month_day.rs
@@ -3,13 +3,11 @@
 use alloc::string::String;
 use core::str::FromStr;
 
-use tinystr::TinyAsciiStr;
-
 use crate::{
     iso::IsoDate,
     options::{ArithmeticOverflow, DisplayCalendar},
     parsers::{FormattableCalendar, FormattableDate, FormattableMonthDay},
-    Calendar, TemporalError, TemporalResult, TemporalUnwrap,
+    Calendar, MonthCode, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
 use super::{PartialDate, PlainDate};
@@ -96,7 +94,7 @@ impl PlainMonthDay {
 
     /// Returns the `monthCode` value of `MonthDay`.
     #[inline]
-    pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
+    pub fn month_code(&self) -> TemporalResult<MonthCode> {
         self.calendar.month_code(&self.iso)
     }
 

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -10,7 +10,7 @@ use crate::{
     options::{ArithmeticOverflow, DifferenceOperation, DifferenceSettings, DisplayCalendar},
     parsers::{FormattableCalendar, FormattableDate, FormattableYearMonth},
     utils::pad_iso_year,
-    Calendar, TemporalError, TemporalResult, TemporalUnwrap,
+    Calendar, MonthCode, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
 use super::{Duration, PartialDate, PlainDate};
@@ -127,7 +127,7 @@ impl PlainYearMonth {
     }
 
     /// Returns the calendar month code of the current `PlainYearMonth`
-    pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
+    pub fn month_code(&self) -> TemporalResult<MonthCode> {
         self.calendar().month_code(&self.iso)
     }
 

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -27,7 +27,7 @@ use crate::{
     rounding::{IncrementRounder, Round},
     temporal_assert,
     time::EpochNanoseconds,
-    Sign, TemporalError, TemporalResult, TemporalUnwrap,
+    MonthCode, Sign, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
 /// A struct representing a partial `ZonedDateTime`.
@@ -497,7 +497,7 @@ impl ZonedDateTime {
     pub fn month_code_with_provider(
         &self,
         provider: &impl TimeZoneProvider,
-    ) -> TemporalResult<TinyAsciiStr<4>> {
+    ) -> TemporalResult<MonthCode> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
         self.calendar.month_code(&dt.iso.date)
@@ -1101,7 +1101,7 @@ mod tests {
         partial::{PartialDate, PartialTime, PartialZonedDateTime},
         primitive::FiniteF64,
         tzdb::FsTzdbProvider,
-        Calendar, TimeZone,
+        Calendar, MonthCode, TimeZone,
     };
     use core::str::FromStr;
     use tinystr::tinystr;
@@ -1160,7 +1160,7 @@ mod tests {
         let partial = PartialZonedDateTime {
             date: PartialDate {
                 year: Some(1970),
-                month_code: Some(tinystr!(4, "M01")),
+                month_code: Some(MonthCode(tinystr!(4, "M01"))),
                 day: Some(1),
                 ..Default::default()
             },

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -994,6 +994,7 @@ fn balance_iso_year_month(year: i32, month: i32) -> (i32, u8) {
     (y, m as u8)
 }
 
+/// Note: month is 1 based.
 #[inline]
 pub(crate) fn constrain_iso_day(year: i32, month: u8, day: u8) -> u8 {
     let days_in_month = utils::iso_days_in_month(year, month.into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,8 +96,10 @@ pub mod time {
 }
 
 pub use crate::builtins::{
-    calendar::Calendar, core::timezone::TimeZone, DateDuration, Duration, Instant, Now, PlainDate,
-    PlainDateTime, PlainMonthDay, PlainTime, PlainYearMonth, TimeDuration, ZonedDateTime,
+    calendar::{Calendar, MonthCode},
+    core::timezone::TimeZone,
+    DateDuration, Duration, Instant, Now, PlainDate, PlainDateTime, PlainMonthDay, PlainTime,
+    PlainYearMonth, TimeDuration, ZonedDateTime,
 };
 
 /// A library specific trait for unwrapping assertions.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -148,6 +148,8 @@ pub(crate) fn epoch_seconds_to_day_of_month(t: i64) -> u16 {
 // NOTE: below was the iso methods in temporal::calendar -> Need to be reassessed.
 
 /// 12.2.31 `ISODaysInMonth ( year, month )`
+///
+/// NOTE: month is 1 based
 pub(crate) fn iso_days_in_month(year: i32, month: i32) -> u8 {
     match month {
         1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,

--- a/temporal_capi/src/calendar.rs
+++ b/temporal_capi/src/calendar.rs
@@ -150,7 +150,7 @@ pub mod ffi {
                 .month_code(&date.into())
                 .map_err(Into::<TemporalError>::into)?;
             // throw away the error, this should always succeed
-            let _ = write.write_str(&code);
+            let _ = write.write_str(code.as_str());
             Ok(())
         }
         pub fn day(&self, date: IsoDate) -> Result<u8, TemporalError> {

--- a/temporal_capi/src/plain_date.rs
+++ b/temporal_capi/src/plain_date.rs
@@ -1,3 +1,5 @@
+use temporal_rs::MonthCode;
+
 use crate::error::ffi::TemporalError;
 
 #[diplomat::bridge]
@@ -166,7 +168,7 @@ pub mod ffi {
         pub fn month_code(&self, write: &mut DiplomatWrite) -> Result<(), TemporalError> {
             let code = self.0.month_code().map_err(Into::<TemporalError>::into)?;
             // throw away the error, this should always succeed
-            let _ = write.write_str(&code);
+            let _ = write.write_str(code.as_str());
             Ok(())
         }
         pub fn day(&self) -> Result<u8, TemporalError> {
@@ -258,7 +260,7 @@ impl TryFrom<ffi::PartialDate<'_>> for temporal_rs::partial::PartialDate {
             None
         } else {
             Some(
-                TinyAsciiStr::try_from_utf8(other.month_code.into())
+                MonthCode::try_from_utf8(other.month_code.into())
                     .map_err(|_| TemporalError::syntax())?,
             )
         };

--- a/temporal_capi/src/plain_date_time.rs
+++ b/temporal_capi/src/plain_date_time.rs
@@ -156,7 +156,7 @@ pub mod ffi {
         pub fn month_code(&self, write: &mut DiplomatWrite) -> Result<(), TemporalError> {
             let code = self.0.month_code().map_err(Into::<TemporalError>::into)?;
             // throw away the error, this should always succeed
-            let _ = write.write_str(&code);
+            let _ = write.write_str(code.as_str());
             Ok(())
         }
         pub fn day(&self) -> Result<u8, TemporalError> {

--- a/temporal_capi/src/plain_month_day.rs
+++ b/temporal_capi/src/plain_month_day.rs
@@ -61,7 +61,7 @@ pub mod ffi {
         pub fn month_code(&self, write: &mut DiplomatWrite) -> Result<(), TemporalError> {
             let code = self.0.month_code().map_err(Into::<TemporalError>::into)?;
             // throw away the error, this should always succeed
-            let _ = write.write_str(&code);
+            let _ = write.write_str(code.as_str());
             Ok(())
         }
 

--- a/temporal_capi/src/plain_year_month.rs
+++ b/temporal_capi/src/plain_year_month.rs
@@ -68,7 +68,7 @@ pub mod ffi {
         pub fn month_code(&self, write: &mut DiplomatWrite) -> Result<(), TemporalError> {
             let code = self.0.month_code().map_err(Into::<TemporalError>::into)?;
             // throw away the error, this should always succeed
-            let _ = write.write_str(&code);
+            let _ = write.write_str(code.as_str());
             Ok(())
         }
 


### PR DESCRIPTION
This change integrate `MonthCode` into the public API of the partial fields and `month_code` methods in order to better represent [PrepareCalendarFields](https://tc39.es/proposal-temporal/#sec-temporal-preparecalendarfields) conversion.

This does also add a host of public APIs to `MonthCode` for interacting with it and adjusts the general validation methods (although, I do suspect this will need to be iterated on in the future to better support more calendars).

CC: @Manishearth as this includes updates to `temporal_capi`