### PR TITLE
Add various updates to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,14 @@ the Temporal specification.
 
 For more information on testing and debugging `temporal_rs`. Please see
 the [testing overview](./docs/testing.md).
+
+## Diplomat and `temporal_capi`
+
+If changes are made to `temporal_capi` that affect the public API, the
+FFI bindings will need to be regenerated / updated.
+
+To update the bindings, run:
+
+```bash
+cargo run -p diplomat-gen
+```

--- a/README.md
+++ b/README.md
@@ -1,38 +1,62 @@
 # Temporal in Rust
 
-`Temporal` is a calendar and timezone aware date/time library that is
-currently being designed and proposed as a new builtin to the
-`ECMAScript` specification.
+Temporal is a calendar and timezone aware date/time builtin currently
+proposed for edition to the ECMAScript specification.
 
-This crate is an implementation of `Temporal` in Rust. While initially
-developed for `Boa`, the crate has been externalized as we intended to
-make an engine agnostic and general usage implementation of `Temporal`
-and its algorithms.
+`temporal_rs` is an implementation of Temporal in Rust that aims to be
+100% test compliant. While initially developed for [Boa][boa-repo], the
+crate has been externalized as we intended to make an engine agnostic
+and general usage implementation of Temporal and its algorithms.
 
-## Temporal Proposal
+## Example usage
+
+```rust
+use temporal_rs::{PlainDate, Calendar};
+use tinystr::tinystr;
+use core::str::FromStr;
+
+// Create a date with an ISO calendar
+let iso8601_date = PlainDate::try_new(2025, 3, 3, Calendar::default()).unwrap();
+
+// Create a new date with the japanese calendar
+let japanese_date = iso8601_date.with_calendar(Calendar::from_str("japanese").unwrap()).unwrap();
+let current_era = japanese_date.era().expect("current date converts between both calendars");
+assert_eq!(current_era, Some(tinystr!(16, "reiwa")));
+assert_eq!(japanese_date.era_year().unwrap(), Some(7));
+assert_eq!(japanese_date.month().unwrap(), 3)
+```
+
+## Temporal proposal
 
 Relevent links regarding Temporal can be found below.
 
