### PR TITLE
Clean up API ergonomics for calendar methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ let iso8601_date = PlainDate::try_new(2025, 3, 3, Calendar::default()).unwrap();
 
 // Create a new date with the japanese calendar
 let japanese_date = iso8601_date.with_calendar(Calendar::from_str("japanese").unwrap()).unwrap();
-let current_era = japanese_date.era().expect("current date converts between both calendars");
-assert_eq!(current_era, Some(tinystr!(16, "reiwa")));
+assert_eq!(japanese_date.era(), Some(tinystr!(16, "reiwa")));
 assert_eq!(japanese_date.era_year().unwrap(), Some(7));
 assert_eq!(japanese_date.month().unwrap(), 3)
 ```

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -363,83 +363,83 @@ impl Calendar {
     }
 
     /// `CalendarEra`
-    pub fn era(&self, iso_date: &IsoDate) -> TemporalResult<Option<TinyAsciiStr<16>>> {
+    pub fn era(&self, iso_date: &IsoDate) -> Option<TinyAsciiStr<16>> {
         if self.is_iso() {
-            return Ok(None);
+            return None;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
-        Ok(self.0.year(&calendar_date).standard_era().map(|era| era.0))
+        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        self.0.year(&calendar_date).standard_era().map(|era| era.0)
     }
 
     /// `CalendarEraYear`
-    pub fn era_year(&self, iso_date: &IsoDate) -> TemporalResult<Option<i32>> {
+    pub fn era_year(&self, iso_date: &IsoDate) -> Option<i32> {
         if self.is_iso() {
-            return Ok(None);
+            return None;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
-        Ok(self.0.year(&calendar_date).era_year())
+        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        self.0.year(&calendar_date).era_year()
     }
 
     /// `CalendarYear`
-    pub fn year(&self, iso_date: &IsoDate) -> TemporalResult<i32> {
+    pub fn year(&self, iso_date: &IsoDate) -> i32 {
         if self.is_iso() {
-            return Ok(iso_date.year);
+            return iso_date.year;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
-        Ok(self.0.year(&calendar_date).extended_year)
+        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        self.0.year(&calendar_date).extended_year
     }
 
     /// `CalendarMonth`
-    pub fn month(&self, iso_date: &IsoDate) -> TemporalResult<u8> {
+    pub fn month(&self, iso_date: &IsoDate) -> u8 {
         if self.is_iso() {
-            return Ok(iso_date.month);
+            return iso_date.month;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
-        Ok(self.0.month(&calendar_date).month_number())
+        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        self.0.month(&calendar_date).month_number()
     }
 
     /// `CalendarMonthCode`
-    pub fn month_code(&self, iso_date: &IsoDate) -> TemporalResult<MonthCode> {
+    pub fn month_code(&self, iso_date: &IsoDate) -> MonthCode {
         if self.is_iso() {
-            let mc = iso_date.as_icu4x()?.month().standard_code.0;
-            return Ok(MonthCode(mc));
+            let mc = iso_date.to_icu4x().month().standard_code.0;
+            return MonthCode(mc);
         }
-        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
-        Ok(MonthCode(self.0.month(&calendar_date).standard_code.0))
+        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        MonthCode(self.0.month(&calendar_date).standard_code.0)
     }
 
     /// `CalendarDay`
-    pub fn day(&self, iso_date: &IsoDate) -> TemporalResult<u8> {
+    pub fn day(&self, iso_date: &IsoDate) -> u8 {
         if self.is_iso() {
-            return Ok(iso_date.day);
+            return iso_date.day;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
-        Ok(self.0.day_of_month(&calendar_date).0)
+        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        self.0.day_of_month(&calendar_date).0
     }
 
     /// `CalendarDayOfWeek`
-    pub fn day_of_week(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
+    pub fn day_of_week(&self, iso_date: &IsoDate) -> u16 {
         if self.is_iso() {
-            return Ok(iso_date.as_icu4x()?.day_of_week() as u16);
+            return iso_date.to_icu4x().day_of_week() as u16;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
+        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
         // TODO: Understand ICU4X's decision for `IsoWeekDay` to be `i8`
-        Ok(self.0.day_of_week(&calendar_date) as u16)
+        self.0.day_of_week(&calendar_date) as u16
     }
 
     /// `CalendarDayOfYear`
-    pub fn day_of_year(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
+    pub fn day_of_year(&self, iso_date: &IsoDate) -> u16 {
         if self.is_iso() {
-            return Ok(iso_date.as_icu4x()?.day_of_year_info().day_of_year);
+            return iso_date.to_icu4x().day_of_year_info().day_of_year;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
-        Ok(self.0.day_of_year_info(&calendar_date).day_of_year)
+        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        self.0.day_of_year_info(&calendar_date).day_of_year
     }
 
     /// `CalendarWeekOfYear`
     pub fn week_of_year(&self, iso_date: &IsoDate) -> TemporalResult<Option<u16>> {
         if self.is_iso() {
-            let date = iso_date.as_icu4x()?;
+            let date = iso_date.to_icu4x();
             let week_calculator = WeekCalculator::default();
             let week_of = date.week_of_year(&week_calculator);
             return Ok(Some(week_of.week as u16));
@@ -451,7 +451,7 @@ impl Calendar {
     /// `CalendarYearOfWeek`
     pub fn year_of_week(&self, iso_date: &IsoDate) -> TemporalResult<Option<i32>> {
         if self.is_iso() {
-            let date = iso_date.as_icu4x()?;
+            let date = iso_date.to_icu4x();
 
             let week_calculator = WeekCalculator::default();
 
@@ -477,39 +477,39 @@ impl Calendar {
     }
 
     /// `CalendarDaysInMonth`
-    pub fn days_in_month(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
+    pub fn days_in_month(&self, iso_date: &IsoDate) -> u16 {
         if self.is_iso() {
-            return Ok(iso_date.as_icu4x()?.days_in_month() as u16);
+            return iso_date.to_icu4x().days_in_month() as u16;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
-        Ok(self.0.days_in_month(&calendar_date) as u16)
+        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        self.0.days_in_month(&calendar_date) as u16
     }
 
     /// `CalendarDaysInYear`
-    pub fn days_in_year(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
+    pub fn days_in_year(&self, iso_date: &IsoDate) -> u16 {
         if self.is_iso() {
-            return Ok(iso_date.as_icu4x()?.days_in_year());
+            return iso_date.to_icu4x().days_in_year();
         }
-        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
-        Ok(self.0.days_in_year(&calendar_date))
+        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        self.0.days_in_year(&calendar_date)
     }
 
     /// `CalendarMonthsInYear`
-    pub fn months_in_year(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
+    pub fn months_in_year(&self, iso_date: &IsoDate) -> u16 {
         if self.is_iso() {
-            return Ok(12);
+            return 12;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
-        Ok(self.0.months_in_year(&calendar_date) as u16)
+        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        self.0.months_in_year(&calendar_date) as u16
     }
 
     /// `CalendarInLeapYear`
-    pub fn in_leap_year(&self, iso_date: &IsoDate) -> TemporalResult<bool> {
+    pub fn in_leap_year(&self, iso_date: &IsoDate) -> bool {
         if self.is_iso() {
-            return Ok(iso_date.as_icu4x()?.is_in_leap_year());
+            return iso_date.to_icu4x().is_in_leap_year();
         }
-        let calendar_date = self.0.date_from_iso(iso_date.as_icu4x()?);
-        Ok(self.0.is_in_leap_year(&calendar_date))
+        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        self.0.is_in_leap_year(&calendar_date)
     }
 
     /// Returns the identifier of this calendar slot.

--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -54,23 +54,23 @@ impl PartialDate {
     }
 
     pub(crate) fn try_from_year_month(year_month: &PlainYearMonth) -> TemporalResult<Self> {
-        let (year, era, era_year) = if year_month.era()?.is_some() {
+        let (year, era, era_year) = if year_month.era().is_some() {
             (
                 None,
                 year_month
-                    .era()?
+                    .era()
                     .map(|t| TinyAsciiStr::<19>::try_from_utf8(t.as_bytes()))
                     .transpose()
                     .map_err(|e| TemporalError::general(format!("{e}")))?,
-                year_month.era_year()?,
+                year_month.era_year(),
             )
         } else {
-            (Some(year_month.year()?), None, None)
+            (Some(year_month.year()), None, None)
         };
         Ok(Self {
             year,
-            month: Some(year_month.month()?),
-            month_code: Some(year_month.month_code()?),
+            month: Some(year_month.month()),
+            month_code: Some(year_month.month_code()),
             day: Some(1),
             era,
             era_year,
@@ -92,7 +92,7 @@ macro_rules! impl_with_fallback_method {
             let era = if let Some(era) = self.era {
                 Some(era)
             } else {
-                let era = fallback.era()?;
+                let era = fallback.era();
                 era.map(|e| {
                     TinyAsciiStr::<19>::try_from_utf8(e.as_bytes())
                         .map_err(|e| TemporalError::general(format!("{e}")))
@@ -101,23 +101,23 @@ macro_rules! impl_with_fallback_method {
             };
             let era_year = self
                 .era_year
-                .map_or_else(|| fallback.era_year(), |ey| Ok(Some(ey)))?;
+                .map_or_else(|| fallback.era_year(), |ey| Some(ey));
 
             let (month, month_code) = match (self.month, self.month_code) {
                 (Some(month), Some(mc)) => (Some(month), Some(mc)),
                 (Some(month), None) => (Some(month), Some(month_to_month_code(month)?)),
                 (None, Some(mc)) => (Some(mc.to_month_integer()).map(Into::into), Some(mc)),
                 (None, None) => (
-                    Some(fallback.month()?).map(Into::into),
-                    Some(fallback.month_code()?),
+                    Some(fallback.month()).map(Into::into),
+                    Some(fallback.month_code()),
                 ),
             };
 
             Ok(Self {
-                year: Some(self.year.unwrap_or(fallback.year()?)),
+                year: Some(self.year.unwrap_or(fallback.year())),
                 month,
                 month_code,
-                day: Some(self.day.unwrap_or(fallback.day()?.into())),
+                day: Some(self.day.unwrap_or(fallback.day().into())),
                 era,
                 era_year,
                 calendar: fallback.calendar().clone(),
@@ -394,9 +394,9 @@ impl PlainDate {
     ///
     /// let date = PlainDate::from_partial(partial, None).unwrap();
     ///
-    /// assert_eq!(date.year().unwrap(), 2000);
-    /// assert_eq!(date.month().unwrap(), 12);
-    /// assert_eq!(date.day().unwrap(), 2);
+    /// assert_eq!(date.year(), 2000);
+    /// assert_eq!(date.month(), 12);
+    /// assert_eq!(date.day(), 2);
     /// assert_eq!(date.calendar().identifier(), "iso8601");
     ///
     /// ```
