### PR TITLE
Fix `Instant::epoch_milliseconds` for values before Epoch

### DIFF
--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -361,6 +361,28 @@ mod tests {
     }
 
     #[test]
+    fn max_min_epoch_millseconds() {
+        // Assert the casting is valid.
+        let max = NS_MAX_INSTANT;
+        let min = NS_MIN_INSTANT;
+        let max_instant = Instant::try_new(max).unwrap();
+        let min_instant = Instant::try_new(min).unwrap();
+
+        // Assert max and min are valid for casting.
+        assert_eq!(
+            max_instant.epoch_milliseconds(),
+            max.div_euclid(1_000_000) as i64
+        );
+        assert_eq!(
+            min_instant.epoch_milliseconds(),
+            min.div_euclid(1_000_000) as i64
+        );
+        // Assert the max and min are not being truncated.
+        assert_ne!(max_instant.epoch_milliseconds(), i64::MAX);
+        assert_ne!(max_instant.epoch_milliseconds(), i64::MIN);
+    }
+
+    #[test]
     fn instant_parsing_limits() {
         // valid cases
         let valid_str = "-271821-04-20T00:00Z";

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -226,7 +226,7 @@ impl Instant {
     /// Returns the `epochMilliseconds` value for this `Instant`.
     #[must_use]
     pub fn epoch_milliseconds(&self) -> i64 {
-        (self.as_i128() / 1_000_000) as i64
+        self.as_i128().div_euclid(1_000_000) as i64
     }
 
     /// Returns the `epochNanoseconds` value for this `Instant`.


### PR DESCRIPTION
Fix `epoch_milliseconds` not using `div_euclid` and add a unit test.