### PR TITLE
Update ixdtf to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,8 +495,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "ixdtf"
-version = "0.3.0"
-source = "git+https://github.com/unicode-org/icu4x.git?rev=3d187da4d3f05b7e37603c4be3f2c1ce45100e03#3d187da4d3f05b7e37603c4be3f2c1ce45100e03"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3be3d801e2817c5311a3be4f1e1b2148dcd2b10baadb3a5eade0544a0521ac9"
 dependencies = [
  "displaydoc",
  "utf8_iter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ icu_calendar = { version = "2.0.0-beta2", default-features = false}
 rustc-hash = "2.1.0"
 bitflags = "2.7.0"
 num-traits = "0.2.19"
-ixdtf = { git = "https://github.com/unicode-org/icu4x.git", rev = "3d187da4d3f05b7e37603c4be3f2c1ce45100e03" }
+ixdtf = "0.4.0"
 iana-time-zone = "0.1.61"
 log = "0.4.26"
 tzif = "0.3.0"

--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -928,8 +928,9 @@ impl FromStr for Duration {
 
         let (hours, minutes, seconds, millis, micros, nanos) = match parse_record.time {
             Some(TimeDurationRecord::Hours { hours, fraction }) => {
-                let minutes = fraction.div_euclid(60 * 1_000_000_000);
-                let rem = fraction.rem_euclid(60 * 1_000_000_000);
+                let ns = fraction.and_then(|x| x.to_nanoseconds()).unwrap_or(0);
+                let minutes = ns.div_euclid(60 * 1_000_000_000);
+                let rem = ns.rem_euclid(60 * 1_000_000_000);
 
                 let seconds = rem.div_euclid(1_000_000_000);
                 let rem = rem.rem_euclid(1_000_000_000);
@@ -955,8 +956,9 @@ impl FromStr for Duration {
                 minutes,
                 fraction,
             }) => {
-                let seconds = fraction.div_euclid(1_000_000_000);
-                let rem = fraction.rem_euclid(1_000_000_000);
+                let ns = fraction.and_then(|x| x.to_nanoseconds()).unwrap_or(0);
+                let seconds = ns.div_euclid(1_000_000_000);
+                let rem = ns.rem_euclid(1_000_000_000);
 
                 let milliseconds = rem.div_euclid(1_000_000);
                 let rem = rem.rem_euclid(1_000_000);
@@ -980,8 +982,9 @@ impl FromStr for Duration {
                 seconds,
                 fraction,
             }) => {
-                let milliseconds = fraction.div_euclid(1_000_000);
-                let rem = fraction.rem_euclid(1_000_000);
+                let ns = fraction.and_then(|x| x.to_nanoseconds()).unwrap_or(0);
+                let milliseconds = ns.div_euclid(1_000_000);
+                let rem = ns.rem_euclid(1_000_000);
 
                 let microseconds = rem.div_euclid(1_000);
                 let nanoseconds = rem.rem_euclid(1_000);

--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -7,7 +7,7 @@ use crate::{
         ArithmeticOverflow, RelativeTo, ResolvedRoundingOptions, RoundingIncrement,
         RoundingOptions, TemporalUnit, ToStringRoundingOptions,
     },
-    parsers::{FormattableDuration, Precision},
+    parsers::{FormattableDateDuration, FormattableDuration, FormattableTimeDuration, Precision},
     primitive::FiniteF64,
     provider::TimeZoneProvider,
     temporal_assert, Sign, TemporalError, TemporalResult,
@@ -17,10 +17,7 @@ use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::{cmp::Ordering, str::FromStr};
-use ixdtf::parsers::{
-    records::{DateDurationRecord, DurationParseRecord, Sign as IxdtfSign, TimeDurationRecord},
-    IsoDurationParser,
-};
+use ixdtf::parsers::{records::TimeDurationRecord, IsoDurationParser};
 use normalized::NormalizedDurationRecord;
 use num_traits::AsPrimitive;
 
@@ -744,15 +741,10 @@ pub fn duration_to_formattable(
     precision: Precision,
 ) -> TemporalResult<FormattableDuration> {
     let sign = duration.sign();
-    let sign = if sign == Sign::Negative {
-        IxdtfSign::Negative
-    } else {
-        IxdtfSign::Positive
-    };
     let duration = duration.abs();
     let date = duration.years().0 + duration.months().0 + duration.weeks().0 + duration.days().0;
     let date = if date != 0.0 {
-        Some(DateDurationRecord {
+        Some(FormattableDateDuration {
             years: duration.years().0 as u32,
             months: duration.months().0 as u32,
             weeks: duration.weeks().0 as u32,
@@ -777,16 +769,18 @@ pub fn duration_to_formattable(
     let seconds = time.seconds().unsigned_abs();
     let subseconds = time.subseconds().unsigned_abs();
 
-    let time = Some(TimeDurationRecord::Seconds {
-        hours: hours.0 as u64,
-        minutes: minutes.0 as u64,
+    let time = Some(FormattableTimeDuration::Seconds(
+        hours.0 as u64,
+        minutes.0 as u64,
         seconds,
-        fraction: subseconds,
-    });
+        Some(subseconds),
+    ));
 
     Ok(FormattableDuration {
         precision,
-        duration: DurationParseRecord { sign, date, time },
+        sign,
+        date,
+        time,
     })
 }
 
@@ -928,7 +922,7 @@ impl FromStr for Duration {
 
         let (hours, minutes, seconds, millis, micros, nanos) = match parse_record.time {
             Some(TimeDurationRecord::Hours { hours, fraction }) => {
-                let ns = fraction.and_then(|x| x.to_nanoseconds()).unwrap_or(0);
+                let ns = fraction.and_then(|x| x.to_nanoseconds()).unwrap_or(0) as u64;
                 let minutes = ns.div_euclid(60 * 1_000_000_000);
                 let rem = ns.rem_euclid(60 * 1_000_000_000);
 

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -299,7 +299,12 @@ impl FromStr for Instant {
             UtcOffsetRecordOrZ::Z => 0,
         };
 
-        let (millisecond, rem) = ns_offset.div_rem_euclid(&1_000_000);
+        let time_nanoseconds = ixdtf_record
+            .time
+            .fraction
+            .and_then(|x| x.to_nanoseconds())
+            .unwrap_or(0);
+        let (millisecond, rem) = time_nanoseconds.div_rem_euclid(&1_000_000);
         let (microsecond, nanosecond) = rem.div_rem_euclid(&1_000);
 
         let balanced = IsoDateTime::balance(

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -284,17 +284,22 @@ impl FromStr for Instant {
         let ixdtf_record = parse_instant(s)?;
 
         // Find the offset
-        let offset = match ixdtf_record.offset {
+        let ns_offset = match ixdtf_record.offset {
             UtcOffsetRecordOrZ::Offset(offset) => {
+                let ns = offset
+                    .fraction
+                    .and_then(|x| x.to_nanoseconds())
+                    .unwrap_or(0);
                 (offset.hour as i64 * NANOSECONDS_PER_HOUR
                     + i64::from(offset.minute) * NANOSECONDS_PER_MINUTE
                     + i64::from(offset.second) * NANOSECONDS_PER_SECOND
-                    + i64::from(offset.nanosecond))
+                    + i64::from(ns))
                     * offset.sign as i64
             }
             UtcOffsetRecordOrZ::Z => 0,
         };
-        let (millisecond, rem) = ixdtf_record.time.nanosecond.div_rem_euclid(&1_000_000);
+
+        let (millisecond, rem) = ns_offset.div_rem_euclid(&1_000_000);
         let (microsecond, nanosecond) = rem.div_rem_euclid(&1_000);
 
         let balanced = IsoDateTime::balance(
@@ -306,7 +311,7 @@ impl FromStr for Instant {
             ixdtf_record.time.second.clamp(0, 59).into(),
             millisecond.into(),
             microsecond.into(),
-            nanosecond as i64 - offset,
+            nanosecond as i64 - ns_offset,
         );
 
         let nanoseconds = balanced.as_nanoseconds()?;

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -960,12 +960,14 @@ impl ZonedDateTime {
                 let hours_in_ns = i64::from(offset.hour) * 3_600_000_000_000_i64;
                 let minutes_in_ns = i64::from(offset.minute) * 60_000_000_000_i64;
                 let seconds_in_ns = i64::from(offset.minute) * 1_000_000_000_i64;
+                let ns = offset
+                    .fraction
+                    .and_then(|x| x.to_nanoseconds())
+                    .unwrap_or(0);
+
                 (
                     Some(
-                        (hours_in_ns
-                            + minutes_in_ns
-                            + seconds_in_ns
-                            + i64::from(offset.nanosecond))
+                        (hours_in_ns + minutes_in_ns + seconds_in_ns + i64::from(ns))
                             * i64::from(offset.sign as i8),
                     ),
                     false,

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -635,7 +635,11 @@ impl IsoTime {
     /// Returns an `IsoTime` based off parse components.
     pub(crate) fn from_time_record(time_record: TimeRecord) -> TemporalResult<Self> {
         let second = time_record.second.clamp(0, 59);
-        let (millisecond, rem) = time_record.nanosecond.div_rem_euclid(&1_000_000);
+        let (millisecond, rem) = time_record
+            .fraction
+            .and_then(|x| x.to_nanoseconds())
+            .map(|x| x.div_rem_euclid(&1_000_000))
+            .unwrap_or((0, 0));
         let (micros, nanos) = rem.div_rem_euclid(&1_000);
 
         Self::new(

--- a/src/options/relative_to.rs
+++ b/src/options/relative_to.rs
@@ -84,12 +84,13 @@ impl RelativeTo {
                 let hours_in_ns = i64::from(offset.hour) * 3_600_000_000_000_i64;
                 let minutes_in_ns = i64::from(offset.minute) * 60_000_000_000_i64;
                 let seconds_in_ns = i64::from(offset.minute) * 1_000_000_000_i64;
+                let ns = offset
+                    .fraction
+                    .and_then(|x| x.to_nanoseconds())
+                    .unwrap_or(0);
                 (
                     Some(
-                        (hours_in_ns
-                            + minutes_in_ns
-                            + seconds_in_ns
-                            + i64::from(offset.nanosecond))
+                        (hours_in_ns + minutes_in_ns + seconds_in_ns + i64::from(ns))
                             * i64::from(offset.sign as i8),
                     ),
                     false,


### PR DESCRIPTION
I can't figure out how to construct a `fraction`, do we need to add APIs upstream?

It may also be worth it to add a direct `.to_milliseconds_and_microseconds()` API to Fraction.