@@ -538,32 +538,32 @@ impl PlainDate {
 
 impl PlainDate {
     /// Returns the calendar year value.
-    pub fn year(&self) -> TemporalResult<i32> {
+    pub fn year(&self) -> i32 {
         self.calendar.year(&self.iso)
     }
 
     /// Returns the calendar month value.
-    pub fn month(&self) -> TemporalResult<u8> {
+    pub fn month(&self) -> u8 {
         self.calendar.month(&self.iso)
     }
 
     /// Returns the calendar month code value.
-    pub fn month_code(&self) -> TemporalResult<MonthCode> {
+    pub fn month_code(&self) -> MonthCode {
         self.calendar.month_code(&self.iso)
     }
 
     /// Returns the calendar day value.
-    pub fn day(&self) -> TemporalResult<u8> {
+    pub fn day(&self) -> u8 {
         self.calendar.day(&self.iso)
     }
 
     /// Returns the calendar day of week value.
-    pub fn day_of_week(&self) -> TemporalResult<u16> {
+    pub fn day_of_week(&self) -> u16 {
         self.calendar.day_of_week(&self.iso)
     }
 
     /// Returns the calendar day of year value.
-    pub fn day_of_year(&self) -> TemporalResult<u16> {
+    pub fn day_of_year(&self) -> u16 {
         self.calendar.day_of_year(&self.iso)
     }
 
@@ -583,30 +583,30 @@ impl PlainDate {
     }
 
     /// Returns the calendar days in month value.
-    pub fn days_in_month(&self) -> TemporalResult<u16> {
+    pub fn days_in_month(&self) -> u16 {
         self.calendar.days_in_month(&self.iso)
     }
 
     /// Returns the calendar days in year value.
-    pub fn days_in_year(&self) -> TemporalResult<u16> {
+    pub fn days_in_year(&self) -> u16 {
         self.calendar.days_in_year(&self.iso)
     }
 
     /// Returns the calendar months in year value.
-    pub fn months_in_year(&self) -> TemporalResult<u16> {
+    pub fn months_in_year(&self) -> u16 {
         self.calendar.months_in_year(&self.iso)
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
-    pub fn in_leap_year(&self) -> TemporalResult<bool> {
+    pub fn in_leap_year(&self) -> bool {
         self.calendar.in_leap_year(&self.iso)
     }
 
-    pub fn era(&self) -> TemporalResult<Option<TinyAsciiStr<16>>> {
+    pub fn era(&self) -> Option<TinyAsciiStr<16>> {
         self.calendar.era(&self.iso)
     }
 
-    pub fn era_year(&self) -> TemporalResult<Option<i32>> {
+    pub fn era_year(&self) -> Option<i32> {
         self.calendar.era_year(&self.iso)
     }
 }
@@ -896,13 +896,10 @@ mod tests {
             ..Default::default()
         };
         let with_year = base.with(partial, None).unwrap();
-        assert_eq!(with_year.year().unwrap(), 2019);
-        assert_eq!(with_year.month().unwrap(), 11);
-        assert_eq!(
-            with_year.month_code().unwrap(),
-            MonthCode::from_str("M11").unwrap()
-        );
-        assert_eq!(with_year.day().unwrap(), 18);
+        assert_eq!(with_year.year(), 2019);
+        assert_eq!(with_year.month(), 11);
+        assert_eq!(with_year.month_code(), MonthCode::from_str("M11").unwrap());
+        assert_eq!(with_year.day(), 18);
 
         // Month
         let partial = PartialDate {
@@ -910,13 +907,10 @@ mod tests {
             ..Default::default()
         };
         let with_month = base.with(partial, None).unwrap();
-        assert_eq!(with_month.year().unwrap(), 1976);
-        assert_eq!(with_month.month().unwrap(), 5);
-        assert_eq!(
-            with_month.month_code().unwrap(),
-            MonthCode::from_str("M05").unwrap()
-        );
-        assert_eq!(with_month.day().unwrap(), 18);
+        assert_eq!(with_month.year(), 1976);
+        assert_eq!(with_month.month(), 5);
+        assert_eq!(with_month.month_code(), MonthCode::from_str("M05").unwrap());
+        assert_eq!(with_month.day(), 18);
 
         // Month Code
         let partial = PartialDate {
@@ -924,13 +918,10 @@ mod tests {
             ..Default::default()
         };
         let with_mc = base.with(partial, None).unwrap();
-        assert_eq!(with_mc.year().unwrap(), 1976);
-        assert_eq!(with_mc.month().unwrap(), 5);
-        assert_eq!(
-            with_mc.month_code().unwrap(),
-            MonthCode::from_str("M05").unwrap()
-        );
-        assert_eq!(with_mc.day().unwrap(), 18);
+        assert_eq!(with_mc.year(), 1976);
+        assert_eq!(with_mc.month(), 5);
+        assert_eq!(with_mc.month_code(), MonthCode::from_str("M05").unwrap());
+        assert_eq!(with_mc.day(), 18);
 
         // Day
         let partial = PartialDate {
@@ -938,13 +929,10 @@ mod tests {
             ..Default::default()
         };
         let with_day = base.with(partial, None).unwrap();
-        assert_eq!(with_day.year().unwrap(), 1976);
-        assert_eq!(with_day.month().unwrap(), 11);
-        assert_eq!(
-            with_day.month_code().unwrap(),
-            MonthCode::from_str("M11").unwrap()
-        );
-        assert_eq!(with_day.day().unwrap(), 17);
+        assert_eq!(with_day.year(), 1976);
+        assert_eq!(with_day.month(), 11);
+        assert_eq!(with_day.month_code(), MonthCode::from_str("M11").unwrap());
+        assert_eq!(with_day.day(), 17);
     }
 
     // test262/test/built-ins/Temporal/Calendar/prototype/month/argument-string-invalid.js

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -327,9 +327,9 @@ impl PlainDateTime {
     ///
     /// let date = PlainDateTime::from_partial(partial, None).unwrap();
     ///
-    /// assert_eq!(date.year().unwrap(), 2000);
-    /// assert_eq!(date.month().unwrap(), 12);
-    /// assert_eq!(date.day().unwrap(), 2);
+    /// assert_eq!(date.year(), 2000);
+    /// assert_eq!(date.month(), 12);
+    /// assert_eq!(date.day(), 2);
     /// assert_eq!(date.calendar().identifier(), "iso8601");
     /// assert_eq!(date.hour(), 4);
     /// assert_eq!(date.minute(), 25);
@@ -371,9 +371,9 @@ impl PlainDateTime {
     ///
     /// let date = initial.with(partial, None).unwrap();
     ///
-    /// assert_eq!(date.year().unwrap(), 2000);
-    /// assert_eq!(date.month().unwrap(), 5);
-    /// assert_eq!(date.day().unwrap(), 2);
+    /// assert_eq!(date.year(), 2000);
+    /// assert_eq!(date.month(), 5);
+    /// assert_eq!(date.day(), 2);
     /// assert_eq!(date.calendar().identifier(), "iso8601");
     /// assert_eq!(date.hour(), 4);
     /// assert_eq!(date.minute(), 0);
@@ -516,32 +516,32 @@ impl PlainDateTime {
 
 impl PlainDateTime {
     /// Returns the calendar year value.
-    pub fn year(&self) -> TemporalResult<i32> {
+    pub fn year(&self) -> i32 {
         self.calendar.year(&self.iso.date)
     }
 
     /// Returns the calendar month value.
-    pub fn month(&self) -> TemporalResult<u8> {
+    pub fn month(&self) -> u8 {
         self.calendar.month(&self.iso.date)
     }
 
     /// Returns the calendar month code value.
-    pub fn month_code(&self) -> TemporalResult<MonthCode> {
+    pub fn month_code(&self) -> MonthCode {
         self.calendar.month_code(&self.iso.date)
     }
 
     /// Returns the calendar day value.
-    pub fn day(&self) -> TemporalResult<u8> {
+    pub fn day(&self) -> u8 {
         self.calendar.day(&self.iso.date)
     }
 
     /// Returns the calendar day of week value.
-    pub fn day_of_week(&self) -> TemporalResult<u16> {
+    pub fn day_of_week(&self) -> u16 {
         self.calendar.day_of_week(&self.iso.date)
     }
 
     /// Returns the calendar day of year value.
-    pub fn day_of_year(&self) -> TemporalResult<u16> {
+    pub fn day_of_year(&self) -> u16 {
         self.calendar.day_of_year(&self.iso.date)
     }
 
@@ -561,30 +561,30 @@ impl PlainDateTime {
     }
 
     /// Returns the calendar days in month value.
-    pub fn days_in_month(&self) -> TemporalResult<u16> {
+    pub fn days_in_month(&self) -> u16 {
         self.calendar.days_in_month(&self.iso.date)
     }
 
     /// Returns the calendar days in year value.
-    pub fn days_in_year(&self) -> TemporalResult<u16> {
+    pub fn days_in_year(&self) -> u16 {
         self.calendar.days_in_year(&self.iso.date)
     }
 
     /// Returns the calendar months in year value.
-    pub fn months_in_year(&self) -> TemporalResult<u16> {
+    pub fn months_in_year(&self) -> u16 {
         self.calendar.months_in_year(&self.iso.date)
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
-    pub fn in_leap_year(&self) -> TemporalResult<bool> {
+    pub fn in_leap_year(&self) -> bool {
         self.calendar.in_leap_year(&self.iso.date)
     }
 
-    pub fn era(&self) -> TemporalResult<Option<TinyAsciiStr<16>>> {
+    pub fn era(&self) -> Option<TinyAsciiStr<16>> {
         self.calendar.era(&self.iso.date)
     }
 
-    pub fn era_year(&self) -> TemporalResult<Option<i32>> {
+    pub fn era_year(&self) -> Option<i32> {
         self.calendar.era_year(&self.iso.date)
     }
 }
@@ -741,10 +741,10 @@ mod tests {
         dt: PlainDateTime,
         fields: (i32, u8, TinyAsciiStr<4>, u8, u8, u8, u8, u16, u16, u16),
     ) {
-        assert_eq!(dt.year().unwrap(), fields.0);
-        assert_eq!(dt.month().unwrap(), fields.1);
-        assert_eq!(dt.month_code().unwrap(), MonthCode(fields.2));
-        assert_eq!(dt.day().unwrap(), fields.3);
+        assert_eq!(dt.year(), fields.0);
+        assert_eq!(dt.month(), fields.1);
+        assert_eq!(dt.month_code(), MonthCode(fields.2));
+        assert_eq!(dt.day(), fields.3);
         assert_eq!(dt.hour(), fields.4);
         assert_eq!(dt.minute(), fields.5);
         assert_eq!(dt.second(), fields.6);
@@ -978,8 +978,8 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(result.month(), Ok(2));
-        assert_eq!(result.day(), Ok(29));
+        assert_eq!(result.month(), 2);
+        assert_eq!(result.day(), 29);
     }
 
     // options-undefined.js
@@ -1004,8 +1004,8 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(result.month(), Ok(2));
-        assert_eq!(result.day(), Ok(29));
+        assert_eq!(result.month(), 2);
+        assert_eq!(result.day(), 29);
     }
 
     // subtract/hour-overflow.js

--- a/src/builtins/core/month_day.rs
+++ b/src/builtins/core/month_day.rs
@@ -94,7 +94,7 @@ impl PlainMonthDay {
 
     /// Returns the `monthCode` value of `MonthDay`.
     #[inline]
-    pub fn month_code(&self) -> TemporalResult<MonthCode> {
+    pub fn month_code(&self) -> MonthCode {
         self.calendar.month_code(&self.iso)
     }
 

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -118,42 +118,42 @@ impl PlainYearMonth {
     }
 
     /// Returns the calendar era of the current `PlainYearMonth`
-    pub fn era(&self) -> TemporalResult<Option<TinyAsciiStr<16>>> {
+    pub fn era(&self) -> Option<TinyAsciiStr<16>> {
         self.calendar().era(&self.iso)
     }
 
     /// Returns the calendar era year of the current `PlainYearMonth`
-    pub fn era_year(&self) -> TemporalResult<Option<i32>> {
+    pub fn era_year(&self) -> Option<i32> {
         self.calendar().era_year(&self.iso)
     }
 
     /// Returns the calendar year of the current `PlainYearMonth`
-    pub fn year(&self) -> TemporalResult<i32> {
+    pub fn year(&self) -> i32 {
         self.calendar().year(&self.iso)
     }
 
     /// Returns the calendar month of the current `PlainYearMonth`
-    pub fn month(&self) -> TemporalResult<u8> {
+    pub fn month(&self) -> u8 {
         self.calendar().month(&self.iso)
     }
 
     /// Returns the calendar month code of the current `PlainYearMonth`
-    pub fn month_code(&self) -> TemporalResult<MonthCode> {
+    pub fn month_code(&self) -> MonthCode {
         self.calendar().month_code(&self.iso)
     }
 
     /// Returns the days in the calendar year of the current `PlainYearMonth`.
-    pub fn days_in_year(&self) -> TemporalResult<u16> {
+    pub fn days_in_year(&self) -> u16 {
         self.calendar().days_in_year(&self.iso)
     }
 
     /// Returns the days in the calendar month of the current `PlainYearMonth`.
-    pub fn days_in_month(&self) -> TemporalResult<u16> {
+    pub fn days_in_month(&self) -> u16 {
         self.calendar().days_in_month(&self.iso)
     }
 
     /// Returns the months in the calendar year of the current `PlainYearMonth`.
-    pub fn months_in_year(&self) -> TemporalResult<u16> {
+    pub fn months_in_year(&self) -> u16 {
         self.calendar().months_in_year(&self.iso)
     }
 
@@ -161,9 +161,7 @@ impl PlainYearMonth {
     #[must_use]
     /// Returns a boolean representing whether the current `PlainYearMonth` is in a leap year.
     pub fn in_leap_year(&self) -> bool {
-        self.calendar()
-            .in_leap_year(&self.iso)
-            .is_ok_and(|is_leap_year| is_leap_year)
+        self.calendar().in_leap_year(&self.iso)
     }
 }
 

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -542,14 +542,14 @@ impl ZonedDateTime {
     pub fn year_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<i32> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.year(&dt.iso.date)
+        Ok(self.calendar.year(&dt.iso.date))
     }
 
     /// Returns the `month` value for this `ZonedDateTime`.
     pub fn month_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u8> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.month(&dt.iso.date)
+        Ok(self.calendar.month(&dt.iso.date))
     }
 
     /// Returns the `monthCode` value for this `ZonedDateTime`.
@@ -559,14 +559,14 @@ impl ZonedDateTime {
     ) -> TemporalResult<MonthCode> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.month_code(&dt.iso.date)
+        Ok(self.calendar.month_code(&dt.iso.date))
     }
 
     /// Returns the `day` value for this `ZonedDateTime`.
     pub fn day_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u8> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let dt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.day(&dt.iso.date)
+        Ok(self.calendar.day(&dt.iso.date))
     }
 
     /// Returns the `hour` value for this `ZonedDateTime`.
@@ -672,7 +672,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<Option<TinyAsciiStr<16>>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.era(&pdt.iso.date)
+        Ok(self.calendar.era(&pdt.iso.date))
     }
 
     pub fn era_year_with_provider(
@@ -681,7 +681,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<Option<i32>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.era_year(&pdt.iso.date)
+        Ok(self.calendar.era_year(&pdt.iso.date))
     }
 
     /// Returns the calendar day of week value.
@@ -691,7 +691,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.day_of_week(&pdt.iso.date)
+        Ok(self.calendar.day_of_week(&pdt.iso.date))
     }
 
     /// Returns the calendar day of year value.
@@ -701,7 +701,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.day_of_year(&pdt.iso.date)
+        Ok(self.calendar.day_of_year(&pdt.iso.date))
     }
 
     /// Returns the calendar week of year value.
@@ -741,7 +741,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.days_in_month(&pdt.iso.date)
+        Ok(self.calendar.days_in_month(&pdt.iso.date))
     }
 
     /// Returns the calendar days in year value.
@@ -751,7 +751,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.days_in_year(&pdt.iso.date)
+        Ok(self.calendar.days_in_year(&pdt.iso.date))
     }
 
     /// Returns the calendar months in year value.
@@ -761,7 +761,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.months_in_year(&pdt.iso.date)
+        Ok(self.calendar.months_in_year(&pdt.iso.date))
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
@@ -771,7 +771,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<bool> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.in_leap_year(&pdt.iso.date)
+        Ok(self.calendar.in_leap_year(&pdt.iso.date))
     }
 }
 

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -22,7 +22,6 @@
 //!
 //! An `IsoDateTime` has the internal slots of both an `IsoDate` and `IsoTime`.
 
-use alloc::string::ToString;
 use core::num::NonZeroU128;
 use ixdtf::parsers::records::TimeRecord;
 
@@ -513,9 +512,8 @@ impl IsoDate {
 
 impl IsoDate {
     /// Creates `[[ISOYear]]`, `[[isoMonth]]`, `[[isoDay]]` fields from `ICU4X`'s `Date<Iso>` struct.
-    pub(crate) fn as_icu4x(self) -> TemporalResult<IcuDate<Iso>> {
-        IcuDate::try_new_iso(self.year, self.month, self.day)
-            .map_err(|e| TemporalError::range().with_message(e.to_string()))
+    pub(crate) fn to_icu4x(self) -> IcuDate<Iso> {
+        IcuDate::try_new_iso(self.year, self.month, self.day).expect("must not fail.")
     }
 }
 
@@ -1042,9 +1040,17 @@ fn div_mod(dividend: i64, divisor: i64) -> (i64, i64) {
 
 #[cfg(test)]
 mod tests {
-    use super::iso_date_to_epoch_days;
+    use super::{iso_date_to_epoch_days, IsoDate};
 
     const MAX_DAYS_BASE: i32 = 100_000_000;
+
+    #[test]
+    fn icu4x_max_conversion_test() {
+        // Test that the max ISO date does not panic on conversion
+        let _ = IsoDate::new_unchecked(275_760, 9, 13).to_icu4x();
+        // Test that the min ISO date does not panic on conversion
+        let _ = IsoDate::new_unchecked(-271_821, 4, 20).to_icu4x();
+    }
 
     #[test]
     fn iso_date_to_epoch_days_limits() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,9 @@
 //!
 //! // Create a new date with the japanese calendar
 //! let japanese_date = iso8601_date.with_calendar(Calendar::from_str("japanese").unwrap()).unwrap();
-//! let current_era = japanese_date.era().expect("current date converts between calendars");
-//! assert_eq!(current_era, Some(tinystr!(16, "reiwa")));
-//! assert_eq!(japanese_date.era_year().unwrap(), Some(7));
-//! assert_eq!(japanese_date.month().unwrap(), 3)
+//! assert_eq!(japanese_date.era(), Some(tinystr!(16, "reiwa")));
+//! assert_eq!(japanese_date.era_year(), Some(7));
+//! assert_eq!(japanese_date.month(), 3)
 //! ```
 //!
 //! [`Temporal`][proposal] is the Stage 3 proposal for ECMAScript that

--- a/temporal_capi/bindings/cpp/temporal_rs/Calendar.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Calendar.d.hpp
@@ -59,19 +59,19 @@ public:
 
   inline diplomat::result<std::string, temporal_rs::TemporalError> era(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> era_year(temporal_rs::IsoDate date) const;
+  inline std::optional<int32_t> era_year(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<int32_t, temporal_rs::TemporalError> year(temporal_rs::IsoDate date) const;
+  inline int32_t year(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<uint8_t, temporal_rs::TemporalError> month(temporal_rs::IsoDate date) const;
+  inline uint8_t month(temporal_rs::IsoDate date) const;
 
   inline diplomat::result<std::string, temporal_rs::TemporalError> month_code(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<uint8_t, temporal_rs::TemporalError> day(temporal_rs::IsoDate date) const;
+  inline uint8_t day(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_week(temporal_rs::IsoDate date) const;
+  inline uint16_t day_of_week(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_year(temporal_rs::IsoDate date) const;
+  inline uint16_t day_of_year(temporal_rs::IsoDate date) const;
 
   inline diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError> week_of_year(temporal_rs::IsoDate date) const;
 
@@ -79,13 +79,13 @@ public:
 
   inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_week(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_month(temporal_rs::IsoDate date) const;
+  inline uint16_t days_in_month(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_year(temporal_rs::IsoDate date) const;
+  inline uint16_t days_in_year(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> months_in_year(temporal_rs::IsoDate date) const;
+  inline uint16_t months_in_year(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<bool, temporal_rs::TemporalError> in_leap_year(temporal_rs::IsoDate date) const;
+  inline bool in_leap_year(temporal_rs::IsoDate date) const;
 
   inline const temporal_rs::capi::Calendar* AsFFI() const;
   inline temporal_rs::capi::Calendar* AsFFI();

--- a/temporal_capi/bindings/cpp/temporal_rs/Calendar.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Calendar.hpp
@@ -53,26 +53,21 @@ namespace capi {
     typedef struct temporal_rs_Calendar_era_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_era_result;
     temporal_rs_Calendar_era_result temporal_rs_Calendar_era(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date, diplomat::capi::DiplomatWrite* write);
     
-    typedef struct temporal_rs_Calendar_era_year_result {union {diplomat::capi::OptionI32 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_era_year_result;
+    typedef struct temporal_rs_Calendar_era_year_result {union {int32_t ok; }; bool is_ok;} temporal_rs_Calendar_era_year_result;
     temporal_rs_Calendar_era_year_result temporal_rs_Calendar_era_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
-    typedef struct temporal_rs_Calendar_year_result {union {int32_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_year_result;
-    temporal_rs_Calendar_year_result temporal_rs_Calendar_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
+    int32_t temporal_rs_Calendar_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
-    typedef struct temporal_rs_Calendar_month_result {union {uint8_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_month_result;
-    temporal_rs_Calendar_month_result temporal_rs_Calendar_month(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
+    uint8_t temporal_rs_Calendar_month(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
     typedef struct temporal_rs_Calendar_month_code_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_month_code_result;
     temporal_rs_Calendar_month_code_result temporal_rs_Calendar_month_code(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date, diplomat::capi::DiplomatWrite* write);
     
-    typedef struct temporal_rs_Calendar_day_result {union {uint8_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_day_result;
-    temporal_rs_Calendar_day_result temporal_rs_Calendar_day(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
+    uint8_t temporal_rs_Calendar_day(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
-    typedef struct temporal_rs_Calendar_day_of_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_day_of_week_result;
-    temporal_rs_Calendar_day_of_week_result temporal_rs_Calendar_day_of_week(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
+    uint16_t temporal_rs_Calendar_day_of_week(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
-    typedef struct temporal_rs_Calendar_day_of_year_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_day_of_year_result;
-    temporal_rs_Calendar_day_of_year_result temporal_rs_Calendar_day_of_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
+    uint16_t temporal_rs_Calendar_day_of_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
     typedef struct temporal_rs_Calendar_week_of_year_result {union {diplomat::capi::OptionU16 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_week_of_year_result;
     temporal_rs_Calendar_week_of_year_result temporal_rs_Calendar_week_of_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
@@ -83,17 +78,13 @@ namespace capi {
     typedef struct temporal_rs_Calendar_days_in_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_days_in_week_result;
     temporal_rs_Calendar_days_in_week_result temporal_rs_Calendar_days_in_week(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
-    typedef struct temporal_rs_Calendar_days_in_month_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_days_in_month_result;
-    temporal_rs_Calendar_days_in_month_result temporal_rs_Calendar_days_in_month(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
+    uint16_t temporal_rs_Calendar_days_in_month(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
-    typedef struct temporal_rs_Calendar_days_in_year_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_days_in_year_result;
-    temporal_rs_Calendar_days_in_year_result temporal_rs_Calendar_days_in_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
+    uint16_t temporal_rs_Calendar_days_in_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
-    typedef struct temporal_rs_Calendar_months_in_year_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_months_in_year_result;
-    temporal_rs_Calendar_months_in_year_result temporal_rs_Calendar_months_in_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
+    uint16_t temporal_rs_Calendar_months_in_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
-    typedef struct temporal_rs_Calendar_in_leap_year_result {union {bool ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_in_leap_year_result;
-    temporal_rs_Calendar_in_leap_year_result temporal_rs_Calendar_in_leap_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
+    bool temporal_rs_Calendar_in_leap_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
     
     void temporal_rs_Calendar_destroy(Calendar* self);
@@ -168,22 +159,22 @@ inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::Ca
   return result.is_ok ? diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> temporal_rs::Calendar::era_year(temporal_rs::IsoDate date) const {
+inline std::optional<int32_t> temporal_rs::Calendar::era_year(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_era_year(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Ok<std::optional<int32_t>>(result.ok.is_ok ? std::optional(result.ok.ok) : std::nullopt)) : diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
 }
 
-inline diplomat::result<int32_t, temporal_rs::TemporalError> temporal_rs::Calendar::year(temporal_rs::IsoDate date) const {
+inline int32_t temporal_rs::Calendar::year(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_year(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<int32_t, temporal_rs::TemporalError>(diplomat::Ok<int32_t>(result.ok)) : diplomat::result<int32_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint8_t, temporal_rs::TemporalError> temporal_rs::Calendar::month(temporal_rs::IsoDate date) const {
+inline uint8_t temporal_rs::Calendar::month(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_month(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Ok<uint8_t>(result.ok)) : diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::Calendar::month_code(temporal_rs::IsoDate date) const {
@@ -195,22 +186,22 @@ inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::Ca
   return result.is_ok ? diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<uint8_t, temporal_rs::TemporalError> temporal_rs::Calendar::day(temporal_rs::IsoDate date) const {
+inline uint8_t temporal_rs::Calendar::day(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_day(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Ok<uint8_t>(result.ok)) : diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::Calendar::day_of_week(temporal_rs::IsoDate date) const {
+inline uint16_t temporal_rs::Calendar::day_of_week(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_day_of_week(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::Calendar::day_of_year(temporal_rs::IsoDate date) const {
+inline uint16_t temporal_rs::Calendar::day_of_year(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_day_of_year(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError> temporal_rs::Calendar::week_of_year(temporal_rs::IsoDate date) const {
@@ -231,28 +222,28 @@ inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::Calen
   return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::Calendar::days_in_month(temporal_rs::IsoDate date) const {
+inline uint16_t temporal_rs::Calendar::days_in_month(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_days_in_month(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::Calendar::days_in_year(temporal_rs::IsoDate date) const {
+inline uint16_t temporal_rs::Calendar::days_in_year(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_days_in_year(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::Calendar::months_in_year(temporal_rs::IsoDate date) const {
+inline uint16_t temporal_rs::Calendar::months_in_year(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_months_in_year(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<bool, temporal_rs::TemporalError> temporal_rs::Calendar::in_leap_year(temporal_rs::IsoDate date) const {
+inline bool temporal_rs::Calendar::in_leap_year(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_in_leap_year(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<bool, temporal_rs::TemporalError>(diplomat::Ok<bool>(result.ok)) : diplomat::result<bool, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline const temporal_rs::capi::Calendar* temporal_rs::Calendar::AsFFI() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
@@ -74,17 +74,17 @@ public:
 
   inline diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> since(const temporal_rs::PlainDate& other, temporal_rs::DifferenceSettings settings) const;
 
-  inline diplomat::result<int32_t, temporal_rs::TemporalError> year() const;
+  inline int32_t year() const;
 
-  inline diplomat::result<uint8_t, temporal_rs::TemporalError> month() const;
+  inline uint8_t month() const;
 
-  inline diplomat::result<std::string, temporal_rs::TemporalError> month_code() const;
+  inline std::string month_code() const;
 
-  inline diplomat::result<uint8_t, temporal_rs::TemporalError> day() const;
+  inline uint8_t day() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_week() const;
+  inline uint16_t day_of_week() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_year() const;
+  inline uint16_t day_of_year() const;
 
   inline diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError> week_of_year() const;
 
@@ -92,17 +92,17 @@ public:
 
   inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_week() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_month() const;
+  inline uint16_t days_in_month() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_year() const;
+  inline uint16_t days_in_year() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> months_in_year() const;
+  inline uint16_t months_in_year() const;
 
-  inline diplomat::result<bool, temporal_rs::TemporalError> in_leap_year() const;
+  inline bool in_leap_year() const;
 
-  inline diplomat::result<std::string, temporal_rs::TemporalError> era() const;
+  inline std::string era() const;
 
-  inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> era_year() const;
+  inline std::optional<int32_t> era_year() const;
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> to_date_time(const temporal_rs::PlainTime* time) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
@@ -69,23 +69,17 @@ namespace capi {
     typedef struct temporal_rs_PlainDate_since_result {union {temporal_rs::capi::Duration* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_since_result;
     temporal_rs_PlainDate_since_result temporal_rs_PlainDate_since(const temporal_rs::capi::PlainDate* self, const temporal_rs::capi::PlainDate* other, temporal_rs::capi::DifferenceSettings settings);
     
-    typedef struct temporal_rs_PlainDate_year_result {union {int32_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_year_result;
-    temporal_rs_PlainDate_year_result temporal_rs_PlainDate_year(const temporal_rs::capi::PlainDate* self);
+    int32_t temporal_rs_PlainDate_year(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_month_result {union {uint8_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_month_result;
-    temporal_rs_PlainDate_month_result temporal_rs_PlainDate_month(const temporal_rs::capi::PlainDate* self);
+    uint8_t temporal_rs_PlainDate_month(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_month_code_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_month_code_result;
-    temporal_rs_PlainDate_month_code_result temporal_rs_PlainDate_month_code(const temporal_rs::capi::PlainDate* self, diplomat::capi::DiplomatWrite* write);
+    void temporal_rs_PlainDate_month_code(const temporal_rs::capi::PlainDate* self, diplomat::capi::DiplomatWrite* write);
     
-    typedef struct temporal_rs_PlainDate_day_result {union {uint8_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_day_result;
-    temporal_rs_PlainDate_day_result temporal_rs_PlainDate_day(const temporal_rs::capi::PlainDate* self);
+    uint8_t temporal_rs_PlainDate_day(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_day_of_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_day_of_week_result;
-    temporal_rs_PlainDate_day_of_week_result temporal_rs_PlainDate_day_of_week(const temporal_rs::capi::PlainDate* self);
+    uint16_t temporal_rs_PlainDate_day_of_week(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_day_of_year_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_day_of_year_result;
-    temporal_rs_PlainDate_day_of_year_result temporal_rs_PlainDate_day_of_year(const temporal_rs::capi::PlainDate* self);
+    uint16_t temporal_rs_PlainDate_day_of_year(const temporal_rs::capi::PlainDate* self);
     
     typedef struct temporal_rs_PlainDate_week_of_year_result {union {diplomat::capi::OptionU16 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_week_of_year_result;
     temporal_rs_PlainDate_week_of_year_result temporal_rs_PlainDate_week_of_year(const temporal_rs::capi::PlainDate* self);
@@ -96,22 +90,17 @@ namespace capi {
     typedef struct temporal_rs_PlainDate_days_in_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_days_in_week_result;
     temporal_rs_PlainDate_days_in_week_result temporal_rs_PlainDate_days_in_week(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_days_in_month_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_days_in_month_result;
-    temporal_rs_PlainDate_days_in_month_result temporal_rs_PlainDate_days_in_month(const temporal_rs::capi::PlainDate* self);
+    uint16_t temporal_rs_PlainDate_days_in_month(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_days_in_year_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_days_in_year_result;
-    temporal_rs_PlainDate_days_in_year_result temporal_rs_PlainDate_days_in_year(const temporal_rs::capi::PlainDate* self);
+    uint16_t temporal_rs_PlainDate_days_in_year(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_months_in_year_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_months_in_year_result;
-    temporal_rs_PlainDate_months_in_year_result temporal_rs_PlainDate_months_in_year(const temporal_rs::capi::PlainDate* self);
+    uint16_t temporal_rs_PlainDate_months_in_year(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_in_leap_year_result {union {bool ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_in_leap_year_result;
-    temporal_rs_PlainDate_in_leap_year_result temporal_rs_PlainDate_in_leap_year(const temporal_rs::capi::PlainDate* self);
+    bool temporal_rs_PlainDate_in_leap_year(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_era_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_era_result;
-    temporal_rs_PlainDate_era_result temporal_rs_PlainDate_era(const temporal_rs::capi::PlainDate* self, diplomat::capi::DiplomatWrite* write);
+    void temporal_rs_PlainDate_era(const temporal_rs::capi::PlainDate* self, diplomat::capi::DiplomatWrite* write);
     
-    typedef struct temporal_rs_PlainDate_era_year_result {union {diplomat::capi::OptionI32 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_era_year_result;
+    typedef struct temporal_rs_PlainDate_era_year_result {union {int32_t ok; }; bool is_ok;} temporal_rs_PlainDate_era_year_result;
     temporal_rs_PlainDate_era_year_result temporal_rs_PlainDate_era_year(const temporal_rs::capi::PlainDate* self);
     
     typedef struct temporal_rs_PlainDate_to_date_time_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_to_date_time_result;
@@ -235,37 +224,37 @@ inline diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::Tem
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::Duration>>(std::unique_ptr<temporal_rs::Duration>(temporal_rs::Duration::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<int32_t, temporal_rs::TemporalError> temporal_rs::PlainDate::year() const {
+inline int32_t temporal_rs::PlainDate::year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<int32_t, temporal_rs::TemporalError>(diplomat::Ok<int32_t>(result.ok)) : diplomat::result<int32_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint8_t, temporal_rs::TemporalError> temporal_rs::PlainDate::month() const {
+inline uint8_t temporal_rs::PlainDate::month() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_month(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Ok<uint8_t>(result.ok)) : diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::PlainDate::month_code() const {
+inline std::string temporal_rs::PlainDate::month_code() const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
-  auto result = temporal_rs::capi::temporal_rs_PlainDate_month_code(this->AsFFI(),
+  temporal_rs::capi::temporal_rs_PlainDate_month_code(this->AsFFI(),
     &write);
-  return result.is_ok ? diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return output;
 }
 
-inline diplomat::result<uint8_t, temporal_rs::TemporalError> temporal_rs::PlainDate::day() const {
+inline uint8_t temporal_rs::PlainDate::day() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_day(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Ok<uint8_t>(result.ok)) : diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDate::day_of_week() const {
+inline uint16_t temporal_rs::PlainDate::day_of_week() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_day_of_week(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDate::day_of_year() const {
+inline uint16_t temporal_rs::PlainDate::day_of_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_day_of_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError> temporal_rs::PlainDate::week_of_year() const {
@@ -283,37 +272,37 @@ inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::Plain
   return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDate::days_in_month() const {
+inline uint16_t temporal_rs::PlainDate::days_in_month() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_days_in_month(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDate::days_in_year() const {
+inline uint16_t temporal_rs::PlainDate::days_in_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_days_in_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDate::months_in_year() const {
+inline uint16_t temporal_rs::PlainDate::months_in_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_months_in_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<bool, temporal_rs::TemporalError> temporal_rs::PlainDate::in_leap_year() const {
+inline bool temporal_rs::PlainDate::in_leap_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_in_leap_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<bool, temporal_rs::TemporalError>(diplomat::Ok<bool>(result.ok)) : diplomat::result<bool, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::PlainDate::era() const {
+inline std::string temporal_rs::PlainDate::era() const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
-  auto result = temporal_rs::capi::temporal_rs_PlainDate_era(this->AsFFI(),
+  temporal_rs::capi::temporal_rs_PlainDate_era(this->AsFFI(),
     &write);
-  return result.is_ok ? diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return output;
 }
 
-inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> temporal_rs::PlainDate::era_year() const {
+inline std::optional<int32_t> temporal_rs::PlainDate::era_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_era_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Ok<std::optional<int32_t>>(result.ok.is_ok ? std::optional(result.ok.ok) : std::nullopt)) : diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
 }
 
 inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDate::to_date_time(const temporal_rs::PlainTime* time) const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
@@ -70,17 +70,17 @@ public:
 
   inline const temporal_rs::Calendar& calendar() const;
 
-  inline diplomat::result<int32_t, temporal_rs::TemporalError> year() const;
+  inline int32_t year() const;
 
-  inline diplomat::result<uint8_t, temporal_rs::TemporalError> month() const;
+  inline uint8_t month() const;
 
-  inline diplomat::result<std::string, temporal_rs::TemporalError> month_code() const;
+  inline std::string month_code() const;
 
-  inline diplomat::result<uint8_t, temporal_rs::TemporalError> day() const;
+  inline uint8_t day() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_week() const;
+  inline uint16_t day_of_week() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_year() const;
+  inline uint16_t day_of_year() const;
 
   inline diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError> week_of_year() const;
 
@@ -88,17 +88,17 @@ public:
 
   inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_week() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_month() const;
+  inline uint16_t days_in_month() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_year() const;
+  inline uint16_t days_in_year() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> months_in_year() const;
+  inline uint16_t months_in_year() const;
 
-  inline diplomat::result<bool, temporal_rs::TemporalError> in_leap_year() const;
+  inline bool in_leap_year() const;
 
-  inline diplomat::result<std::string, temporal_rs::TemporalError> era() const;
+  inline std::string era() const;
 
-  inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> era_year() const;
+  inline std::optional<int32_t> era_year() const;
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> add(const temporal_rs::Duration& duration, std::optional<temporal_rs::ArithmeticOverflow> overflow) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
@@ -64,23 +64,17 @@ namespace capi {
     
     const temporal_rs::capi::Calendar* temporal_rs_PlainDateTime_calendar(const temporal_rs::capi::PlainDateTime* self);
     
-    typedef struct temporal_rs_PlainDateTime_year_result {union {int32_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_year_result;
-    temporal_rs_PlainDateTime_year_result temporal_rs_PlainDateTime_year(const temporal_rs::capi::PlainDateTime* self);
+    int32_t temporal_rs_PlainDateTime_year(const temporal_rs::capi::PlainDateTime* self);
     
-    typedef struct temporal_rs_PlainDateTime_month_result {union {uint8_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_month_result;
-    temporal_rs_PlainDateTime_month_result temporal_rs_PlainDateTime_month(const temporal_rs::capi::PlainDateTime* self);
+    uint8_t temporal_rs_PlainDateTime_month(const temporal_rs::capi::PlainDateTime* self);
     
-    typedef struct temporal_rs_PlainDateTime_month_code_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_month_code_result;
-    temporal_rs_PlainDateTime_month_code_result temporal_rs_PlainDateTime_month_code(const temporal_rs::capi::PlainDateTime* self, diplomat::capi::DiplomatWrite* write);
+    void temporal_rs_PlainDateTime_month_code(const temporal_rs::capi::PlainDateTime* self, diplomat::capi::DiplomatWrite* write);
     
-    typedef struct temporal_rs_PlainDateTime_day_result {union {uint8_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_day_result;
-    temporal_rs_PlainDateTime_day_result temporal_rs_PlainDateTime_day(const temporal_rs::capi::PlainDateTime* self);
+    uint8_t temporal_rs_PlainDateTime_day(const temporal_rs::capi::PlainDateTime* self);
     
-    typedef struct temporal_rs_PlainDateTime_day_of_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_day_of_week_result;
-    temporal_rs_PlainDateTime_day_of_week_result temporal_rs_PlainDateTime_day_of_week(const temporal_rs::capi::PlainDateTime* self);
+    uint16_t temporal_rs_PlainDateTime_day_of_week(const temporal_rs::capi::PlainDateTime* self);
     
-    typedef struct temporal_rs_PlainDateTime_day_of_year_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_day_of_year_result;
-    temporal_rs_PlainDateTime_day_of_year_result temporal_rs_PlainDateTime_day_of_year(const temporal_rs::capi::PlainDateTime* self);
+    uint16_t temporal_rs_PlainDateTime_day_of_year(const temporal_rs::capi::PlainDateTime* self);
     
     typedef struct temporal_rs_PlainDateTime_week_of_year_result {union {diplomat::capi::OptionU16 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_week_of_year_result;
     temporal_rs_PlainDateTime_week_of_year_result temporal_rs_PlainDateTime_week_of_year(const temporal_rs::capi::PlainDateTime* self);
@@ -91,22 +85,17 @@ namespace capi {
     typedef struct temporal_rs_PlainDateTime_days_in_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_days_in_week_result;
     temporal_rs_PlainDateTime_days_in_week_result temporal_rs_PlainDateTime_days_in_week(const temporal_rs::capi::PlainDateTime* self);
     
-    typedef struct temporal_rs_PlainDateTime_days_in_month_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_days_in_month_result;
-    temporal_rs_PlainDateTime_days_in_month_result temporal_rs_PlainDateTime_days_in_month(const temporal_rs::capi::PlainDateTime* self);
+    uint16_t temporal_rs_PlainDateTime_days_in_month(const temporal_rs::capi::PlainDateTime* self);
     
-    typedef struct temporal_rs_PlainDateTime_days_in_year_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_days_in_year_result;
-    temporal_rs_PlainDateTime_days_in_year_result temporal_rs_PlainDateTime_days_in_year(const temporal_rs::capi::PlainDateTime* self);
+    uint16_t temporal_rs_PlainDateTime_days_in_year(const temporal_rs::capi::PlainDateTime* self);
     
-    typedef struct temporal_rs_PlainDateTime_months_in_year_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_months_in_year_result;
-    temporal_rs_PlainDateTime_months_in_year_result temporal_rs_PlainDateTime_months_in_year(const temporal_rs::capi::PlainDateTime* self);
+    uint16_t temporal_rs_PlainDateTime_months_in_year(const temporal_rs::capi::PlainDateTime* self);
     
-    typedef struct temporal_rs_PlainDateTime_in_leap_year_result {union {bool ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_in_leap_year_result;
-    temporal_rs_PlainDateTime_in_leap_year_result temporal_rs_PlainDateTime_in_leap_year(const temporal_rs::capi::PlainDateTime* self);
+    bool temporal_rs_PlainDateTime_in_leap_year(const temporal_rs::capi::PlainDateTime* self);
     
-    typedef struct temporal_rs_PlainDateTime_era_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_era_result;
-    temporal_rs_PlainDateTime_era_result temporal_rs_PlainDateTime_era(const temporal_rs::capi::PlainDateTime* self, diplomat::capi::DiplomatWrite* write);
+    void temporal_rs_PlainDateTime_era(const temporal_rs::capi::PlainDateTime* self, diplomat::capi::DiplomatWrite* write);
     
-    typedef struct temporal_rs_PlainDateTime_era_year_result {union {diplomat::capi::OptionI32 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_era_year_result;
+    typedef struct temporal_rs_PlainDateTime_era_year_result {union {int32_t ok; }; bool is_ok;} temporal_rs_PlainDateTime_era_year_result;
     temporal_rs_PlainDateTime_era_year_result temporal_rs_PlainDateTime_era_year(const temporal_rs::capi::PlainDateTime* self);
     
     typedef struct temporal_rs_PlainDateTime_add_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_add_result;
@@ -240,37 +229,37 @@ inline const temporal_rs::Calendar& temporal_rs::PlainDateTime::calendar() const
   return *temporal_rs::Calendar::FromFFI(result);
 }
 
-inline diplomat::result<int32_t, temporal_rs::TemporalError> temporal_rs::PlainDateTime::year() const {
+inline int32_t temporal_rs::PlainDateTime::year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<int32_t, temporal_rs::TemporalError>(diplomat::Ok<int32_t>(result.ok)) : diplomat::result<int32_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint8_t, temporal_rs::TemporalError> temporal_rs::PlainDateTime::month() const {
+inline uint8_t temporal_rs::PlainDateTime::month() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_month(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Ok<uint8_t>(result.ok)) : diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::PlainDateTime::month_code() const {
+inline std::string temporal_rs::PlainDateTime::month_code() const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
-  auto result = temporal_rs::capi::temporal_rs_PlainDateTime_month_code(this->AsFFI(),
+  temporal_rs::capi::temporal_rs_PlainDateTime_month_code(this->AsFFI(),
     &write);
-  return result.is_ok ? diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return output;
 }
 
-inline diplomat::result<uint8_t, temporal_rs::TemporalError> temporal_rs::PlainDateTime::day() const {
+inline uint8_t temporal_rs::PlainDateTime::day() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_day(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Ok<uint8_t>(result.ok)) : diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDateTime::day_of_week() const {
+inline uint16_t temporal_rs::PlainDateTime::day_of_week() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_day_of_week(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDateTime::day_of_year() const {
+inline uint16_t temporal_rs::PlainDateTime::day_of_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_day_of_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::week_of_year() const {
@@ -288,37 +277,37 @@ inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::Plain
   return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDateTime::days_in_month() const {
+inline uint16_t temporal_rs::PlainDateTime::days_in_month() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_days_in_month(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDateTime::days_in_year() const {
+inline uint16_t temporal_rs::PlainDateTime::days_in_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_days_in_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDateTime::months_in_year() const {
+inline uint16_t temporal_rs::PlainDateTime::months_in_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_months_in_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<bool, temporal_rs::TemporalError> temporal_rs::PlainDateTime::in_leap_year() const {
+inline bool temporal_rs::PlainDateTime::in_leap_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_in_leap_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<bool, temporal_rs::TemporalError>(diplomat::Ok<bool>(result.ok)) : diplomat::result<bool, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::PlainDateTime::era() const {
+inline std::string temporal_rs::PlainDateTime::era() const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
-  auto result = temporal_rs::capi::temporal_rs_PlainDateTime_era(this->AsFFI(),
+  temporal_rs::capi::temporal_rs_PlainDateTime_era(this->AsFFI(),
     &write);
-  return result.is_ok ? diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return output;
 }
 
-inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::era_year() const {
+inline std::optional<int32_t> temporal_rs::PlainDateTime::era_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_era_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Ok<std::optional<int32_t>>(result.ok.is_ok ? std::optional(result.ok.ok) : std::nullopt)) : diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
 }
 
 inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::add(const temporal_rs::Duration& duration, std::optional<temporal_rs::ArithmeticOverflow> overflow) const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
@@ -44,7 +44,7 @@ public:
 
   inline const temporal_rs::Calendar& calendar() const;
 
-  inline diplomat::result<std::string, temporal_rs::TemporalError> month_code() const;
+  inline std::string month_code() const;
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> to_plain_date() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
@@ -35,8 +35,7 @@ namespace capi {
     
     const temporal_rs::capi::Calendar* temporal_rs_PlainMonthDay_calendar(const temporal_rs::capi::PlainMonthDay* self);
     
-    typedef struct temporal_rs_PlainMonthDay_month_code_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_month_code_result;
-    temporal_rs_PlainMonthDay_month_code_result temporal_rs_PlainMonthDay_month_code(const temporal_rs::capi::PlainMonthDay* self, diplomat::capi::DiplomatWrite* write);
+    void temporal_rs_PlainMonthDay_month_code(const temporal_rs::capi::PlainMonthDay* self, diplomat::capi::DiplomatWrite* write);
     
     typedef struct temporal_rs_PlainMonthDay_to_plain_date_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_to_plain_date_result;
     temporal_rs_PlainMonthDay_to_plain_date_result temporal_rs_PlainMonthDay_to_plain_date(const temporal_rs::capi::PlainMonthDay* self);
@@ -84,12 +83,12 @@ inline const temporal_rs::Calendar& temporal_rs::PlainMonthDay::calendar() const
   return *temporal_rs::Calendar::FromFFI(result);
 }
 
-inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::PlainMonthDay::month_code() const {
+inline std::string temporal_rs::PlainMonthDay::month_code() const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
-  auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_month_code(this->AsFFI(),
+  temporal_rs::capi::temporal_rs_PlainMonthDay_month_code(this->AsFFI(),
     &write);
-  return result.is_ok ? diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return output;
 }
 
 inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainMonthDay::to_plain_date() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.d.hpp
@@ -45,23 +45,23 @@ public:
 
   inline uint8_t iso_month() const;
 
-  inline diplomat::result<int32_t, temporal_rs::TemporalError> year() const;
+  inline int32_t year() const;
 
-  inline diplomat::result<uint8_t, temporal_rs::TemporalError> month() const;
+  inline uint8_t month() const;
 
-  inline diplomat::result<std::string, temporal_rs::TemporalError> month_code() const;
+  inline std::string month_code() const;
 
   inline bool in_leap_year() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_month() const;
+  inline uint16_t days_in_month() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_year() const;
+  inline uint16_t days_in_year() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> months_in_year() const;
+  inline uint16_t months_in_year() const;
 
-  inline diplomat::result<std::string, temporal_rs::TemporalError> era() const;
+  inline std::string era() const;
 
-  inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> era_year() const;
+  inline std::optional<int32_t> era_year() const;
 
   inline const temporal_rs::Calendar& calendar() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.hpp
@@ -35,30 +35,23 @@ namespace capi {
     
     uint8_t temporal_rs_PlainYearMonth_iso_month(const temporal_rs::capi::PlainYearMonth* self);
     
-    typedef struct temporal_rs_PlainYearMonth_year_result {union {int32_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_year_result;
-    temporal_rs_PlainYearMonth_year_result temporal_rs_PlainYearMonth_year(const temporal_rs::capi::PlainYearMonth* self);
+    int32_t temporal_rs_PlainYearMonth_year(const temporal_rs::capi::PlainYearMonth* self);
     
-    typedef struct temporal_rs_PlainYearMonth_month_result {union {uint8_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_month_result;
-    temporal_rs_PlainYearMonth_month_result temporal_rs_PlainYearMonth_month(const temporal_rs::capi::PlainYearMonth* self);
+    uint8_t temporal_rs_PlainYearMonth_month(const temporal_rs::capi::PlainYearMonth* self);
     
-    typedef struct temporal_rs_PlainYearMonth_month_code_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_month_code_result;
-    temporal_rs_PlainYearMonth_month_code_result temporal_rs_PlainYearMonth_month_code(const temporal_rs::capi::PlainYearMonth* self, diplomat::capi::DiplomatWrite* write);
+    void temporal_rs_PlainYearMonth_month_code(const temporal_rs::capi::PlainYearMonth* self, diplomat::capi::DiplomatWrite* write);
     
     bool temporal_rs_PlainYearMonth_in_leap_year(const temporal_rs::capi::PlainYearMonth* self);
     
-    typedef struct temporal_rs_PlainYearMonth_days_in_month_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_days_in_month_result;
-    temporal_rs_PlainYearMonth_days_in_month_result temporal_rs_PlainYearMonth_days_in_month(const temporal_rs::capi::PlainYearMonth* self);
+    uint16_t temporal_rs_PlainYearMonth_days_in_month(const temporal_rs::capi::PlainYearMonth* self);
     
-    typedef struct temporal_rs_PlainYearMonth_days_in_year_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_days_in_year_result;
-    temporal_rs_PlainYearMonth_days_in_year_result temporal_rs_PlainYearMonth_days_in_year(const temporal_rs::capi::PlainYearMonth* self);
+    uint16_t temporal_rs_PlainYearMonth_days_in_year(const temporal_rs::capi::PlainYearMonth* self);
     
-    typedef struct temporal_rs_PlainYearMonth_months_in_year_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_months_in_year_result;
-    temporal_rs_PlainYearMonth_months_in_year_result temporal_rs_PlainYearMonth_months_in_year(const temporal_rs::capi::PlainYearMonth* self);
+    uint16_t temporal_rs_PlainYearMonth_months_in_year(const temporal_rs::capi::PlainYearMonth* self);
     
-    typedef struct temporal_rs_PlainYearMonth_era_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_era_result;
-    temporal_rs_PlainYearMonth_era_result temporal_rs_PlainYearMonth_era(const temporal_rs::capi::PlainYearMonth* self, diplomat::capi::DiplomatWrite* write);
+    void temporal_rs_PlainYearMonth_era(const temporal_rs::capi::PlainYearMonth* self, diplomat::capi::DiplomatWrite* write);
     
-    typedef struct temporal_rs_PlainYearMonth_era_year_result {union {diplomat::capi::OptionI32 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_era_year_result;
+    typedef struct temporal_rs_PlainYearMonth_era_year_result {union {int32_t ok; }; bool is_ok;} temporal_rs_PlainYearMonth_era_year_result;
     temporal_rs_PlainYearMonth_era_year_result temporal_rs_PlainYearMonth_era_year(const temporal_rs::capi::PlainYearMonth* self);
     
     const temporal_rs::capi::Calendar* temporal_rs_PlainYearMonth_calendar(const temporal_rs::capi::PlainYearMonth* self);
@@ -119,22 +112,22 @@ inline uint8_t temporal_rs::PlainYearMonth::iso_month() const {
   return result;
 }
 
-inline diplomat::result<int32_t, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::year() const {
+inline int32_t temporal_rs::PlainYearMonth::year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<int32_t, temporal_rs::TemporalError>(diplomat::Ok<int32_t>(result.ok)) : diplomat::result<int32_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint8_t, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::month() const {
+inline uint8_t temporal_rs::PlainYearMonth::month() const {
   auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_month(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Ok<uint8_t>(result.ok)) : diplomat::result<uint8_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::month_code() const {
+inline std::string temporal_rs::PlainYearMonth::month_code() const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
-  auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_month_code(this->AsFFI(),
+  temporal_rs::capi::temporal_rs_PlainYearMonth_month_code(this->AsFFI(),
     &write);
-  return result.is_ok ? diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return output;
 }
 
 inline bool temporal_rs::PlainYearMonth::in_leap_year() const {
@@ -142,32 +135,32 @@ inline bool temporal_rs::PlainYearMonth::in_leap_year() const {
   return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::days_in_month() const {
+inline uint16_t temporal_rs::PlainYearMonth::days_in_month() const {
   auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_days_in_month(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::days_in_year() const {
+inline uint16_t temporal_rs::PlainYearMonth::days_in_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_days_in_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::months_in_year() const {
+inline uint16_t temporal_rs::PlainYearMonth::months_in_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_months_in_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
-inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::era() const {
+inline std::string temporal_rs::PlainYearMonth::era() const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
-  auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_era(this->AsFFI(),
+  temporal_rs::capi::temporal_rs_PlainYearMonth_era(this->AsFFI(),
     &write);
-  return result.is_ok ? diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return output;
 }
 
-inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::era_year() const {
+inline std::optional<int32_t> temporal_rs::PlainYearMonth::era_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_era_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Ok<std::optional<int32_t>>(result.ok.is_ok ? std::optional(result.ok.ok) : std::nullopt)) : diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
 }
 
 inline const temporal_rs::Calendar& temporal_rs::PlainYearMonth::calendar() const {

--- a/temporal_capi/src/calendar.rs
+++ b/temporal_capi/src/calendar.rs
@@ -119,10 +119,7 @@ pub mod ffi {
 
         // Writes an empty string for no era
         pub fn era(&self, date: IsoDate, write: &mut DiplomatWrite) -> Result<(), TemporalError> {
-            let era = self
-                .0
-                .era(&date.into())
-                .map_err(Into::<TemporalError>::into)?;
+            let era = self.0.era(&date.into());
             if let Some(era) = era {
                 // throw away the error, this should always succeed
                 let _ = write.write_str(&era);
@@ -130,37 +127,34 @@ pub mod ffi {
             Ok(())
         }
 
-        pub fn era_year(&self, date: IsoDate) -> Result<Option<i32>, TemporalError> {
-            self.0.era_year(&date.into()).map_err(Into::into)
+        pub fn era_year(&self, date: IsoDate) -> Option<i32> {
+            self.0.era_year(&date.into())
         }
 
-        pub fn year(&self, date: IsoDate) -> Result<i32, TemporalError> {
-            self.0.year(&date.into()).map_err(Into::into)
+        pub fn year(&self, date: IsoDate) -> i32 {
+            self.0.year(&date.into())
         }
-        pub fn month(&self, date: IsoDate) -> Result<u8, TemporalError> {
-            self.0.month(&date.into()).map_err(Into::into)
+        pub fn month(&self, date: IsoDate) -> u8 {
+            self.0.month(&date.into())
         }
         pub fn month_code(
             &self,
             date: IsoDate,
             write: &mut DiplomatWrite,
         ) -> Result<(), TemporalError> {
-            let code = self
-                .0
-                .month_code(&date.into())
-                .map_err(Into::<TemporalError>::into)?;
+            let code = self.0.month_code(&date.into());
             // throw away the error, this should always succeed
             let _ = write.write_str(code.as_str());
             Ok(())
         }
-        pub fn day(&self, date: IsoDate) -> Result<u8, TemporalError> {
-            self.0.day(&date.into()).map_err(Into::into)
+        pub fn day(&self, date: IsoDate) -> u8 {
+            self.0.day(&date.into())
         }
-        pub fn day_of_week(&self, date: IsoDate) -> Result<u16, TemporalError> {
-            self.0.day_of_week(&date.into()).map_err(Into::into)
+        pub fn day_of_week(&self, date: IsoDate) -> u16 {
+            self.0.day_of_week(&date.into())
         }
-        pub fn day_of_year(&self, date: IsoDate) -> Result<u16, TemporalError> {
-            self.0.day_of_year(&date.into()).map_err(Into::into)
+        pub fn day_of_year(&self, date: IsoDate) -> u16 {
+            self.0.day_of_year(&date.into())
         }
         pub fn week_of_year(&self, date: IsoDate) -> Result<Option<u16>, TemporalError> {
             self.0.week_of_year(&date.into()).map_err(Into::into)
@@ -171,17 +165,17 @@ pub mod ffi {
         pub fn days_in_week(&self, date: IsoDate) -> Result<u16, TemporalError> {
             self.0.days_in_week(&date.into()).map_err(Into::into)
         }
-        pub fn days_in_month(&self, date: IsoDate) -> Result<u16, TemporalError> {
-            self.0.days_in_month(&date.into()).map_err(Into::into)
+        pub fn days_in_month(&self, date: IsoDate) -> u16 {
+            self.0.days_in_month(&date.into())
         }
-        pub fn days_in_year(&self, date: IsoDate) -> Result<u16, TemporalError> {
-            self.0.days_in_year(&date.into()).map_err(Into::into)
+        pub fn days_in_year(&self, date: IsoDate) -> u16 {
+            self.0.days_in_year(&date.into())
         }
-        pub fn months_in_year(&self, date: IsoDate) -> Result<u16, TemporalError> {
-            self.0.months_in_year(&date.into()).map_err(Into::into)
+        pub fn months_in_year(&self, date: IsoDate) -> u16 {
+            self.0.months_in_year(&date.into())
         }
-        pub fn in_leap_year(&self, date: IsoDate) -> Result<bool, TemporalError> {
-            self.0.in_leap_year(&date.into()).map_err(Into::into)
+        pub fn in_leap_year(&self, date: IsoDate) -> bool {
+            self.0.in_leap_year(&date.into())
         }
 
         // TODO .fields() (need to pick a convenient way to return vectors or iterators, depending on how the API gets used)

--- a/temporal_capi/src/plain_date.rs
+++ b/temporal_capi/src/plain_date.rs
@@ -159,26 +159,25 @@ pub mod ffi {
                 .map_err(Into::into)
         }
 
-        pub fn year(&self) -> Result<i32, TemporalError> {
-            self.0.year().map_err(Into::into)
+        pub fn year(&self) -> i32 {
+            self.0.year()
         }
-        pub fn month(&self) -> Result<u8, TemporalError> {
-            self.0.month().map_err(Into::into)
+        pub fn month(&self) -> u8 {
+            self.0.month()
         }
-        pub fn month_code(&self, write: &mut DiplomatWrite) -> Result<(), TemporalError> {
-            let code = self.0.month_code().map_err(Into::<TemporalError>::into)?;
+        pub fn month_code(&self, write: &mut DiplomatWrite) {
+            let code = self.0.month_code();
             // throw away the error, this should always succeed
             let _ = write.write_str(code.as_str());
-            Ok(())
         }
-        pub fn day(&self) -> Result<u8, TemporalError> {
-            self.0.day().map_err(Into::into)
+        pub fn day(&self) -> u8 {
+            self.0.day()
         }
-        pub fn day_of_week(&self) -> Result<u16, TemporalError> {
-            self.0.day_of_week().map_err(Into::into)
+        pub fn day_of_week(&self) -> u16 {
+            self.0.day_of_week()
         }
-        pub fn day_of_year(&self) -> Result<u16, TemporalError> {
-            self.0.day_of_year().map_err(Into::into)
+        pub fn day_of_year(&self) -> u16 {
+            self.0.day_of_year()
         }
         pub fn week_of_year(&self) -> Result<Option<u16>, TemporalError> {
             self.0.week_of_year().map_err(Into::into)
@@ -189,30 +188,29 @@ pub mod ffi {
         pub fn days_in_week(&self) -> Result<u16, TemporalError> {
             self.0.days_in_week().map_err(Into::into)
         }
-        pub fn days_in_month(&self) -> Result<u16, TemporalError> {
-            self.0.days_in_month().map_err(Into::into)
+        pub fn days_in_month(&self) -> u16 {
+            self.0.days_in_month()
         }
-        pub fn days_in_year(&self) -> Result<u16, TemporalError> {
-            self.0.days_in_year().map_err(Into::into)
+        pub fn days_in_year(&self) -> u16 {
+            self.0.days_in_year()
         }
-        pub fn months_in_year(&self) -> Result<u16, TemporalError> {
-            self.0.months_in_year().map_err(Into::into)
+        pub fn months_in_year(&self) -> u16 {
+            self.0.months_in_year()
         }
-        pub fn in_leap_year(&self) -> Result<bool, TemporalError> {
-            self.0.in_leap_year().map_err(Into::into)
+        pub fn in_leap_year(&self) -> bool {
+            self.0.in_leap_year()
         }
         // Writes an empty string for no era
-        pub fn era(&self, write: &mut DiplomatWrite) -> Result<(), TemporalError> {
-            let era = self.0.era().map_err(Into::<TemporalError>::into)?;
+        pub fn era(&self, write: &mut DiplomatWrite) {
+            let era = self.0.era();
             if let Some(era) = era {
                 // throw away the error, this should always succeed
                 let _ = write.write_str(&era);
             }
-            Ok(())
         }
 
-        pub fn era_year(&self) -> Result<Option<i32>, TemporalError> {
-            self.0.era_year().map_err(Into::into)
+        pub fn era_year(&self) -> Option<i32> {
+            self.0.era_year()
         }
 
         pub fn to_date_time(

--- a/temporal_capi/src/plain_date_time.rs
+++ b/temporal_capi/src/plain_date_time.rs
@@ -147,26 +147,25 @@ pub mod ffi {
             Calendar::transparent_convert(self.0.calendar())
         }
 
-        pub fn year(&self) -> Result<i32, TemporalError> {
-            self.0.year().map_err(Into::into)
+        pub fn year(&self) -> i32 {
+            self.0.year()
         }
-        pub fn month(&self) -> Result<u8, TemporalError> {
-            self.0.month().map_err(Into::into)
+        pub fn month(&self) -> u8 {
+            self.0.month()
         }
-        pub fn month_code(&self, write: &mut DiplomatWrite) -> Result<(), TemporalError> {
-            let code = self.0.month_code().map_err(Into::<TemporalError>::into)?;
+        pub fn month_code(&self, write: &mut DiplomatWrite) {
+            let code = self.0.month_code();
             // throw away the error, this should always succeed
             let _ = write.write_str(code.as_str());
-            Ok(())
         }
-        pub fn day(&self) -> Result<u8, TemporalError> {
-            self.0.day().map_err(Into::into)
+        pub fn day(&self) -> u8 {
+            self.0.day()
         }
-        pub fn day_of_week(&self) -> Result<u16, TemporalError> {
-            self.0.day_of_week().map_err(Into::into)
+        pub fn day_of_week(&self) -> u16 {
+            self.0.day_of_week()
         }
-        pub fn day_of_year(&self) -> Result<u16, TemporalError> {
-            self.0.day_of_year().map_err(Into::into)
+        pub fn day_of_year(&self) -> u16 {
+            self.0.day_of_year()
         }
         pub fn week_of_year(&self) -> Result<Option<u16>, TemporalError> {
             self.0.week_of_year().map_err(Into::into)
@@ -177,30 +176,29 @@ pub mod ffi {
         pub fn days_in_week(&self) -> Result<u16, TemporalError> {
             self.0.days_in_week().map_err(Into::into)
         }
-        pub fn days_in_month(&self) -> Result<u16, TemporalError> {
-            self.0.days_in_month().map_err(Into::into)
+        pub fn days_in_month(&self) -> u16 {
+            self.0.days_in_month()
         }
-        pub fn days_in_year(&self) -> Result<u16, TemporalError> {
-            self.0.days_in_year().map_err(Into::into)
+        pub fn days_in_year(&self) -> u16 {
+            self.0.days_in_year()
         }
-        pub fn months_in_year(&self) -> Result<u16, TemporalError> {
-            self.0.months_in_year().map_err(Into::into)
+        pub fn months_in_year(&self) -> u16 {
+            self.0.months_in_year()
         }
-        pub fn in_leap_year(&self) -> Result<bool, TemporalError> {
-            self.0.in_leap_year().map_err(Into::into)
+        pub fn in_leap_year(&self) -> bool {
+            self.0.in_leap_year()
         }
         // Writes an empty string for no era
-        pub fn era(&self, write: &mut DiplomatWrite) -> Result<(), TemporalError> {
-            let era = self.0.era().map_err(Into::<TemporalError>::into)?;
+        pub fn era(&self, write: &mut DiplomatWrite) {
+            let era = self.0.era();
             if let Some(era) = era {
                 // throw away the error, this should always succeed
                 let _ = write.write_str(&era);
             }
-            Ok(())
         }
 
-        pub fn era_year(&self) -> Result<Option<i32>, TemporalError> {
-            self.0.era_year().map_err(Into::into)
+        pub fn era_year(&self) -> Option<i32> {
+            self.0.era_year()
         }
 
         pub fn add(

--- a/temporal_capi/src/plain_month_day.rs
+++ b/temporal_capi/src/plain_month_day.rs
@@ -58,11 +58,10 @@ pub mod ffi {
             Calendar::transparent_convert(self.0.calendar())
         }
 
-        pub fn month_code(&self, write: &mut DiplomatWrite) -> Result<(), TemporalError> {
-            let code = self.0.month_code().map_err(Into::<TemporalError>::into)?;
+        pub fn month_code(&self, write: &mut DiplomatWrite) {
+            let code = self.0.month_code();
             // throw away the error, this should always succeed
             let _ = write.write_str(code.as_str());
-            Ok(())
         }
 
         pub fn to_plain_date(&self) -> Result<Box<PlainDate>, TemporalError> {

--- a/temporal_capi/src/plain_year_month.rs
+++ b/temporal_capi/src/plain_year_month.rs
@@ -59,43 +59,41 @@ pub mod ffi {
             self.0.iso_month()
         }
 
-        pub fn year(&self) -> Result<i32, TemporalError> {
-            self.0.year().map_err(Into::into)
+        pub fn year(&self) -> i32 {
+            self.0.year()
         }
-        pub fn month(&self) -> Result<u8, TemporalError> {
-            self.0.month().map_err(Into::into)
+        pub fn month(&self) -> u8 {
+            self.0.month()
         }
-        pub fn month_code(&self, write: &mut DiplomatWrite) -> Result<(), TemporalError> {
-            let code = self.0.month_code().map_err(Into::<TemporalError>::into)?;
+        pub fn month_code(&self, write: &mut DiplomatWrite) {
+            let code = self.0.month_code();
             // throw away the error, this should always succeed
             let _ = write.write_str(code.as_str());
-            Ok(())
         }
 
         pub fn in_leap_year(&self) -> bool {
             self.0.in_leap_year()
         }
-        pub fn days_in_month(&self) -> Result<u16, TemporalError> {
-            self.0.days_in_month().map_err(Into::into)
+        pub fn days_in_month(&self) -> u16 {
+            self.0.days_in_month()
         }
-        pub fn days_in_year(&self) -> Result<u16, TemporalError> {
-            self.0.days_in_year().map_err(Into::into)
+        pub fn days_in_year(&self) -> u16 {
+            self.0.days_in_year()
         }
-        pub fn months_in_year(&self) -> Result<u16, TemporalError> {
-            self.0.months_in_year().map_err(Into::into)
+        pub fn months_in_year(&self) -> u16 {
+            self.0.months_in_year()
         }
         // Writes an empty string for no era
-        pub fn era(&self, write: &mut DiplomatWrite) -> Result<(), TemporalError> {
-            let era = self.0.era().map_err(Into::<TemporalError>::into)?;
+        pub fn era(&self, write: &mut DiplomatWrite) {
+            let era = self.0.era();
             if let Some(era) = era {
                 // throw away the error, this should always succeed
                 let _ = write.write_str(&era);
             }
-            Ok(())
         }
 
-        pub fn era_year(&self) -> Result<Option<i32>, TemporalError> {
-            self.0.era_year().map_err(Into::into)
+        pub fn era_year(&self) -> Option<i32> {
+            self.0.era_year()
         }
 
         pub fn calendar<'a>(&'a self) -> &'a Calendar {


### PR DESCRIPTION
This PR removes a lot of the `TemporalResult` returns from most of the calendar methods.

This is made possible on most methods because we no longer need to support Not Yet Implemented errors.

There is also an expect added in the conversion from `IsoDate` -> `icu_calendar::Date<Iso>`. This is tested to be valid in a test added to `iso.rs` for the max bounds of `IsoDate`.

The core changes in this PR are made to `iso.rs` and `calendar.rs` by extension. The rest is mostly updating all the calendar methods accordingly.

Note: calendar methods that are still not fully implemented across various calendars were left as a `TemporalResult`