- - [Temporal Documentation](https://tc39.es/proposal-temporal/docs/) 
- - [Temporal Proposal Specification](https://tc39.es/proposal-temporal/) 
- - [Temporal Proposal Repository](https://github.com/tc39/proposal-temporal)
+- [Temporal Documentation](https://tc39.es/proposal-temporal/docs/)
+- [Temporal Proposal Specification](https://tc39.es/proposal-temporal/)
+- [Temporal Proposal Repository](https://github.com/tc39/proposal-temporal)
 
-## Core Maintainers
-- Jason Williams ([jasonwilliams](https://github.com/orgs/boa-dev/people/jasonwilliams))
-- José Julián Espina ([jedel1043](https://github.com/orgs/boa-dev/people/jedel1043))
+## Core maintainers
+
+- Jason Williams
+  ([jasonwilliams](https://github.com/orgs/boa-dev/people/jasonwilliams))
+- José Julián Espina
+  ([jedel1043](https://github.com/orgs/boa-dev/people/jedel1043))
 - Kevin Ness ([nekevss](https://github.com/orgs/boa-dev/people/nekevss))
 - Boa Developers
 
 ## Contributing
 
-This project is open source and welcomes anyone interested to participate.
-Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for more information.
+This project is open source and welcomes anyone interested to
+participate. Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for more
+information.
 
 ## Communication
 
-Feel free to contact us on [Matrix](https://matrix.to/#/#boa:matrix.org).
+Feel free to contact us on
+[Matrix](https://matrix.to/#/#boa:matrix.org).
 
 ## License
 
 This project is licensed under the [Apache](./LICENSE-Apache) or
 [MIT](./LICENSE-MIT) licenses, at your option.
+
+[boa-repo]: https://github.com/boa-dev/boa

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,7 +57,7 @@ impl ZonedDateTime {
 }
 ```
 
-### Compiled  implementation
+### Compiled implementation
 
 The native implementation is only available via the "compiled" default
 feature flag.

--- a/src/builtins/core/now.rs
+++ b/src/builtins/core/now.rs
@@ -29,9 +29,6 @@ impl Now {
     ///
     ///   1. Resolve user input `TimeZone` with the `SystemTimeZone`.
     ///   2. Get the `SystemNanoseconds`
-    ///
-    /// For an example implementation see [`Self::zoneddatetime_iso`]
-    ///
     pub(crate) fn system_datetime_with_provider(
         epoch_nanoseconds: EpochNanoseconds,
         timezone: TimeZone,
@@ -62,7 +59,8 @@ impl Now {
     ///   1. Resolve user input `TimeZone` with the `SystemTimeZone`.
     ///   2. Get the `SystemNanoseconds`
     ///
-    /// For an example implementation see [`Self::zoneddatetime_iso`]
+    /// For an example implementation, see `Now::zoneddatetime_iso`; available with
+    /// the `compiled_data` feature flag.
     pub fn zoneddatetime_iso_with_system_values(
         epoch_nanos: EpochNanoseconds,
         timezone: TimeZone,
@@ -121,7 +119,8 @@ impl Now {
     ///   1. Resolve user input `TimeZone` with the `SystemTimeZone`.
     ///   2. Get the `SystemNanoseconds`
     ///
-    /// For an example implementation see [`Self::plain_datetime_iso`]
+    /// For an example implementation, see `Now::plain_datetime_iso`; available with the
+    /// `compiled_data` feature flag.
     pub fn plain_datetime_iso_with_provider(
         epoch_nanos: EpochNanoseconds,
         timezone: TimeZone,
@@ -144,7 +143,8 @@ impl Now {
     ///   1. Resolve user input `TimeZone` with the `SystemTimeZone`.
     ///   2. Get the `SystemNanoseconds`
     ///
-    /// For an example implementation see [`Self::plain_date_iso`]
+    /// For an example implementation, see `Now::plain_date_iso`; available
+    /// with the `compiled_data` feature flag.
     pub fn plain_date_iso_with_provider(
         epoch_nanos: EpochNanoseconds,
         timezone: TimeZone,
@@ -167,7 +167,8 @@ impl Now {
     ///   1. Resolve user input `TimeZone` with the `SystemTimeZone`.
     ///   2. Get the `SystemNanoseconds`
     ///
-    /// For an example implementation see [`Self::plain_time_iso`]
+    /// For an example implementation, see `Now::plain_time_iso`; available with the
+    /// `compiled_data` feature flag.
     pub fn plain_time_iso_with_provider(
         epoch_nanos: EpochNanoseconds,
         timezone: TimeZone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,21 @@
 //! The `temporal_rs` crate is an implementation of ECMAScript's Temporal
-//! built-in objects.
+//! built-in objects in Rust.
 //!
-//! The crate is being designed with both engine and general use in
-//! mind.
+//! ```rust
+//! use temporal_rs::{PlainDate, Calendar};
+//! use tinystr::tinystr;
+//! use core::str::FromStr;
+//!
+//! // Create a date with an ISO calendar
+//! let iso8601_date = PlainDate::try_new(2025, 3, 3, Calendar::default()).unwrap();
+//!
+//! // Create a new date with the japanese calendar
+//! let japanese_date = iso8601_date.with_calendar(Calendar::from_str("japanese").unwrap()).unwrap();
+//! let current_era = japanese_date.era().expect("current date converts between calendars");
+//! assert_eq!(current_era, Some(tinystr!(16, "reiwa")));
+//! assert_eq!(japanese_date.era_year().unwrap(), Some(7));
+//! assert_eq!(japanese_date.month().unwrap(), 3)
+//! ```
 //!
 //! [`Temporal`][proposal] is the Stage 3 proposal for ECMAScript that
 //! provides new JS objects and functions for working with dates and


### PR DESCRIPTION
This updates the docs to include how to run `diplomat-gen`.

It also includes adding an example to the README and the lib.rs header. It may be worthwhile to look into unifying those in the future.

Once we have a good setup for handling `TimeZoneProvider`s, it may be worth while looking into including `Now` into the docs that can run in CI. For now I went with a rather simple example to show conversion of `PlainDate` with an ISO calendar to a `PlainDate` with a japanese calendar.

The examples are nice to see, but they do show a slight weakness in the API ergonomics that using `TemporalResult` is not always ideal. I think the primary reason the `TemporalResult` is there is due to a fallible conversion from us -> ICU4X. But I'm not entirely sure it is 100% fallible. It would be worth confirming if we could use an `expect` on `as_icu4x`. It would probably dramatically increase our API ergonomics.