### PR TITLE
Fix not adjusting fraction for duration unit

### DIFF
--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -922,15 +922,17 @@ impl FromStr for Duration {
 
         let (hours, minutes, seconds, millis, micros, nanos) = match parse_record.time {
             Some(TimeDurationRecord::Hours { hours, fraction }) => {
-                let ns = fraction.and_then(|x| x.to_nanoseconds()).unwrap_or(0) as u64;
-                let minutes = ns.div_euclid(60 * 1_000_000_000);
-                let rem = ns.rem_euclid(60 * 1_000_000_000);
+                let unadjusted_fraction =
+                    fraction.and_then(|x| x.to_nanoseconds()).unwrap_or(0) as u64;
+                let fractional_hours_ns = unadjusted_fraction * 3600;
+                let minutes = fractional_hours_ns.div_euclid(60 * 1_000_000_000);
+                let fractional_minutes_ns = fractional_hours_ns.rem_euclid(60 * 1_000_000_000);
 
-                let seconds = rem.div_euclid(1_000_000_000);
-                let rem = rem.rem_euclid(1_000_000_000);
+                let seconds = fractional_minutes_ns.div_euclid(1_000_000_000);
+                let fractional_seconds = fractional_minutes_ns.rem_euclid(1_000_000_000);
 
-                let milliseconds = rem.div_euclid(1_000_000);
-                let rem = rem.rem_euclid(1_000_000);
+                let milliseconds = fractional_seconds.div_euclid(1_000_000);
+                let rem = fractional_seconds.rem_euclid(1_000_000);
 
                 let microseconds = rem.div_euclid(1_000);
                 let nanoseconds = rem.rem_euclid(1_000);
@@ -950,12 +952,14 @@ impl FromStr for Duration {
                 minutes,
                 fraction,
             }) => {
-                let ns = fraction.and_then(|x| x.to_nanoseconds()).unwrap_or(0);
-                let seconds = ns.div_euclid(1_000_000_000);
-                let rem = ns.rem_euclid(1_000_000_000);
+                let unadjusted_fraction =
+                    fraction.and_then(|x| x.to_nanoseconds()).unwrap_or(0) as u64;
+                let fractional_minutes_ns = unadjusted_fraction * 60;
+                let seconds = fractional_minutes_ns.div_euclid(1_000_000_000);
+                let fractional_seconds = fractional_minutes_ns.rem_euclid(1_000_000_000);
 
-                let milliseconds = rem.div_euclid(1_000_000);
-                let rem = rem.rem_euclid(1_000_000);
+                let milliseconds = fractional_seconds.div_euclid(1_000_000);
+                let rem = fractional_seconds.rem_euclid(1_000_000);
 
                 let microseconds = rem.div_euclid(1_000);
                 let nanoseconds = rem.rem_euclid(1_000);

--- a/src/builtins/core/duration/tests.rs
+++ b/src/builtins/core/duration/tests.rs
@@ -1,3 +1,5 @@
+use core::str::FromStr;
+
 use crate::{
     options::ToStringRoundingOptions, parsers::Precision, partial::PartialDuration,
     primitive::FiniteF64,
@@ -185,4 +187,27 @@ fn preserve_precision_loss() {
         .unwrap();
 
     assert_eq!(&result, "PT9016206453995.731991S");
+}
+
+#[test]
+fn duration_from_str() {
+    let duration = Duration::from_str("PT0.999999999H").unwrap();
+    assert_eq!(duration.minutes(), FiniteF64(59.0));
+    assert_eq!(duration.seconds(), FiniteF64(59.0));
+    assert_eq!(duration.milliseconds(), FiniteF64(999.0));
+    assert_eq!(duration.microseconds(), FiniteF64(996.0));
+    assert_eq!(duration.nanoseconds(), FiniteF64(400.0));
+
+    let duration = Duration::from_str("PT0.000000011H").unwrap();
+    assert_eq!(duration.minutes(), FiniteF64(0.0));
+    assert_eq!(duration.seconds(), FiniteF64(0.0));
+    assert_eq!(duration.milliseconds(), FiniteF64(0.0));
+    assert_eq!(duration.microseconds(), FiniteF64(39.0));
+    assert_eq!(duration.nanoseconds(), FiniteF64(600.0));
+
+    let duration = Duration::from_str("PT0.999999999M").unwrap();
+    assert_eq!(duration.seconds(), FiniteF64(59.0));
+    assert_eq!(duration.milliseconds(), FiniteF64(999.0));
+    assert_eq!(duration.microseconds(), FiniteF64(999.0));
+    assert_eq!(duration.nanoseconds(), FiniteF64(940.0));
 }


### PR DESCRIPTION
Fix for the regression showing up on boa-dev/boa#4193.

During the last update, I forgot that fraction is now agnostic about it's unit, so it needs to be adjusted for the unit.