### PR TITLE
Fixes for `EpochNanosecond`s and `Offset` parsing

### DIFF
--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -87,7 +87,7 @@ impl PlainDateTime {
         offset: i64,
         calendar: Calendar,
     ) -> TemporalResult<Self> {
-        let iso = IsoDateTime::from_epoch_nanos(&instant.as_i128(), offset)?;
+        let iso = IsoDateTime::from_epoch_nanos(instant.epoch_nanoseconds(), offset)?;
         Ok(Self { iso, calendar })
     }
 

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -52,7 +52,7 @@ impl Instant {
     /// Temporal-Proposal equivalent: `AddInstant`.
     pub(crate) fn add_to_instant(&self, duration: &TimeDuration) -> TemporalResult<Self> {
         let norm = NormalizedTimeDuration::from_time_duration(duration);
-        let result = self.epoch_nanoseconds() + norm.0;
+        let result = self.epoch_nanoseconds().0 + norm.0;
         Ok(Self::from(EpochNanoseconds::try_from(result)?))
     }
 
@@ -231,8 +231,8 @@ impl Instant {
 
     /// Returns the `epochNanoseconds` value for this `Instant`.
     #[must_use]
-    pub fn epoch_nanoseconds(&self) -> i128 {
-        self.as_i128()
+    pub fn epoch_nanoseconds(&self) -> &EpochNanoseconds {
+        &self.0
     }
 
     // TODO: May end up needing a provider API during impl
@@ -340,8 +340,8 @@ mod tests {
         let max_instant = Instant::try_new(max).unwrap();
         let min_instant = Instant::try_new(min).unwrap();
 
-        assert_eq!(max_instant.epoch_nanoseconds(), max);
-        assert_eq!(min_instant.epoch_nanoseconds(), min);
+        assert_eq!(max_instant.epoch_nanoseconds().0, max);
+        assert_eq!(min_instant.epoch_nanoseconds().0, min);
 
         let max_plus_one = NS_MAX_INSTANT + 1;
         let min_minus_one = NS_MIN_INSTANT - 1;

--- a/src/builtins/core/timezone.rs
+++ b/src/builtins/core/timezone.rs
@@ -96,7 +96,7 @@ impl TimeZone {
         provider: &impl TimeZoneProvider,
     ) -> TemporalResult<IsoDateTime> {
         let nanos = self.get_offset_nanos_for(instant.as_i128(), provider)?;
-        IsoDateTime::from_epoch_nanos(&instant.as_i128(), nanos.to_i64().unwrap_or(0))
+        IsoDateTime::from_epoch_nanos(instant.epoch_nanoseconds(), nanos.to_i64().unwrap_or(0))
     }
 
     /// Get the offset for this current `TimeZoneSlot`.

--- a/src/epoch_nanoseconds.rs
+++ b/src/epoch_nanoseconds.rs
@@ -38,6 +38,13 @@ impl TryFrom<f64> for EpochNanoseconds {
     }
 }
 
+// Potential TODO: Build out primitive arthmetic methods if needed.
+impl EpochNanoseconds {
+    pub fn as_i128(&self) -> i128 {
+        self.0
+    }
+}
+
 /// Utility for determining if the nanos are within a valid range.
 #[inline]
 #[must_use]

--- a/src/parsers/timezone.rs
+++ b/src/parsers/timezone.rs
@@ -77,6 +77,10 @@ pub(crate) fn parse_offset(chars: &mut Peekable<Chars<'_>>) -> TemporalResult<i1
     // First offset portion
     let hours = parse_digit_pair(chars)?;
 
+    if !(0..24).contains(&hours) {
+        return Err(TemporalError::range().with_message("Invalid offset hour value."));
+    }
+
     let sep = chars.peek().is_some_and(|ch| *ch == ':');
     if sep {
         let _ = chars.next();
@@ -90,7 +94,54 @@ pub(crate) fn parse_offset(chars: &mut Peekable<Chars<'_>>) -> TemporalResult<i1
         None => 0,
     };
 
-    Ok((hours * 60 + minutes) * sign)
+    if !(0..60).contains(&minutes) {
+        return Err(TemporalError::range().with_message("Invalid offset hour value."));
+    }
+
+    let result = (hours * 60 + minutes) * sign;
+
+    // We continue parsing for correctness, but we only care about
+    // minute precision
+
+    let next_peek = chars.peek();
+    match next_peek {
+        Some(&':') if sep => _ = chars.next(),
+        Some(&':') => {
+            return Err(TemporalError::range().with_message("offset separators do not align."))
+        }
+        Some(_) => _ = parse_digit_pair(chars),
+        None => return Ok(result),
+    }
+
+    let potential_fraction = chars.next();
+    match potential_fraction {
+        Some(ch) if ch == '.' || ch == ',' => {
+            if !chars.peek().is_some_and(|ch| ch.is_ascii_digit()) {
+                return Err(
+                    TemporalError::range().with_message("fraction separator must have digit after")
+                );
+            }
+        }
+        Some(_) => return Err(TemporalError::range().with_message("Invalid offset")),
+        None => return Ok(result),
+    }
+
+    for _ in 0..9 {
+        let digit_or_end = chars.next().map(|ch| ch.is_ascii_digit());
+        match digit_or_end {
+            Some(true) => {}
+            Some(false) => {
+                return Err(TemporalError::range().with_message("Not a valid fractional second"))
+            }
+            None => break,
+        }
+    }
+
+    if chars.peek().is_some() {
+        return Err(TemporalError::range().with_message("Invalid offset"));
+    }
+
+    Ok(result)
 }
 
 fn parse_digit_pair(chars: &mut Peekable<Chars<'_>>) -> TemporalResult<i16> {

--- a/src/parsers/timezone.rs
+++ b/src/parsers/timezone.rs
@@ -154,7 +154,15 @@ fn parse_digit_pair(chars: &mut Peekable<Chars<'_>>) -> TemporalResult<i16> {
     let tens = (first.to_digit(10).expect("validated") * 10) as i16;
     let ones = second.to_digit(10).expect("validated") as i16;
 
-    Ok(tens + ones)
+    let result = tens + ones;
+
+    if !(0..=59).contains(&result) {
+        return Err(
+            TemporalError::range().with_message("digit pair not in a valid range of [0..59]")
+        );
+    }
+
+    Ok(result)
 }
 
 fn parse_iana_component(chars: &mut Peekable<Chars<'_>>) -> bool {

--- a/temporal_capi/src/instant.rs
+++ b/temporal_capi/src/instant.rs
@@ -102,7 +102,7 @@ pub mod ffi {
         }
 
         pub fn epoch_nanoseconds(&self) -> I128Nanoseconds {
-            let ns = self.0.epoch_nanoseconds();
+            let ns = self.0.epoch_nanoseconds().as_i128();
             let is_neg = ns < 0;
             let ns = ns.unsigned_abs();
 


### PR DESCRIPTION
This PR contains some fixes that was causing `IsoDateTime::from_epoch_nanoseconds` to throw incorrectly along with fixing the offset parsing that was being too forgiving and therefore not throwing errors when it should.