### PR TITLE
Adjustments to `toPlainYearMonth` and `toPlainMonthDay` methods on PlainDate

### DIFF
--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
@@ -65,8 +65,6 @@ public:
 
   inline bool is_valid() const;
 
-  inline int32_t days_until(const temporal_rs::PlainDate& other) const;
-
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> add(const temporal_rs::Duration& duration, std::optional<temporal_rs::ArithmeticOverflow> overflow) const;
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> subtract(const temporal_rs::Duration& duration, std::optional<temporal_rs::ArithmeticOverflow> overflow) const;
@@ -105,11 +103,11 @@ public:
 
   inline std::optional<int32_t> era_year() const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> to_date_time(const temporal_rs::PlainTime* time) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> to_plain_date_time(const temporal_rs::PlainTime* time) const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> to_month_day() const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> to_plain_month_day() const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError> to_year_month() const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError> to_plain_year_month() const;
 
   inline std::string to_ixdtf_string(temporal_rs::DisplayCalendar display_calendar) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
@@ -56,8 +56,6 @@ namespace capi {
     
     bool temporal_rs_PlainDate_is_valid(const temporal_rs::capi::PlainDate* self);
     
-    int32_t temporal_rs_PlainDate_days_until(const temporal_rs::capi::PlainDate* self, const temporal_rs::capi::PlainDate* other);
-    
     typedef struct temporal_rs_PlainDate_add_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_add_result;
     temporal_rs_PlainDate_add_result temporal_rs_PlainDate_add(const temporal_rs::capi::PlainDate* self, const temporal_rs::capi::Duration* duration, temporal_rs::capi::ArithmeticOverflow_option overflow);
     
@@ -104,14 +102,14 @@ namespace capi {
     typedef struct temporal_rs_PlainDate_era_year_result {union {int32_t ok; }; bool is_ok;} temporal_rs_PlainDate_era_year_result;
     temporal_rs_PlainDate_era_year_result temporal_rs_PlainDate_era_year(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_to_date_time_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_to_date_time_result;
-    temporal_rs_PlainDate_to_date_time_result temporal_rs_PlainDate_to_date_time(const temporal_rs::capi::PlainDate* self, const temporal_rs::capi::PlainTime* time);
+    typedef struct temporal_rs_PlainDate_to_plain_date_time_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_to_plain_date_time_result;
+    temporal_rs_PlainDate_to_plain_date_time_result temporal_rs_PlainDate_to_plain_date_time(const temporal_rs::capi::PlainDate* self, const temporal_rs::capi::PlainTime* time);
     
-    typedef struct temporal_rs_PlainDate_to_month_day_result {union {temporal_rs::capi::PlainMonthDay* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_to_month_day_result;
-    temporal_rs_PlainDate_to_month_day_result temporal_rs_PlainDate_to_month_day(const temporal_rs::capi::PlainDate* self);
+    typedef struct temporal_rs_PlainDate_to_plain_month_day_result {union {temporal_rs::capi::PlainMonthDay* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_to_plain_month_day_result;
+    temporal_rs_PlainDate_to_plain_month_day_result temporal_rs_PlainDate_to_plain_month_day(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_to_year_month_result {union {temporal_rs::capi::PlainYearMonth* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_to_year_month_result;
-    temporal_rs_PlainDate_to_year_month_result temporal_rs_PlainDate_to_year_month(const temporal_rs::capi::PlainDate* self);
+    typedef struct temporal_rs_PlainDate_to_plain_year_month_result {union {temporal_rs::capi::PlainYearMonth* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_to_plain_year_month_result;
+    temporal_rs_PlainDate_to_plain_year_month_result temporal_rs_PlainDate_to_plain_year_month(const temporal_rs::capi::PlainDate* self);
     
     void temporal_rs_PlainDate_to_ixdtf_string(const temporal_rs::capi::PlainDate* self, temporal_rs::capi::DisplayCalendar display_calendar, diplomat::capi::DiplomatWrite* write);
     
@@ -188,12 +186,6 @@ inline const temporal_rs::Calendar& temporal_rs::PlainDate::calendar() const {
 
 inline bool temporal_rs::PlainDate::is_valid() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_is_valid(this->AsFFI());
-  return result;
-}
-
-inline int32_t temporal_rs::PlainDate::days_until(const temporal_rs::PlainDate& other) const {
-  auto result = temporal_rs::capi::temporal_rs_PlainDate_days_until(this->AsFFI(),
-    other.AsFFI());
   return result;
 }
 
@@ -306,19 +298,19 @@ inline std::optional<int32_t> temporal_rs::PlainDate::era_year() const {
   return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDate::to_date_time(const temporal_rs::PlainTime* time) const {
-  auto result = temporal_rs::capi::temporal_rs_PlainDate_to_date_time(this->AsFFI(),
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDate::to_plain_date_time(const temporal_rs::PlainTime* time) const {
+  auto result = temporal_rs::capi::temporal_rs_PlainDate_to_plain_date_time(this->AsFFI(),
     time ? time->AsFFI() : nullptr);
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDateTime>>(std::unique_ptr<temporal_rs::PlainDateTime>(temporal_rs::PlainDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> temporal_rs::PlainDate::to_month_day() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainDate_to_month_day(this->AsFFI());
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> temporal_rs::PlainDate::to_plain_month_day() const {
+  auto result = temporal_rs::capi::temporal_rs_PlainDate_to_plain_month_day(this->AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainMonthDay>>(std::unique_ptr<temporal_rs::PlainMonthDay>(temporal_rs::PlainMonthDay::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError> temporal_rs::PlainDate::to_year_month() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainDate_to_year_month(this->AsFFI());
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError> temporal_rs::PlainDate::to_plain_year_month() const {
+  auto result = temporal_rs::capi::temporal_rs_PlainDate_to_plain_year_month(this->AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainYearMonth>>(std::unique_ptr<temporal_rs::PlainYearMonth>(temporal_rs::PlainYearMonth::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 

--- a/temporal_capi/src/plain_date.rs
+++ b/temporal_capi/src/plain_date.rs
@@ -114,10 +114,6 @@ pub mod ffi {
             self.0.is_valid()
         }
 
-        pub fn days_until(&self, other: &Self) -> i32 {
-            self.0.days_until(&other.0)
-        }
-
         pub fn add(
             &self,
             duration: &Duration,
@@ -213,26 +209,26 @@ pub mod ffi {
             self.0.era_year()
         }
 
-        pub fn to_date_time(
+        pub fn to_plain_date_time(
             &self,
             time: Option<&PlainTime>,
         ) -> Result<Box<PlainDateTime>, TemporalError> {
             self.0
-                .to_date_time(time.map(|t| t.0))
+                .to_plain_date_time(time.map(|t| t.0))
                 .map(|x| Box::new(PlainDateTime(x)))
                 .map_err(Into::into)
         }
 
-        pub fn to_month_day(&self) -> Result<Box<PlainMonthDay>, TemporalError> {
+        pub fn to_plain_month_day(&self) -> Result<Box<PlainMonthDay>, TemporalError> {
             self.0
-                .to_month_day()
+                .to_plain_month_day()
                 .map(|x| Box::new(PlainMonthDay(x)))
                 .map_err(Into::into)
         }
 
-        pub fn to_year_month(&self) -> Result<Box<PlainYearMonth>, TemporalError> {
+        pub fn to_plain_year_month(&self) -> Result<Box<PlainYearMonth>, TemporalError> {
             self.0
-                .to_year_month()
+                .to_plain_year_month()
                 .map(|x| Box::new(PlainYearMonth(x)))
                 .map_err(Into::into)
         }


### PR DESCRIPTION
Closes #204 

This PR updates a couple methods on `PlainDate` and adjusts the implementation of `PlainDate::to_plain_year_month`.

Both `to_plain_year_month` and `to_plain_month_day` are passing 100% of tests in Boa.

This PR also removes `PlainDate::days_until` from being pub. There's not clear reason why it was made public, so it's been made private.