### PR TITLE
Add with to PlainYearMonth

### DIFF
--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -77,7 +77,7 @@ impl PartialDate {
             calendar: year_month.calendar().clone(),
         })
     }
-
+    crate::impl_with_fallback_method!(with_fallback_year_month, PlainYearMonth);
     crate::impl_with_fallback_method!(with_fallback_date, PlainDate);
     crate::impl_with_fallback_method!(with_fallback_datetime, PlainDateTime);
     // TODO: ZonedDateTime


### PR DESCRIPTION
Worked with @HenrikTennebekk on #143

We encountered an issue in `temporal_capi/src/plain_year_month.rs`.
Error: 
the trait From<options::ffi::ArithmeticOverflow> is not implemented for Option<temporal_rs::options::ArithmeticOverflow>

Unsure how to fix this.
