### PR TITLE
Update Duration's inner representation from floating point to integers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,7 @@ dependencies = [
  "diplomat",
  "diplomat-runtime",
  "icu_calendar",
+ "num-traits",
  "temporal_rs",
 ]
 

--- a/src/builtins/compiled/duration/tests.rs
+++ b/src/builtins/compiled/duration/tests.rs
@@ -760,3 +760,29 @@ fn test_rounding_boundaries() {
     let err = duration.round(options, Some(RelativeTo::PlainDate(relative_to)));
     assert!(err.is_err());
 }
+
+#[test]
+fn test_duration_compare_boundary() {
+    let relative_to = PlainDate::new(2000, 1, 1, Calendar::default()).unwrap();
+    let zero = Duration::default();
+
+    let max_days = 2i64.pow(53) / 86_400;
+    let max_duration = Duration::new(0, 0, 1, max_days, 0, 0, 0, 0, 0, 0).unwrap();
+    let err = zero.compare(
+        &max_duration,
+        Some(RelativeTo::PlainDate(relative_to.clone())),
+    );
+    assert!(err.is_err());
+    let err = max_duration.compare(&zero, Some(RelativeTo::PlainDate(relative_to.clone())));
+    assert!(err.is_err());
+
+    let min_days = -(2i64.pow(53) / 86_400);
+    let min_duration = Duration::new(0, 0, -1, min_days, 0, 0, 0, 0, 0, 0).unwrap();
+    let err = zero.compare(
+        &min_duration,
+        Some(RelativeTo::PlainDate(relative_to.clone())),
+    );
+    assert!(err.is_err());
+    let err = min_duration.compare(&zero, Some(RelativeTo::PlainDate(relative_to.clone())));
+    assert!(err.is_err());
+}

--- a/src/builtins/compiled/duration/tests.rs
+++ b/src/builtins/compiled/duration/tests.rs
@@ -646,3 +646,117 @@ fn balance_days_up_to_both_years_and_months() {
         -2.0
     );
 }
+
+// relativeto-plaindate-add24hourdaystonormalizedtimeduration-out-of-range.js
+#[test]
+fn add_normalized_time_duration_out_of_range() {
+    let duration = Duration::from_partial_duration(PartialDuration {
+        years: Some(1),
+        seconds: Some(9_007_199_254_740_990_i64),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let relative_to = PlainDate::new(2000, 1, 1, Calendar::default()).unwrap();
+
+    let err = duration.total(Unit::Day, Some(RelativeTo::PlainDate(relative_to)));
+    assert!(err.is_err())
+}
+
+#[test]
+fn test_rounding_boundaries() {
+    let relative_to = PlainDate::new(2000, 1, 1, Calendar::default()).unwrap();
+
+    // test year
+    let duration = Duration::from_partial_duration(PartialDuration {
+        years: Some((u32::MAX - 1) as i64),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let options = RoundingOptions {
+        smallest_unit: Some(Unit::Week),
+        ..Default::default()
+    };
+    let err = duration.round(options, Some(RelativeTo::PlainDate(relative_to.clone())));
+    assert!(err.is_err());
+
+    // test month
+    let duration = Duration::from_partial_duration(PartialDuration {
+        months: Some((u32::MAX - 1) as i64),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let options = RoundingOptions {
+        smallest_unit: Some(Unit::Week),
+        ..Default::default()
+    };
+    let err = duration.round(options, Some(RelativeTo::PlainDate(relative_to.clone())));
+    assert!(err.is_err());
+
+    // test week
+    let duration = Duration::from_partial_duration(PartialDuration {
+        weeks: Some((u32::MAX - 1) as i64),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let options = RoundingOptions {
+        smallest_unit: Some(Unit::Week),
+        ..Default::default()
+    };
+    let err = duration.round(options, Some(RelativeTo::PlainDate(relative_to.clone())));
+    assert!(err.is_err());
+
+    // test calendar max
+    let duration = Duration::from_partial_duration(PartialDuration {
+        years: Some((u32::MAX - 1) as i64),
+        months: Some((u32::MAX - 1) as i64),
+        weeks: Some((u32::MAX - 1) as i64),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let options = RoundingOptions {
+        smallest_unit: Some(Unit::Week),
+        ..Default::default()
+    };
+    let err = duration.round(options, Some(RelativeTo::PlainDate(relative_to.clone())));
+    assert!(err.is_err());
+
+    // test days for safety
+    let duration = Duration::from_partial_duration(PartialDuration {
+        years: Some((u32::MAX - 1) as i64),
+        months: Some((u32::MAX - 1) as i64),
+        weeks: Some((u32::MAX - 1) as i64),
+        days: Some(104_249_991_374),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let options = RoundingOptions {
+        smallest_unit: Some(Unit::Week),
+        ..Default::default()
+    };
+    let err = duration.round(options, Some(RelativeTo::PlainDate(relative_to.clone())));
+    assert!(err.is_err());
+
+    // test minimum bounds with days for safety
+    let min_calendar_value = -((u32::MAX - 1) as i64);
+    let duration = Duration::from_partial_duration(PartialDuration {
+        years: Some(min_calendar_value),
+        months: Some(min_calendar_value),
+        weeks: Some(min_calendar_value),
+        days: Some(-104_249_991_374),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let options = RoundingOptions {
+        smallest_unit: Some(Unit::Week),
+        ..Default::default()
+    };
+    let err = duration.round(options, Some(RelativeTo::PlainDate(relative_to)));
+    assert!(err.is_err());
+}

--- a/src/builtins/compiled/duration/tests.rs
+++ b/src/builtins/compiled/duration/tests.rs
@@ -8,7 +8,6 @@ use crate::{
     Calendar, DateDuration, PlainDate, TimeDuration, TimeZone, ZonedDateTime,
 };
 
-use alloc::vec::Vec;
 use core::{num::NonZeroU32, str::FromStr};
 
 use super::Duration;
@@ -17,12 +16,26 @@ fn get_round_result(
     test_duration: &Duration,
     relative_to: RelativeTo,
     options: RoundingOptions,
-) -> Vec<i64> {
-    test_duration
-        .round(options, Some(relative_to))
-        .unwrap()
-        .fields()
-        .to_vec()
+) -> Duration {
+    test_duration.round(options, Some(relative_to)).unwrap()
+}
+
+fn assert_duration(result: Duration, values: (i64, i64, i64, i64, i64, i64, i64, i64, i128, i128)) {
+    assert_eq!(
+        (
+            result.years(),
+            result.months(),
+            result.weeks(),
+            result.days(),
+            result.hours(),
+            result.minutes(),
+            result.seconds(),
+            result.milliseconds(),
+            result.microseconds(),
+            result.nanoseconds()
+        ),
+        values
+    )
 }
 
 // roundingmode-floor.js
@@ -42,43 +55,43 @@ fn basic_positive_floor_rounding_v2() {
 
     let _ = options.smallest_unit.insert(Unit::Year);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 0, 0, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Month);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Week);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 3, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 3, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Day);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Hour);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Minute);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Second);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 20, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Millisecond);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 20, 123, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Microsecond);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 987, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 20, 123, 987, 0));
 
     let _ = options.smallest_unit.insert(Unit::Nanosecond);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 987, 500],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 20, 123, 987, 500));
 }
 
 #[test]
@@ -98,43 +111,43 @@ fn basic_negative_floor_rounding_v2() {
 
     let _ = options.smallest_unit.insert(Unit::Year);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-6, 0, 0, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-6, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Month);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -8, 0, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -8, 0, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Week);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, -4, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, -4, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Day);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -28, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -28, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Hour);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -17, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -17, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Minute);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -31, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -31, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Second);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -21, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, -21, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Millisecond);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -124, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, -20, -124, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Microsecond);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -988, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, -20, -123, -988, 0));
 
     let _ = options.smallest_unit.insert(Unit::Nanosecond);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -987, -500],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, -20, -123, -987, -500));
 }
 
 // roundingmode-ceil.js
@@ -154,43 +167,43 @@ fn basic_positive_ceil_rounding() {
 
     let _ = options.smallest_unit.insert(Unit::Year);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[6, 0, 0, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (6, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Month);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 8, 0, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 8, 0, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Week);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 4, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 4, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Day);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 28, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 28, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Hour);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 17, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 17, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Minute);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 31, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 31, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Second);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 21, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 21, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Millisecond);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 124, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 20, 124, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Microsecond);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 988, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 20, 123, 988, 0));
 
     let _ = options.smallest_unit.insert(Unit::Nanosecond);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 987, 500],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 20, 123, 987, 500));
 }
 
 #[test]
@@ -209,43 +222,43 @@ fn basic_negative_ceil_rounding() {
 
     let _ = options.smallest_unit.insert(Unit::Year);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, 0, 0, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Month);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Week);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, -3, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, -3, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Day);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Hour);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Minute);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Second);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, -20, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Millisecond);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, -20, -123, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Microsecond);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -987, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, -20, -123, -987, 0));
 
     let _ = options.smallest_unit.insert(Unit::Nanosecond);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -987, -500],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, -20, -123, -987, -500));
 }
 
 // roundingmode-expand.js
@@ -264,43 +277,43 @@ fn basic_positive_expand_rounding() {
 
     let _ = options.smallest_unit.insert(Unit::Year);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[6, 0, 0, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (6, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Month);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 8, 0, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 8, 0, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Week);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 4, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 4, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Day);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 28, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 28, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Hour);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 17, 0, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 17, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Minute);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 31, 0, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 31, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Second);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 21, 0, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 21, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Millisecond);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 124, 0, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 20, 124, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Microsecond);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 988, 0],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 20, 123, 988, 0));
 
     let _ = options.smallest_unit.insert(Unit::Nanosecond);
     let result = get_round_result(&test_duration, relative_forward.clone(), options);
-    assert_eq!(&result, &[5, 7, 0, 27, 16, 30, 20, 123, 987, 500],);
+    assert_duration(result, (5, 7, 0, 27, 16, 30, 20, 123, 987, 500));
 }
 
 #[test]
@@ -321,43 +334,43 @@ fn basic_negative_expand_rounding() {
 
     let _ = options.smallest_unit.insert(Unit::Year);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-6, 0, 0, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-6, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Month);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -8, 0, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -8, 0, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Week);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, -4, 0, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, -4, 0, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Day);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -28, 0, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -28, 0, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Hour);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -17, 0, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -17, 0, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Minute);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -31, 0, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -31, 0, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Second);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -21, 0, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, -21, 0, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Millisecond);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -124, 0, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, -20, -124, 0, 0));
 
     let _ = options.smallest_unit.insert(Unit::Microsecond);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -988, 0],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, -20, -123, -988, 0));
 
     let _ = options.smallest_unit.insert(Unit::Nanosecond);
     let result = get_round_result(&test_duration.negated(), relative_backward.clone(), options);
-    assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -987, -500],);
+    assert_duration(result, (-5, -7, 0, -27, -16, -30, -20, -123, -987, -500));
 }
 
 #[test]
@@ -370,7 +383,7 @@ fn rounding_to_fractional_day_tests() {
         rounding_mode: Some(RoundingMode::Floor),
     };
     let result = twenty_five_hours.round(options, None).unwrap();
-    assert_eq!(result.fields(), [0, 0, 0, 1, 1, 0, 0, 0, 0, 0]);
+    assert_duration(result, (0, 0, 0, 1, 1, 0, 0, 0, 0, 0));
 
     let sixty_days = Duration::from(DateDuration::new_unchecked(0, 0, 0, 64));
     let options = RoundingOptions {
@@ -380,7 +393,7 @@ fn rounding_to_fractional_day_tests() {
         rounding_mode: Some(RoundingMode::Floor),
     };
     let result = sixty_days.round(options, None).unwrap();
-    assert_eq!(result.fields(), [0, 0, 0, 60, 0, 0, 0, 0, 0, 0]);
+    assert_duration(result, (0, 0, 0, 60, 0, 0, 0, 0, 0, 0));
 
     let sixty_days = Duration::from(DateDuration::new_unchecked(0, 0, 0, 64));
     let options = RoundingOptions {
@@ -390,7 +403,7 @@ fn rounding_to_fractional_day_tests() {
         rounding_mode: Some(RoundingMode::Floor),
     };
     let result = sixty_days.round(options, None).unwrap();
-    assert_eq!(result.fields(), [0, 0, 0, 60, 0, 0, 0, 0, 0, 0]);
+    assert_duration(result, (0, 0, 0, 60, 0, 0, 0, 0, 0, 0));
 
     let sixty_days = Duration::from(DateDuration::new_unchecked(0, 0, 0, 64));
     let options = RoundingOptions {
@@ -400,7 +413,7 @@ fn rounding_to_fractional_day_tests() {
         rounding_mode: Some(RoundingMode::Ceil),
     };
     let result = sixty_days.round(options, None).unwrap();
-    assert_eq!(result.fields(), [0, 0, 0, 70, 0, 0, 0, 0, 0, 0]);
+    assert_duration(result, (0, 0, 0, 70, 0, 0, 0, 0, 0, 0));
 
     let sixty_days = Duration::from(DateDuration::new_unchecked(0, 0, 0, 1000));
     let options = RoundingOptions {
@@ -410,7 +423,7 @@ fn rounding_to_fractional_day_tests() {
         rounding_mode: Some(RoundingMode::Expand),
     };
     let result = sixty_days.round(options, None).unwrap();
-    assert_eq!(result.fields(), [0, 0, 0, 1_000_000_000, 0, 0, 0, 0, 0, 0]);
+    assert_duration(result, (0, 0, 0, 1_000_000_000, 0, 0, 0, 0, 0, 0));
 }
 
 // test262/test/built-ins/Temporal/Duration/prototype/round/roundingincrement-non-integer.js
@@ -434,13 +447,13 @@ fn rounding_increment_non_integer() {
         .round(options, Some(relative_to.clone()))
         .unwrap();
 
-    assert_eq!(result.fields(), [0, 0, 0, 2, 0, 0, 0, 0, 0, 0,]);
+    assert_duration(result, (0, 0, 0, 2, 0, 0, 0, 0, 0, 0));
 
     let _ = options
         .increment
         .insert(RoundingIncrement::try_from(1e9 + 0.5).unwrap());
     let result = test_duration.round(options, Some(relative_to)).unwrap();
-    assert_eq!(result.fields(), [0, 0, 0, 1_000_000_000, 0, 0, 0, 0, 0, 0,]);
+    assert_duration(result, (0, 0, 0, 1_000_000_000, 0, 0, 0, 0, 0, 0));
 }
 
 #[test]

--- a/src/builtins/compiled/duration/tests.rs
+++ b/src/builtins/compiled/duration/tests.rs
@@ -5,12 +5,11 @@ use crate::{
         OffsetDisambiguation, RelativeTo, RoundingIncrement, RoundingMode, RoundingOptions, Unit,
     },
     partial::PartialDuration,
-    primitive::FiniteF64,
     Calendar, DateDuration, PlainDate, TimeDuration, TimeZone, ZonedDateTime,
 };
 
 use alloc::vec::Vec;
-use core::str::FromStr;
+use core::{num::NonZeroU32, str::FromStr};
 
 use super::Duration;
 
@@ -18,33 +17,19 @@ fn get_round_result(
     test_duration: &Duration,
     relative_to: RelativeTo,
     options: RoundingOptions,
-) -> Vec<i32> {
+) -> Vec<i64> {
     test_duration
         .round(options, Some(relative_to))
         .unwrap()
         .fields()
-        .iter()
-        .map(|f| f.as_date_value().unwrap())
-        .collect::<Vec<i32>>()
+        .to_vec()
 }
 
 // roundingmode-floor.js
 #[test]
 fn basic_positive_floor_rounding_v2() {
-    let test_duration = Duration::new(
-        FiniteF64(5.0),
-        FiniteF64(6.0),
-        FiniteF64(7.0),
-        FiniteF64(8.0),
-        FiniteF64(40.0),
-        FiniteF64(30.0),
-        FiniteF64(20.0),
-        FiniteF64(123.0),
-        FiniteF64(987.0),
-        FiniteF64(500.0),
-    )
-    .unwrap();
-    let forward_date = PlainDate::new(2020, 4, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
+    let test_duration = Duration::new(5, 6, 7, 8, 40, 30, 20, 123, 987, 500).unwrap();
+    let forward_date = PlainDate::new(2020, 4, 1, Calendar::default()).unwrap();
 
     let relative_forward = RelativeTo::PlainDate(forward_date);
 
@@ -99,21 +84,8 @@ fn basic_positive_floor_rounding_v2() {
 #[test]
 fn basic_negative_floor_rounding_v2() {
     // Test setup
-    let test_duration = Duration::new(
-        FiniteF64(5.0),
-        FiniteF64(6.0),
-        FiniteF64(7.0),
-        FiniteF64(8.0),
-        FiniteF64(40.0),
-        FiniteF64(30.0),
-        FiniteF64(20.0),
-        FiniteF64(123.0),
-        FiniteF64(987.0),
-        FiniteF64(500.0),
-    )
-    .unwrap();
-    let backward_date =
-        PlainDate::new(2020, 12, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
+    let test_duration = Duration::new(5, 6, 7, 8, 40, 30, 20, 123, 987, 500).unwrap();
+    let backward_date = PlainDate::new(2020, 12, 1, Calendar::default()).unwrap();
 
     let relative_backward = RelativeTo::PlainDate(backward_date);
 
@@ -168,19 +140,7 @@ fn basic_negative_floor_rounding_v2() {
 // roundingmode-ceil.js
 #[test]
 fn basic_positive_ceil_rounding() {
-    let test_duration = Duration::new(
-        FiniteF64(5.0),
-        FiniteF64(6.0),
-        FiniteF64(7.0),
-        FiniteF64(8.0),
-        FiniteF64(40.0),
-        FiniteF64(30.0),
-        FiniteF64(20.0),
-        FiniteF64(123.0),
-        FiniteF64(987.0),
-        FiniteF64(500.0),
-    )
-    .unwrap();
+    let test_duration = Duration::new(5, 6, 7, 8, 40, 30, 20, 123, 987, 500).unwrap();
     let forward_date = PlainDate::new(2020, 4, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
 
     let relative_forward = RelativeTo::PlainDate(forward_date);
@@ -235,19 +195,7 @@ fn basic_positive_ceil_rounding() {
 
 #[test]
 fn basic_negative_ceil_rounding() {
-    let test_duration = Duration::new(
-        FiniteF64(5.0),
-        FiniteF64(6.0),
-        FiniteF64(7.0),
-        FiniteF64(8.0),
-        FiniteF64(40.0),
-        FiniteF64(30.0),
-        FiniteF64(20.0),
-        FiniteF64(123.0),
-        FiniteF64(987.0),
-        FiniteF64(500.0),
-    )
-    .unwrap();
+    let test_duration = Duration::new(5, 6, 7, 8, 40, 30, 20, 123, 987, 500).unwrap();
     let backward_date =
         PlainDate::new(2020, 12, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
     let relative_backward = RelativeTo::PlainDate(backward_date);
@@ -303,19 +251,7 @@ fn basic_negative_ceil_rounding() {
 // roundingmode-expand.js
 #[test]
 fn basic_positive_expand_rounding() {
-    let test_duration = Duration::new(
-        FiniteF64(5.0),
-        FiniteF64(6.0),
-        FiniteF64(7.0),
-        FiniteF64(8.0),
-        FiniteF64(40.0),
-        FiniteF64(30.0),
-        FiniteF64(20.0),
-        FiniteF64(123.0),
-        FiniteF64(987.0),
-        FiniteF64(500.0),
-    )
-    .unwrap();
+    let test_duration = Duration::new(5, 6, 7, 8, 40, 30, 20, 123, 987, 500).unwrap();
     let forward_date = PlainDate::new(2020, 4, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
     let relative_forward = RelativeTo::PlainDate(forward_date);
 
@@ -369,19 +305,7 @@ fn basic_positive_expand_rounding() {
 
 #[test]
 fn basic_negative_expand_rounding() {
-    let test_duration = Duration::new(
-        FiniteF64(5.0),
-        FiniteF64(6.0),
-        FiniteF64(7.0),
-        FiniteF64(8.0),
-        FiniteF64(40.0),
-        FiniteF64(30.0),
-        FiniteF64(20.0),
-        FiniteF64(123.0),
-        FiniteF64(987.0),
-        FiniteF64(500.0),
-    )
-    .unwrap();
+    let test_duration = Duration::new(5, 6, 7, 8, 40, 30, 20, 123, 987, 500).unwrap();
 
     let backward_date =
         PlainDate::new(2020, 12, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
@@ -436,18 +360,63 @@ fn basic_negative_expand_rounding() {
     assert_eq!(&result, &[-5, -7, 0, -27, -16, -30, -20, -123, -987, -500],);
 }
 
+#[test]
+fn rounding_to_fractional_day_tests() {
+    let twenty_five_hours = Duration::from(TimeDuration::new(25, 0, 0, 0, 0, 0).unwrap());
+    let options = RoundingOptions {
+        largest_unit: Some(Unit::Day),
+        smallest_unit: None,
+        increment: None,
+        rounding_mode: Some(RoundingMode::Floor),
+    };
+    let result = twenty_five_hours.round(options, None).unwrap();
+    assert_eq!(result.fields(), [0, 0, 0, 1, 1, 0, 0, 0, 0, 0]);
+
+    let sixty_days = Duration::from(DateDuration::new_unchecked(0, 0, 0, 64));
+    let options = RoundingOptions {
+        largest_unit: None,
+        smallest_unit: Some(Unit::Day),
+        increment: Some(RoundingIncrement(NonZeroU32::new(5).unwrap())),
+        rounding_mode: Some(RoundingMode::Floor),
+    };
+    let result = sixty_days.round(options, None).unwrap();
+    assert_eq!(result.fields(), [0, 0, 0, 60, 0, 0, 0, 0, 0, 0]);
+
+    let sixty_days = Duration::from(DateDuration::new_unchecked(0, 0, 0, 64));
+    let options = RoundingOptions {
+        largest_unit: None,
+        smallest_unit: Some(Unit::Day),
+        increment: Some(RoundingIncrement(NonZeroU32::new(10).unwrap())),
+        rounding_mode: Some(RoundingMode::Floor),
+    };
+    let result = sixty_days.round(options, None).unwrap();
+    assert_eq!(result.fields(), [0, 0, 0, 60, 0, 0, 0, 0, 0, 0]);
+
+    let sixty_days = Duration::from(DateDuration::new_unchecked(0, 0, 0, 64));
+    let options = RoundingOptions {
+        largest_unit: None,
+        smallest_unit: Some(Unit::Day),
+        increment: Some(RoundingIncrement(NonZeroU32::new(10).unwrap())),
+        rounding_mode: Some(RoundingMode::Ceil),
+    };
+    let result = sixty_days.round(options, None).unwrap();
+    assert_eq!(result.fields(), [0, 0, 0, 70, 0, 0, 0, 0, 0, 0]);
+
+    let sixty_days = Duration::from(DateDuration::new_unchecked(0, 0, 0, 1000));
+    let options = RoundingOptions {
+        largest_unit: None,
+        smallest_unit: Some(Unit::Day),
+        increment: Some(RoundingIncrement(NonZeroU32::new(1_000_000_000).unwrap())),
+        rounding_mode: Some(RoundingMode::Expand),
+    };
+    let result = sixty_days.round(options, None).unwrap();
+    assert_eq!(result.fields(), [0, 0, 0, 1_000_000_000, 0, 0, 0, 0, 0, 0]);
+}
+
 // test262/test/built-ins/Temporal/Duration/prototype/round/roundingincrement-non-integer.js
 #[test]
 fn rounding_increment_non_integer() {
-    let test_duration = Duration::from(
-        DateDuration::new(
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64(1.0),
-        )
-        .unwrap(),
-    );
+    let test_duration = Duration::from(DateDuration::new(0, 0, 0, 1).unwrap());
     let binding = PlainDate::new(2000, 1, 1, Calendar::from_str("iso8601").unwrap()).unwrap();
     let relative_to = RelativeTo::PlainDate(binding);
 
@@ -465,157 +434,47 @@ fn rounding_increment_non_integer() {
         .round(options, Some(relative_to.clone()))
         .unwrap();
 
-    assert_eq!(
-        result.fields(),
-        &[
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64(2.0),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default()
-        ]
-    );
+    assert_eq!(result.fields(), [0, 0, 0, 2, 0, 0, 0, 0, 0, 0,]);
 
     let _ = options
         .increment
         .insert(RoundingIncrement::try_from(1e9 + 0.5).unwrap());
     let result = test_duration.round(options, Some(relative_to)).unwrap();
-    assert_eq!(
-        result.fields(),
-        &[
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64(1e9),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default()
-        ]
-    );
+    assert_eq!(result.fields(), [0, 0, 0, 1_000_000_000, 0, 0, 0, 0, 0, 0,]);
 }
 
 #[test]
 fn basic_add_duration() {
-    let base = Duration::new(
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64(1.0),
-        FiniteF64::default(),
-        FiniteF64(5.0),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-    )
-    .unwrap();
-    let other = Duration::new(
-        FiniteF64(0.0),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64(2.0),
-        FiniteF64::default(),
-        FiniteF64(5.0),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-    )
-    .unwrap();
+    let base = Duration::new(0, 0, 0, 1, 0, 5, 0, 0, 0, 0).unwrap();
+    let other = Duration::new(0, 0, 0, 2, 0, 5, 0, 0, 0, 0).unwrap();
     let result = base.add(&other).unwrap();
-    assert_eq!(result.days(), 3.0);
-    assert_eq!(result.minutes(), 10.0);
+    assert_eq!(result.days(), 3);
+    assert_eq!(result.minutes(), 10);
 
-    let other = Duration::new(
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64(-3.0),
-        FiniteF64::default(),
-        FiniteF64(-15.0),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-    )
-    .unwrap();
+    let other = Duration::new(0, 0, 0, -3, 0, -15, 0, 0, 0, 0).unwrap();
     let result = base.add(&other).unwrap();
-    assert_eq!(result.days(), -2.0);
-    assert_eq!(result.minutes(), -10.0);
+    assert_eq!(result.days(), -2);
+    assert_eq!(result.minutes(), -10);
 }
 
 #[test]
 fn basic_subtract_duration() {
-    let base = Duration::new(
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64(3.0),
-        FiniteF64::default(),
-        FiniteF64(15.0),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-    )
-    .unwrap();
-    let other = Duration::new(
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64(1.0),
-        FiniteF64::default(),
-        FiniteF64(5.0),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-    )
-    .unwrap();
+    let base = Duration::new(0, 0, 0, 3, 0, 15, 0, 0, 0, 0).unwrap();
+    let other = Duration::new(0, 0, 0, 1, 0, 5, 0, 0, 0, 0).unwrap();
     let result = base.subtract(&other).unwrap();
-    assert_eq!(result.days(), 2.0);
-    assert_eq!(result.minutes(), 10.0);
+    assert_eq!(result.days(), 2);
+    assert_eq!(result.minutes(), 10);
 
-    let other = Duration::new(
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64(-3.0),
-        FiniteF64::default(),
-        FiniteF64(-15.0),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-    )
-    .unwrap();
+    let other = Duration::new(0, 0, 0, -3, 0, -15, 0, 0, 0, 0).unwrap();
     let result = base.subtract(&other).unwrap();
-    assert_eq!(result.days(), 6.0);
-    assert_eq!(result.minutes(), 30.0);
+    assert_eq!(result.days(), 6);
+    assert_eq!(result.minutes(), 30);
 }
 
 // days-24-hours-relative-to-zoned-date-time.js
 #[test]
 fn round_relative_to_zoned_datetime() {
-    let duration = Duration::from(
-        TimeDuration::new(
-            25.into(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-        )
-        .unwrap(),
-    );
+    let duration = Duration::from(TimeDuration::new(25, 0, 0, 0, 0, 0).unwrap());
     let zdt = ZonedDateTime::try_new(
         1_000_000_000_000_000_000,
         Calendar::default(),
@@ -632,8 +491,8 @@ fn round_relative_to_zoned_datetime() {
         .round(options, Some(RelativeTo::ZonedDateTime(zdt)))
         .unwrap();
     // Result duration should be: (0, 0, 0, 1, 1, 0, 0, 0, 0, 0)
-    assert_eq!(result.days(), 1.0);
-    assert_eq!(result.hours(), 1.0);
+    assert_eq!(result.days(), 1);
+    assert_eq!(result.hours(), 1);
 }
 
 #[test]
@@ -641,22 +500,22 @@ fn test_duration_compare() {
     // TODO(#199): fix this on Windows
     if cfg!(not(windows)) {
         let one = Duration::from_partial_duration(PartialDuration {
-            hours: Some(FiniteF64::from(79)),
-            minutes: Some(FiniteF64::from(10)),
+            hours: Some(79),
+            minutes: Some(10),
             ..Default::default()
         })
         .unwrap();
         let two = Duration::from_partial_duration(PartialDuration {
-            days: Some(FiniteF64::from(3)),
-            hours: Some(FiniteF64::from(7)),
-            seconds: Some(FiniteF64::from(630)),
+            days: Some(3),
+            hours: Some(7),
+            seconds: Some(630),
             ..Default::default()
         })
         .unwrap();
         let three = Duration::from_partial_duration(PartialDuration {
-            days: Some(FiniteF64::from(3)),
-            hours: Some(FiniteF64::from(6)),
-            minutes: Some(FiniteF64::from(50)),
+            days: Some(3),
+            hours: Some(6),
+            minutes: Some(50),
             ..Default::default()
         })
         .unwrap();
@@ -688,8 +547,8 @@ fn test_duration_compare() {
 #[test]
 fn test_duration_total() {
     let d1 = Duration::from_partial_duration(PartialDuration {
-        hours: Some(FiniteF64::from(130)),
-        minutes: Some(FiniteF64::from(20)),
+        hours: Some(130),
+        minutes: Some(20),
         ..Default::default()
     })
     .unwrap();
@@ -701,7 +560,7 @@ fn test_duration_total() {
 
     // Find totals in months, with and without taking DST into account
     let d3 = Duration::from_partial_duration(PartialDuration {
-        hours: Some(FiniteF64::from(2756)),
+        hours: Some(2756),
         ..Default::default()
     })
     .unwrap();
@@ -733,9 +592,9 @@ fn test_duration_total() {
 fn balance_subseconds() {
     // Test positive
     let pos = Duration::from_partial_duration(PartialDuration {
-        milliseconds: Some(FiniteF64::from(999)),
-        microseconds: Some(FiniteF64::from(999999)),
-        nanoseconds: Some(FiniteF64::from(999999999)),
+        milliseconds: Some(999),
+        microseconds: Some(999999),
+        nanoseconds: Some(999999999),
         ..Default::default()
     })
     .unwrap();
@@ -743,9 +602,9 @@ fn balance_subseconds() {
 
     // Test negative
     let neg = Duration::from_partial_duration(PartialDuration {
-        milliseconds: Some(FiniteF64::from(-999)),
-        microseconds: Some(FiniteF64::from(-999999)),
-        nanoseconds: Some(FiniteF64::from(-999999999)),
+        milliseconds: Some(-999),
+        microseconds: Some(-999999),
+        nanoseconds: Some(-999999999),
         ..Default::default()
     })
     .unwrap();
@@ -757,8 +616,8 @@ fn balance_subseconds() {
 fn balance_days_up_to_both_years_and_months() {
     // Test positive
     let two_years = Duration::from_partial_duration(PartialDuration {
-        months: Some(FiniteF64::from(11)),
-        days: Some(FiniteF64::from(396)),
+        months: Some(11),
+        days: Some(396),
         ..Default::default()
     })
     .unwrap();
@@ -774,8 +633,8 @@ fn balance_days_up_to_both_years_and_months() {
 
     // Test negative
     let two_years_negative = Duration::from_partial_duration(PartialDuration {
-        months: Some(FiniteF64::from(-11)),
-        days: Some(FiniteF64::from(-396)),
+        months: Some(-11),
+        days: Some(-396),
         ..Default::default()
     })
     .unwrap();

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -337,7 +337,7 @@ impl Calendar {
                     duration.years(),
                     duration.months(),
                     duration.weeks(),
-                    duration.days().checked_add(&balance_days)?,
+                    duration.days().saturating_add(balance_days),
                 ),
                 overflow,
             )?;
@@ -954,22 +954,22 @@ mod tests {
             let second = IsoDate::new_unchecked(test.1 .0, test.1 .1, test.1 .2);
             let result = calendar.date_until(&first, &second, Unit::Year).unwrap();
             assert_eq!(
-                result.years().0 as i32,
+                result.years() as i32,
                 test.2 .0,
                 "year failed for test \"{test:?}\""
             );
             assert_eq!(
-                result.months().0 as i32,
+                result.months() as i32,
                 test.2 .1,
                 "months failed for test \"{test:?}\""
             );
             assert_eq!(
-                result.weeks().0 as i32,
+                result.weeks() as i32,
                 test.2 .2,
                 "weeks failed for test \"{test:?}\""
             );
             assert_eq!(
-                result.days().0 as i32,
+                result.days(),
                 test.2 .3,
                 "days failed for test \"{test:?}\""
             );

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -337,7 +337,10 @@ impl Calendar {
                     duration.years(),
                     duration.months(),
                     duration.weeks(),
-                    duration.days().saturating_add(balance_days),
+                    duration
+                        .days()
+                        .checked_add(balance_days)
+                        .ok_or(TemporalError::range())?,
                 ),
                 overflow,
             )?;

--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -231,9 +231,12 @@ impl PlainDate {
         //    duration.[[Nanoseconds]]).
         // 6. Let days be duration.[[Days]] + BalanceTimeDuration(norm,
         //    "day").[[Days]].
-        let days = duration.days().saturating_add(
-            TimeDuration::from_normalized(duration.time().to_normalized(), Unit::Day)?.0,
-        );
+        let days = duration
+            .days()
+            .checked_add(
+                TimeDuration::from_normalized(duration.time().to_normalized(), Unit::Day)?.0,
+            )
+            .ok_or(TemporalError::range())?;
 
         // 7. Let result be ? AddISODate(plainDate.[[ISOYear]], plainDate.[[ISOMonth]], plainDate.[[ISODay]], 0, 0, 0, days, overflow).
         let result = self

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -199,7 +199,6 @@ impl PlainDateTime {
         let diff = self
             .iso
             .diff(&other.iso, &self.calendar, options.largest_unit)?;
-
         // 4. If smallestUnit is nanosecond and roundingIncrement = 1, return diff.
         if options.smallest_unit == Unit::Nanosecond && options.increment.get() == 1 {
             return Ok(diff);
@@ -799,7 +798,6 @@ mod tests {
             ToStringRoundingOptions, Unit,
         },
         parsers::Precision,
-        primitive::FiniteF64,
         MonthCode, TemporalResult,
     };
 
@@ -1031,15 +1029,7 @@ mod tests {
 
         let result = pdt
             .add(
-                &Duration::from(
-                    DateDuration::new(
-                        FiniteF64::default(),
-                        FiniteF64(1.0),
-                        FiniteF64::default(),
-                        FiniteF64::default(),
-                    )
-                    .unwrap(),
-                ),
+                &Duration::from(DateDuration::new(0, 1, 0, 0).unwrap()),
                 None,
             )
             .unwrap();
@@ -1057,15 +1047,7 @@ mod tests {
 
         let result = pdt
             .subtract(
-                &Duration::from(
-                    DateDuration::new(
-                        FiniteF64::default(),
-                        FiniteF64(1.0),
-                        FiniteF64::default(),
-                        FiniteF64::default(),
-                    )
-                    .unwrap(),
-                ),
+                &Duration::from(DateDuration::new(0, 1, 0, 0).unwrap()),
                 None,
             )
             .unwrap();
@@ -1081,13 +1063,13 @@ mod tests {
             PlainDateTime::try_new(2019, 10, 29, 10, 46, 38, 271, 986, 102, Calendar::default())
                 .unwrap();
 
-        let result = dt.subtract(&Duration::hour(FiniteF64(12.0)), None).unwrap();
+        let result = dt.subtract(&Duration::hour(12), None).unwrap();
         assert_datetime(
             result,
             (2019, 10, tinystr!(4, "M10"), 28, 22, 46, 38, 271, 986, 102),
         );
 
-        let result = dt.add(&Duration::hour(FiniteF64(-12.0)), None).unwrap();
+        let result = dt.add(&Duration::hour(-12), None).unwrap();
         assert_datetime(
             result,
             (2019, 10, tinystr!(4, "M10"), 28, 22, 46, 38, 271, 986, 102),
@@ -1119,15 +1101,15 @@ mod tests {
         let settings = create_diff_setting(Unit::Hour, 3, RoundingMode::HalfExpand);
         let result = earlier.until(&later, settings).unwrap();
 
-        assert_eq!(result.days(), 973.0);
-        assert_eq!(result.hours(), 3.0);
+        assert_eq!(result.days(), 973);
+        assert_eq!(result.hours(), 3);
 
         let settings = create_diff_setting(Unit::Minute, 30, RoundingMode::HalfExpand);
         let result = earlier.until(&later, settings).unwrap();
 
-        assert_eq!(result.days(), 973.0);
-        assert_eq!(result.hours(), 4.0);
-        assert_eq!(result.minutes(), 30.0);
+        assert_eq!(result.days(), 973);
+        assert_eq!(result.hours(), 4);
+        assert_eq!(result.minutes(), 30);
     }
 
     #[test]
@@ -1142,15 +1124,15 @@ mod tests {
         let settings = create_diff_setting(Unit::Hour, 3, RoundingMode::HalfExpand);
         let result = later.since(&earlier, settings).unwrap();
 
-        assert_eq!(result.days(), 973.0);
-        assert_eq!(result.hours(), 3.0);
+        assert_eq!(result.days(), 973);
+        assert_eq!(result.hours(), 3);
 
         let settings = create_diff_setting(Unit::Minute, 30, RoundingMode::HalfExpand);
         let result = later.since(&earlier, settings).unwrap();
 
-        assert_eq!(result.days(), 973.0);
-        assert_eq!(result.hours(), 4.0);
-        assert_eq!(result.minutes(), 30.0);
+        assert_eq!(result.days(), 973);
+        assert_eq!(result.hours(), 4);
+        assert_eq!(result.minutes(), 30);
     }
 
     #[test]

--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -147,16 +147,16 @@ impl Duration {
     /// Returns the a `Vec` of the fields values.
     #[inline]
     #[must_use]
-    pub(crate) fn fields(&self) -> [i64; 10] {
+    pub(crate) fn fields_signum(&self) -> [i64; 10] {
         [
-            self.years(),
-            self.months(),
-            self.weeks(),
-            self.days(),
-            self.hours(),
-            self.minutes(),
-            self.seconds(),
-            self.milliseconds(),
+            self.years().signum(),
+            self.months().signum(),
+            self.weeks().signum(),
+            self.days().signum(),
+            self.hours().signum(),
+            self.minutes().signum(),
+            self.seconds().signum(),
+            self.milliseconds().signum(),
             self.microseconds().signum() as i64,
             self.nanoseconds().signum() as i64,
         ]
@@ -172,7 +172,7 @@ impl Duration {
     /// Returns the `Unit` corresponding to the largest non-zero field.
     #[inline]
     pub(crate) fn default_largest_unit(&self) -> Unit {
-        self.fields()
+        self.fields_signum()
             .iter()
             .enumerate()
             .find(|x| x.1 != &0)
@@ -414,7 +414,7 @@ impl Duration {
     #[inline]
     #[must_use]
     pub fn sign(&self) -> Sign {
-        duration_sign(&self.fields())
+        duration_sign(&self.fields_signum())
     }
 
     /// Returns whether the current `Duration` is zero.
@@ -935,15 +935,17 @@ pub(crate) fn is_valid_duration(
     // String manipulation will also give an exact result, since the multiplication is by a power of 10.
     // Seconds part
     // TODO: Fix the below parts after clarification around behavior.
-    let normalized_nanoseconds =
-        (days as i128 * NS_PER_DAY as i128) + (hours as i128) * 3_600_000_000_000 + minutes as i128 * 60_000_000_000 + seconds as i128 * 1_000_000_000;
+    let normalized_nanoseconds = (days as i128 * NS_PER_DAY as i128)
+        + (hours as i128) * 3_600_000_000_000
+        + minutes as i128 * 60_000_000_000
+        + seconds as i128 * 1_000_000_000;
     // Subseconds part
     let normalized_subseconds_parts =
         (milliseconds as i128 * 1_000_000) + (microseconds * 1_000) + nanoseconds;
 
-    let normalized_seconds = normalized_nanoseconds + normalized_subseconds_parts;
+    let total_normalized_seconds = normalized_nanoseconds + normalized_subseconds_parts;
     // 8. If abs(normalizedSeconds) ≥ 2**53, return false.
-    if normalized_seconds.abs() >= MAX_SAFE_NS_PRECISION  {
+    if total_normalized_seconds.abs() >= MAX_SAFE_NS_PRECISION {
         return false;
     }
 

--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -475,7 +475,11 @@ impl Duration {
         // Maximum amount of days in a valid duration: 104_249_991_374 * 2 < i64::MAX
         // 29. Let normResult be ? AddNormalizedTimeDuration(norm1, norm2).
         // 30. Set normResult to ? Add24HourDaysToNormalizedTimeDuration(normResult, d1 + d2).
-        let result = (norm_one + norm_two)?.add_days(self.days().saturating_add(other.days()))?;
+        let result = (norm_one + norm_two)?.add_days(
+            self.days()
+                .checked_add(other.days())
+                .ok_or(TemporalError::range())?,
+        )?;
 
         // 31. Let result be ? BalanceTimeDuration(normResult, largestUnit).
         let (result_days, result_time) = TimeDuration::from_normalized(result, largest_unit)?;
@@ -606,7 +610,9 @@ impl Duration {
                     self.years(),
                     self.months(),
                     self.weeks(),
-                    self.days().saturating_add(balanced_days),
+                    self.days()
+                        .checked_add(balanced_days)
+                        .ok_or(TemporalError::range())?,
                 )?;
                 // NOTE (remove): values are fine to this point.
                 // TODO: Should this be using AdjustDateDurationRecord?
@@ -732,7 +738,9 @@ impl Duration {
                     self.years(),
                     self.months(),
                     self.weeks(),
-                    self.days().saturating_add(balanced_days),
+                    self.days()
+                        .checked_add(balanced_days)
+                        .ok_or(TemporalError::range())?,
                 )?;
                 // e. Let targetDate be ? CalendarDateAdd(calendar, plainRelativeTo.[[ISODate]], dateDuration, constrain).
                 let target_date = plain_date.calendar().date_add(

--- a/src/builtins/core/duration/date.rs
+++ b/src/builtins/core/duration/date.rs
@@ -1,10 +1,11 @@
 //! Implementation of a `DateDuration`
 
 use crate::{
-    iso::iso_date_to_epoch_days, options::ArithmeticOverflow, primitive::FiniteF64, Duration,
-    PlainDate, Sign, TemporalError, TemporalResult,
+    iso::iso_date_to_epoch_days, options::ArithmeticOverflow, Duration, PlainDate, Sign,
+    TemporalError, TemporalResult,
 };
-use alloc::vec::Vec;
+
+use super::duration_sign;
 
 /// `DateDuration` represents the [date duration record][spec] of the `Duration.`
 ///
@@ -16,25 +17,20 @@ use alloc::vec::Vec;
 #[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd)]
 pub struct DateDuration {
     /// `DateDuration`'s internal year value.
-    pub years: FiniteF64,
+    pub years: i64,
     /// `DateDuration`'s internal month value.
-    pub months: FiniteF64,
+    pub months: i64,
     /// `DateDuration`'s internal week value.
-    pub weeks: FiniteF64,
+    pub weeks: i64,
     /// `DateDuration`'s internal day value.
-    pub days: FiniteF64,
+    pub days: i64,
 }
 
 impl DateDuration {
     /// Creates a new, non-validated `DateDuration`.
     #[inline]
     #[must_use]
-    pub(crate) const fn new_unchecked(
-        years: FiniteF64,
-        months: FiniteF64,
-        weeks: FiniteF64,
-        days: FiniteF64,
-    ) -> Self {
+    pub(crate) const fn new_unchecked(years: i64, months: i64, weeks: i64, days: i64) -> Self {
         Self {
             years,
             months,
@@ -46,33 +42,17 @@ impl DateDuration {
     /// Returns the iterator for `DateDuration`
     #[inline]
     #[must_use]
-    pub(crate) fn fields(&self) -> Vec<FiniteF64> {
-        Vec::from(&[self.years, self.months, self.weeks, self.days])
+    pub(crate) fn fields(&self) -> [i64; 4] {
+        [self.years, self.months, self.weeks, self.days]
     }
 }
 
 impl DateDuration {
     /// Creates a new `DateDuration` with provided values.
     #[inline]
-    pub fn new(
-        years: FiniteF64,
-        months: FiniteF64,
-        weeks: FiniteF64,
-        days: FiniteF64,
-    ) -> TemporalResult<Self> {
+    pub fn new(years: i64, months: i64, weeks: i64, days: i64) -> TemporalResult<Self> {
         let result = Self::new_unchecked(years, months, weeks, days);
-        if !super::is_valid_duration(
-            years,
-            months,
-            weeks,
-            days,
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-            FiniteF64::default(),
-        ) {
+        if !super::is_valid_duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0) {
             return Err(TemporalError::range().with_message("Invalid DateDuration."));
         }
         Ok(result)
@@ -83,10 +63,10 @@ impl DateDuration {
     #[must_use]
     pub fn negated(&self) -> Self {
         Self {
-            years: self.years.negate(),
-            months: self.months.negate(),
-            weeks: self.weeks.negate(),
-            days: self.days.negate(),
+            years: self.years.saturating_neg(),
+            months: self.months.saturating_neg(),
+            weeks: self.weeks.saturating_neg(),
+            days: self.days.saturating_neg(),
         }
     }
 
@@ -106,16 +86,16 @@ impl DateDuration {
     #[inline]
     #[must_use]
     pub fn sign(&self) -> Sign {
-        super::duration_sign(&self.fields())
+        duration_sign(self.fields().as_slice())
     }
 
     /// DateDurationDays
     pub(crate) fn days(&self, relative_to: &PlainDate) -> TemporalResult<i64> {
         // 1. Let yearsMonthsWeeksDuration be ! AdjustDateDurationRecord(dateDuration, 0).
-        let ymw_duration = self.adjust(FiniteF64(0.0), None, None)?;
+        let ymw_duration = self.adjust(0, None, None)?;
         // 2. If DateDurationSign(yearsMonthsWeeksDuration) = 0, return dateDuration.[[Days]].
         if ymw_duration.sign() == Sign::Zero {
-            return self.days.as_integer_if_integral();
+            return Ok(self.days);
         }
         // 3. Let later be ? CalendarDateAdd(plainRelativeTo.[[Calendar]], plainRelativeTo.[[ISODate]], yearsMonthsWeeksDuration, constrain).
         let later = relative_to.add(
@@ -140,15 +120,15 @@ impl DateDuration {
         // 6. Let yearsMonthsWeeksInDays be epochDays2 - epochDays1.
         let ymd_in_days = epoch_days_2 - epoch_days_1;
         // 7. Return dateDuration.[[Days]] + yearsMonthsWeeksInDays.
-        Ok(self.days.as_integer_if_integral::<i64>()? + i64::from(ymd_in_days))
+        Ok(self.days + i64::from(ymd_in_days))
     }
 
     /// AdjustDateDurationRecord
     pub(crate) fn adjust(
         &self,
-        days: FiniteF64,
-        weeks: Option<FiniteF64>,
-        months: Option<FiniteF64>,
+        days: i64,
+        weeks: Option<i64>,
+        months: Option<i64>,
     ) -> TemporalResult<Self> {
         // 1. If weeks is not present, set weeks to dateDuration.[[Weeks]].
         // 2. If months is not present, set months to dateDuration.[[Months]].

--- a/src/builtins/core/duration/date.rs
+++ b/src/builtins/core/duration/date.rs
@@ -120,7 +120,7 @@ impl DateDuration {
         // 6. Let yearsMonthsWeeksInDays be epochDays2 - epochDays1.
         let ymd_in_days = epoch_days_2 - epoch_days_1;
         // 7. Return dateDuration.[[Days]] + yearsMonthsWeeksInDays.
-        Ok(self.days + i64::from(ymd_in_days))
+        Ok(self.days + ymd_in_days)
     }
 
     /// AdjustDateDurationRecord

--- a/src/builtins/core/duration/normalized.rs
+++ b/src/builtins/core/duration/normalized.rs
@@ -47,8 +47,8 @@ impl NormalizedTimeDuration {
         nanoseconds += time.minutes as i128 * NANOSECONDS_PER_MINUTE;
         nanoseconds += time.seconds as i128 * 1_000_000_000;
         nanoseconds += time.milliseconds as i128 * 1_000_000;
-        nanoseconds += time.microseconds as i128 * 1_000;
-        nanoseconds += time.nanoseconds as i128;
+        nanoseconds += time.microseconds * 1_000;
+        nanoseconds += time.nanoseconds;
         // NOTE(nekevss): Is it worth returning a `RangeError` below.
         debug_assert!(nanoseconds.abs() <= MAX_TIME_DURATION);
         Self(nanoseconds)

--- a/src/builtins/core/duration/normalized.rs
+++ b/src/builtins/core/duration/normalized.rs
@@ -2,7 +2,7 @@
 
 use core::{num::NonZeroU128, ops::Add};
 
-use num_traits::{AsPrimitive, Euclid, FromPrimitive};
+use num_traits::AsPrimitive;
 
 use crate::{
     builtins::core::{timezone::TimeZone, PlainDate, PlainDateTime},
@@ -43,12 +43,12 @@ impl NormalizedTimeDuration {
     /// Equivalent: 7.5.20 NormalizeTimeDuration ( hours, minutes, seconds, milliseconds, microseconds, nanoseconds )
     pub(crate) fn from_time_duration(time: &TimeDuration) -> Self {
         // Note: Calculations must be done after casting to `i128` in order to preserve precision
-        let mut nanoseconds: i128 = time.hours.0 as i128 * NANOSECONDS_PER_HOUR;
-        nanoseconds += time.minutes.0 as i128 * NANOSECONDS_PER_MINUTE;
-        nanoseconds += time.seconds.0 as i128 * 1_000_000_000;
-        nanoseconds += time.milliseconds.0 as i128 * 1_000_000;
-        nanoseconds += time.microseconds.0 as i128 * 1_000;
-        nanoseconds += time.nanoseconds.0 as i128;
+        let mut nanoseconds: i128 = time.hours as i128 * NANOSECONDS_PER_HOUR;
+        nanoseconds += time.minutes as i128 * NANOSECONDS_PER_MINUTE;
+        nanoseconds += time.seconds as i128 * 1_000_000_000;
+        nanoseconds += time.milliseconds as i128 * 1_000_000;
+        nanoseconds += time.microseconds as i128 * 1_000;
+        nanoseconds += time.nanoseconds as i128;
         // NOTE(nekevss): Is it worth returning a `RangeError` below.
         debug_assert!(nanoseconds.abs() <= MAX_TIME_DURATION);
         Self(nanoseconds)
@@ -89,13 +89,6 @@ impl NormalizedTimeDuration {
         (self.0 / i128::from(divisor), self.0 % i128::from(divisor))
     }
 
-    // Returns the fractionalDays value represented by this `NormalizedTimeDuration`
-    pub(super) fn as_fractional_days(&self) -> f64 {
-        // TODO: Unit test to verify MaxNormalized is within a castable f64 range.
-        let (days, remainder) = self.0.div_rem_euclid(&NS_PER_DAY_128BIT);
-        days as f64 + (remainder as f64 / NS_PER_DAY as f64)
-    }
-
     /// Equivalent: 7.5.31 NormalizedTimeDurationSign ( d )
     #[inline]
     #[must_use]
@@ -132,69 +125,18 @@ impl NormalizedTimeDuration {
     }
 
     /// The equivalent of `RoundTimeDuration` abstract operation.
-    pub(crate) fn round(
-        &self,
-        days: FiniteF64,
-        options: ResolvedRoundingOptions,
-    ) -> TemporalResult<(NormalizedDurationRecord, Option<i128>)> {
-        // 1. Assert: IsCalendarUnit(unit) is false.
-        let (days, norm, total) = match options.smallest_unit {
-            // 2. If unit is "day", then
-            Unit::Day => {
-                // a. Let fractionalDays be days + DivideNormalizedTimeDuration(norm, nsPerDay).
-                let fractional_days = days.checked_add(&FiniteF64(self.as_fractional_days()))?;
-                // b. Set days to RoundNumberToIncrement(fractionalDays, increment, roundingMode).
-                let days = IncrementRounder::from_signed_num(
-                    fractional_days.0,
-                    options.increment.as_extended_increment(),
-                )?
-                .round(options.rounding_mode);
-                // c. Let total be fractionalDays.
-                // d. Set norm to ZeroTimeDuration().
-                (
-                    FiniteF64::try_from(days)?,
-                    NormalizedTimeDuration::default(),
-                    i128::from_f64(fractional_days.0),
-                )
-            }
-            // 3. Else,
-            Unit::Hour
-            | Unit::Minute
-            | Unit::Second
-            | Unit::Millisecond
-            | Unit::Microsecond
-            | Unit::Nanosecond => {
-                // a. Assert: The value in the "Category" column of the row of Table 22 whose "Singular" column contains unit, is time.
-                // b. Let divisor be the value in the "Length in Nanoseconds" column of the row of Table 22 whose "Singular" column contains unit.
-                let divisor = options.smallest_unit.as_nanoseconds().temporal_unwrap()?;
-                // c. Let total be DivideNormalizedTimeDuration(norm, divisor).
-                let total = self.divide(divisor as i64);
-                let non_zero_divisor = unsafe { NonZeroU128::new_unchecked(divisor.into()) };
-                // d. Set norm to ? RoundNormalizedTimeDurationToIncrement(norm, divisor × increment, roundingMode).
-                let norm = self.round_inner(
-                    non_zero_divisor
-                        .checked_mul(options.increment.as_extended_increment())
-                        .temporal_unwrap()?,
-                    options.rounding_mode,
-                )?;
-                (days, norm, Some(total))
-            }
-            _ => return Err(TemporalError::assert()),
-        };
-
-        // 4. Return the Record { [[NormalizedDuration]]: ? CreateNormalizedDurationRecord(0, 0, 0, days, norm), [[Total]]: total  }.
-        Ok((
-            NormalizedDurationRecord::new(
-                DateDuration::new(
-                    FiniteF64::default(),
-                    FiniteF64::default(),
-                    FiniteF64::default(),
-                    days,
-                )?,
-                norm,
-            )?,
-            total,
-        ))
+    pub(crate) fn round(&self, options: ResolvedRoundingOptions) -> TemporalResult<Self> {
+        // a. Assert: The value in the "Category" column of the row of Table 22 whose "Singular" column contains unit, is time.
+        // b. Let divisor be the value in the "Length in Nanoseconds" column of the row of Table 22 whose "Singular" column contains unit.
+        let divisor = options.smallest_unit.as_nanoseconds().temporal_unwrap()?;
+        // c. Let total be DivideNormalizedTimeDuration(norm, divisor).
+        let increment = options
+            .increment
+            .as_extended_increment()
+            .checked_mul(NonZeroU128::new(divisor.into()).expect("cannot fail"))
+            .temporal_unwrap()?;
+        // d. Set norm to ? RoundNormalizedTimeDurationToIncrement(norm, divisor × increment, roundingMode).
+        self.round_inner(increment, options.rounding_mode)
     }
 
     /// Equivalent: 7.5.31 TotalTimeDuration ( timeDuration, unit )
@@ -207,6 +149,19 @@ impl NormalizedTimeDuration {
         // The division can be implemented in C++ with the __float128 type if the compiler supports it, or with software emulation such as in the SoftFP library.
         // 3. Return timeDuration / divisor.
         DurationTotal::new(time_duration, unit_nanoseconds).to_fractional_total()
+    }
+
+    pub(crate) fn round_to_fractional_days(
+        &self,
+        increment: RoundingIncrement,
+        mode: RoundingMode,
+    ) -> TemporalResult<i64> {
+        let adjusted_increment = increment
+            .as_extended_increment()
+            .saturating_mul(NonZeroU128::new(NS_PER_DAY as u128).expect("cannot fail"));
+        let rounded =
+            IncrementRounder::<i128>::from_signed_num(self.0, adjusted_increment)?.round(mode);
+        Ok((rounded / NS_PER_DAY_128BIT) as i64)
     }
 
     /// Round the current `NormalizedTimeDuration`.
@@ -300,6 +255,20 @@ impl NormalizedDurationRecord {
         Ok(Self { date, norm })
     }
 
+    /// Equivalent of 7.5.6
+    pub(crate) fn from_duration_with_24_hour_days(duration: &Duration) -> TemporalResult<Self> {
+        // 1. Let timeDuration be TimeDurationFromComponents(duration.[[Hours]], duration.[[Minutes]],
+        // duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]]).
+        let normalized_time = NormalizedTimeDuration::from_time_duration(&duration.time);
+        // 2. Set timeDuration to ! Add24HourDaysToTimeDuration(timeDuration, duration.[[Days]]).
+        let normalized_time = normalized_time.add_days(duration.days())?;
+        // 3. Let dateDuration be ! CreateDateDurationRecord(duration.[[Years]], duration.[[Months]], duration.[[Weeks]], 0).
+        let date =
+            DateDuration::new_unchecked(duration.years(), duration.months(), duration.weeks(), 0);
+        // 4. Return CombineDateAndTimeDuration(dateDuration, timeDuration).
+        Self::new(date, normalized_time)
+    }
+
     pub(crate) fn from_date_duration(date: DateDuration) -> TemporalResult<Self> {
         Self::new(date, NormalizedTimeDuration::default())
     }
@@ -349,7 +318,7 @@ impl NormalizedDurationRecord {
             Unit::Year => {
                 // a. Let years be RoundNumberToIncrement(duration.[[Years]], increment, "trunc").
                 let years = IncrementRounder::from_signed_num(
-                    self.date().years.0,
+                    self.date().years,
                     options.increment.as_extended_increment(),
                 )?
                 .round(RoundingMode::Trunc);
@@ -364,16 +333,16 @@ impl NormalizedDurationRecord {
                     r1,
                     r2,
                     DateDuration::new(
-                        FiniteF64::try_from(r1)?,
-                        FiniteF64::default(),
-                        FiniteF64::default(),
-                        FiniteF64::default(),
+                        i64::try_from(r1).map_err(|_| TemporalError::range())?,
+                        0,
+                        0,
+                        0,
                     )?,
                     DateDuration::new(
-                        FiniteF64::try_from(r2)?,
-                        FiniteF64::default(),
-                        FiniteF64::default(),
-                        FiniteF64::default(),
+                        i64::try_from(r2).map_err(|_| TemporalError::range())?,
+                        0,
+                        0,
+                        0,
                     )?,
                 )
             }
@@ -381,7 +350,7 @@ impl NormalizedDurationRecord {
             Unit::Month => {
                 // a. Let months be RoundNumberToIncrement(duration.[[Months]], increment, "trunc").
                 let months = IncrementRounder::from_signed_num(
-                    self.date().months.0,
+                    self.date().months,
                     options.increment.as_extended_increment(),
                 )?
                 .round(RoundingMode::Trunc);
@@ -397,36 +366,47 @@ impl NormalizedDurationRecord {
                     r2,
                     DateDuration::new(
                         self.date().years,
-                        FiniteF64::try_from(r1)?,
-                        FiniteF64::default(),
-                        FiniteF64::default(),
+                        i64::try_from(r1).map_err(|_| TemporalError::range())?,
+                        0,
+                        0,
                     )?,
                     DateDuration::new(
                         self.date().years,
-                        FiniteF64::try_from(r2)?,
-                        FiniteF64::default(),
-                        FiniteF64::default(),
+                        i64::try_from(r2).map_err(|_| TemporalError::range())?,
+                        0,
+                        0,
                     )?,
                 )
             }
             // 3. Else if unit is "week", then
             Unit::Week => {
-                // TODO: Reconcile potential overflow on years as i32. `ValidateDuration` requires years, months, weeks to be abs(x) <= 2^32
+                // TODO: Reconcile potential overflow on years as i32. `ValidateDuration`
+                // requires years, months, weeks to be abs(x) <= 2^32.
+                //
+                // Do we even care? This needs tests, but even a truncated i32::MAX is still
+                // FAR TOO LARGE for adding to a duration and will throw at steps c-d. This
+                // is only really an issue, because we are trying to optimize out floating
+                // points, but it may really show that a Duration's max range is very very
+                // very big. Too big. To be tested and determined.
+                //
+                // Oh our range is +- 280_000? Let's add 3 BILLION to that. It won't overflow,
+                // right?
+
                 // a. Let isoResult1 be BalanceISODate(dateTime.[[Year]] + duration.[[Years]],
                 // dateTime.[[Month]] + duration.[[Months]], dateTime.[[Day]]).
-                let iso_one = IsoDate::balance(
-                    dt.iso_year() + self.date().years.as_date_value()?,
-                    i32::from(dt.iso_month()) + self.date().months.as_date_value()?,
-                    i32::from(dt.iso_day()),
-                );
+                let iso_one = IsoDate::try_balance(
+                    dt.iso_year() + self.date().years as i32,
+                    i32::from(dt.iso_month()) + self.date().months as i32,
+                    i64::from(dt.iso_day()),
+                )?;
 
                 // b. Let isoResult2 be BalanceISODate(dateTime.[[Year]] + duration.[[Years]], dateTime.[[Month]] +
                 // duration.[[Months]], dateTime.[[Day]] + duration.[[Days]]).
-                let iso_two = IsoDate::balance(
-                    dt.iso_year() + self.date().years.as_date_value()?,
-                    i32::from(dt.iso_month()) + self.date().months.as_date_value()?,
-                    i32::from(dt.iso_day()) + self.date().days.as_date_value()?,
-                );
+                let iso_two = IsoDate::try_balance(
+                    dt.iso_year() + self.date().years as i32,
+                    i32::from(dt.iso_month()) + self.date().months as i32,
+                    i64::from(dt.iso_day()) + self.date().days,
+                )?;
 
                 // c. Let weeksStart be ! CreateTemporalDate(isoResult1.[[Year]], isoResult1.[[Month]], isoResult1.[[Day]],
                 // calendarRec.[[Receiver]]).
@@ -449,11 +429,12 @@ impl NormalizedDurationRecord {
                 // e. Let untilOptions be OrdinaryObjectCreate(null).
                 // f. Perform ! CreateDataPropertyOrThrow(untilOptions, "largestUnit", "week").
                 // g. Let untilResult be ? DifferenceDate(calendarRec, weeksStart, weeksEnd, untilOptions).
+
                 let until_result = weeks_start.internal_diff_date(&weeks_end, Unit::Week)?;
 
                 // h. Let weeks be RoundNumberToIncrement(duration.[[Weeks]] + untilResult.[[Weeks]], increment, "trunc").
                 let weeks = IncrementRounder::from_signed_num(
-                    self.date().weeks.checked_add(&until_result.weeks())?.0,
+                    self.date().weeks + until_result.weeks(),
                     options.increment.as_extended_increment(),
                 )?
                 .round(RoundingMode::Trunc);
@@ -471,14 +452,14 @@ impl NormalizedDurationRecord {
                     DateDuration::new(
                         self.date().years,
                         self.date().months,
-                        FiniteF64::try_from(r1)?,
-                        FiniteF64::default(),
+                        i64::try_from(r1).map_err(|_| TemporalError::range())?,
+                        0,
                     )?,
                     DateDuration::new(
                         self.date().years,
                         self.date().months,
-                        FiniteF64::try_from(r2)?,
-                        FiniteF64::default(),
+                        i64::try_from(r2).map_err(|_| TemporalError::range())?,
+                        0,
                     )?,
                 )
             }
@@ -487,7 +468,7 @@ impl NormalizedDurationRecord {
                 // a. Assert: unit is "day".
                 // b. Let days be RoundNumberToIncrement(duration.[[Days]], increment, "trunc").
                 let days = IncrementRounder::from_signed_num(
-                    self.date().days.0,
+                    self.date().days,
                     options.increment.as_extended_increment(),
                 )?
                 .round(RoundingMode::Trunc);
@@ -505,13 +486,13 @@ impl NormalizedDurationRecord {
                         self.date().years,
                         self.date().months,
                         self.date().weeks,
-                        FiniteF64::try_from(r1)?,
+                        i64::try_from(r1).map_err(|_| TemporalError::range())?,
                     )?,
                     DateDuration::new(
                         self.date().years,
                         self.date().months,
                         self.date().weeks,
-                        FiniteF64::try_from(r2)?,
+                        i64::try_from(r2).map_err(|_| TemporalError::range())?,
                     )?,
                 )
             }
@@ -701,7 +682,7 @@ impl NormalizedDurationRecord {
             self.date.years,
             self.date.months,
             self.date.weeks,
-            self.date.days.checked_add(&day_delta.into())?,
+            self.date.days.saturating_add(day_delta.into()),
         )?;
         // 15. Let resultDuration be CombineDateAndTimeDuration(dateDuration, roundedTimeDuration).
         let normalized = NormalizedDurationRecord::new(date, rounded_time)?;
@@ -777,7 +758,7 @@ impl NormalizedDurationRecord {
                 self.date().years,
                 self.date().months,
                 self.date().weeks,
-                FiniteF64::try_from(days)?,
+                days as i64,
             )?,
             remainder,
         )?;
@@ -835,10 +816,10 @@ impl NormalizedDurationRecord {
                         duration
                             .date()
                             .years
-                            .checked_add(&FiniteF64::from(sign.as_sign_multiplier()))?,
-                        FiniteF64::default(),
-                        FiniteF64::default(),
-                        FiniteF64::default(),
+                            .saturating_add(sign.as_sign_multiplier().into()),
+                        0,
+                        0,
+                        0,
                     )?
                 }
                 // ii. Else if unit is "month", then
@@ -850,9 +831,9 @@ impl NormalizedDurationRecord {
                         duration
                             .date()
                             .months
-                            .checked_add(&FiniteF64::from(sign.as_sign_multiplier()))?,
-                        FiniteF64::default(),
-                        FiniteF64::default(),
+                            .saturating_add(sign.as_sign_multiplier().into()),
+                        0,
+                        0,
                     )?
                 }
                 // iii. Else if unit is "week", then
@@ -865,8 +846,8 @@ impl NormalizedDurationRecord {
                         duration
                             .date()
                             .weeks
-                            .checked_add(&FiniteF64::from(sign.as_sign_multiplier()))?,
-                        FiniteF64::default(),
+                            .saturating_add(sign.as_sign_multiplier().into()),
+                        0,
                     )?
                 }
                 // iv. Else,
@@ -881,7 +862,7 @@ impl NormalizedDurationRecord {
                         duration
                             .date()
                             .days
-                            .checked_add(&FiniteF64::from(sign.as_sign_multiplier()))?,
+                            .saturating_add(sign.as_sign_multiplier().into()),
                     )?
                 }
                 _ => unreachable!(),

--- a/src/builtins/core/duration/normalized.rs
+++ b/src/builtins/core/duration/normalized.rs
@@ -681,7 +681,10 @@ impl NormalizedDurationRecord {
             self.date.years,
             self.date.months,
             self.date.weeks,
-            self.date.days.saturating_add(day_delta.into()),
+            self.date
+                .days
+                .checked_add(day_delta.into())
+                .ok_or(TemporalError::range())?,
         )?;
         // 15. Let resultDuration be CombineDateAndTimeDuration(dateDuration, roundedTimeDuration).
         let normalized = NormalizedDurationRecord::new(date, rounded_time)?;
@@ -815,7 +818,8 @@ impl NormalizedDurationRecord {
                         duration
                             .date()
                             .years
-                            .saturating_add(sign.as_sign_multiplier().into()),
+                            .checked_add(sign.as_sign_multiplier().into())
+                            .ok_or(TemporalError::range())?,
                         0,
                         0,
                         0,
@@ -830,7 +834,8 @@ impl NormalizedDurationRecord {
                         duration
                             .date()
                             .months
-                            .saturating_add(sign.as_sign_multiplier().into()),
+                            .checked_add(sign.as_sign_multiplier().into())
+                            .ok_or(TemporalError::range())?,
                         0,
                         0,
                     )?
@@ -845,7 +850,8 @@ impl NormalizedDurationRecord {
                         duration
                             .date()
                             .weeks
-                            .saturating_add(sign.as_sign_multiplier().into()),
+                            .checked_add(sign.as_sign_multiplier().into())
+                            .ok_or(TemporalError::range())?,
                         0,
                     )?
                 }
@@ -861,7 +867,8 @@ impl NormalizedDurationRecord {
                         duration
                             .date()
                             .days
-                            .saturating_add(sign.as_sign_multiplier().into()),
+                            .checked_add(sign.as_sign_multiplier().into())
+                            .ok_or(TemporalError::range())?,
                     )?
                 }
                 _ => unreachable!(),

--- a/src/builtins/core/duration/normalized.rs
+++ b/src/builtins/core/duration/normalized.rs
@@ -64,7 +64,6 @@ impl NormalizedTimeDuration {
         Ok(Self(result))
     }
 
-    // NOTE: `days: f64` should be an integer -> `i64`.
     /// Equivalent: 7.5.23 Add24HourDaysToNormalizedTimeDuration ( d, days )
     /// Add24HourDaysToTimeDuration??
     pub(crate) fn add_days(&self, days: i64) -> TemporalResult<Self> {
@@ -389,8 +388,8 @@ impl NormalizedDurationRecord {
                 // points, but it may really show that a Duration's max range is very very
                 // very big. Too big. To be tested and determined.
                 //
-                // Oh our range is +- 280_000? Let's add 3 BILLION to that. It won't overflow,
-                // right?
+                // In other words, our year range is roughly +/- 280_000? Let's add 2^32 to
+                // that. It won't overflow, right?
 
                 // a. Let isoResult1 be BalanceISODate(dateTime.[[Year]] + duration.[[Years]],
                 // dateTime.[[Month]] + duration.[[Months]], dateTime.[[Day]]).

--- a/src/builtins/core/duration/tests.rs
+++ b/src/builtins/core/duration/tests.rs
@@ -1,9 +1,6 @@
 use core::str::FromStr;
 
-use crate::{
-    options::ToStringRoundingOptions, parsers::Precision, partial::PartialDuration,
-    primitive::FiniteF64,
-};
+use crate::{options::ToStringRoundingOptions, parsers::Precision, partial::PartialDuration};
 
 use super::Duration;
 
@@ -16,9 +13,9 @@ fn partial_duration_empty() {
 #[test]
 fn partial_duration_values() {
     let mut partial = PartialDuration::default();
-    let _ = partial.years.insert(FiniteF64(20.0));
+    let _ = partial.years.insert(20);
     let result = Duration::from_partial_duration(partial).unwrap();
-    assert_eq!(result.years(), 20.0);
+    assert_eq!(result.years(), 20);
 }
 
 #[test]
@@ -60,37 +57,13 @@ fn default_duration_string() {
 
 #[test]
 fn duration_to_string_auto_precision() {
-    let duration = Duration::new(
-        1.into(),
-        2.into(),
-        3.into(),
-        4.into(),
-        5.into(),
-        6.into(),
-        7.into(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-        FiniteF64::default(),
-    )
-    .unwrap();
+    let duration = Duration::new(1, 2, 3, 4, 5, 6, 7, 0, 0, 0).unwrap();
     let result = duration
         .as_temporal_string(ToStringRoundingOptions::default())
         .unwrap();
     assert_eq!(&result, "P1Y2M3W4DT5H6M7S");
 
-    let duration = Duration::new(
-        1.into(),
-        2.into(),
-        3.into(),
-        4.into(),
-        5.into(),
-        6.into(),
-        7.into(),
-        987.into(),
-        650.into(),
-        FiniteF64::default(),
-    )
-    .unwrap();
+    let duration = Duration::new(1, 2, 3, 4, 5, 6, 7, 987, 650, 0).unwrap();
     let result = duration
         .as_temporal_string(ToStringRoundingOptions::default())
         .unwrap();
@@ -113,16 +86,16 @@ fn empty_date_duration() {
 #[test]
 fn negative_fields_to_string() {
     let duration = Duration::from_partial_duration(PartialDuration {
-        years: Some(FiniteF64::from(-1)),
-        months: Some(FiniteF64::from(-1)),
-        weeks: Some(FiniteF64::from(-1)),
-        days: Some(FiniteF64::from(-1)),
-        hours: Some(FiniteF64::from(-1)),
-        minutes: Some(FiniteF64::from(-1)),
-        seconds: Some(FiniteF64::from(-1)),
-        milliseconds: Some(FiniteF64::from(-1)),
-        microseconds: Some(FiniteF64::from(-1)),
-        nanoseconds: Some(FiniteF64::from(-1)),
+        years: Some(-1),
+        months: Some(-1),
+        weeks: Some(-1),
+        days: Some(-1),
+        hours: Some(-1),
+        minutes: Some(-1),
+        seconds: Some(-1),
+        milliseconds: Some(-1),
+        microseconds: Some(-1),
+        nanoseconds: Some(-1),
     })
     .unwrap();
     let result = duration
@@ -131,7 +104,7 @@ fn negative_fields_to_string() {
     assert_eq!(&result, "-P1Y1M1W1DT1H1M1.001001001S");
 
     let duration = Duration::from_partial_duration(PartialDuration {
-        milliseconds: Some(FiniteF64::from(-250)),
+        milliseconds: Some(-250),
         ..Default::default()
     })
     .unwrap();
@@ -141,7 +114,7 @@ fn negative_fields_to_string() {
     assert_eq!(&result, "-PT0.25S");
 
     let duration = Duration::from_partial_duration(PartialDuration {
-        milliseconds: Some(FiniteF64::from(-3500)),
+        milliseconds: Some(-3500),
         ..Default::default()
     })
     .unwrap();
@@ -151,7 +124,7 @@ fn negative_fields_to_string() {
     assert_eq!(&result, "-PT3.5S");
 
     let duration = Duration::from_partial_duration(PartialDuration {
-        milliseconds: Some(FiniteF64::from(-3500)),
+        milliseconds: Some(-3500),
         ..Default::default()
     })
     .unwrap();
@@ -161,8 +134,8 @@ fn negative_fields_to_string() {
     assert_eq!(&result, "-PT3.5S");
 
     let duration = Duration::from_partial_duration(PartialDuration {
-        weeks: Some(FiniteF64::from(-1)),
-        days: Some(FiniteF64::from(-1)),
+        weeks: Some(-1),
+        days: Some(-1),
         ..Default::default()
     })
     .unwrap();
@@ -175,10 +148,10 @@ fn negative_fields_to_string() {
 
 #[test]
 fn preserve_precision_loss() {
-    const MAX_SAFE_INT: f64 = 9_007_199_254_740_991.0;
+    const MAX_SAFE_INT: i64 = 9_007_199_254_740_991;
     let duration = Duration::from_partial_duration(PartialDuration {
-        milliseconds: Some(FiniteF64::try_from(MAX_SAFE_INT).unwrap()),
-        microseconds: Some(FiniteF64::try_from(MAX_SAFE_INT).unwrap()),
+        milliseconds: Some(MAX_SAFE_INT),
+        microseconds: Some(MAX_SAFE_INT),
         ..Default::default()
     })
     .unwrap();
@@ -192,22 +165,22 @@ fn preserve_precision_loss() {
 #[test]
 fn duration_from_str() {
     let duration = Duration::from_str("PT0.999999999H").unwrap();
-    assert_eq!(duration.minutes(), FiniteF64(59.0));
-    assert_eq!(duration.seconds(), FiniteF64(59.0));
-    assert_eq!(duration.milliseconds(), FiniteF64(999.0));
-    assert_eq!(duration.microseconds(), FiniteF64(996.0));
-    assert_eq!(duration.nanoseconds(), FiniteF64(400.0));
+    assert_eq!(duration.minutes(), 59);
+    assert_eq!(duration.seconds(), 59);
+    assert_eq!(duration.milliseconds(), 999);
+    assert_eq!(duration.microseconds(), 996);
+    assert_eq!(duration.nanoseconds(), 400);
 
     let duration = Duration::from_str("PT0.000000011H").unwrap();
-    assert_eq!(duration.minutes(), FiniteF64(0.0));
-    assert_eq!(duration.seconds(), FiniteF64(0.0));
-    assert_eq!(duration.milliseconds(), FiniteF64(0.0));
-    assert_eq!(duration.microseconds(), FiniteF64(39.0));
-    assert_eq!(duration.nanoseconds(), FiniteF64(600.0));
+    assert_eq!(duration.minutes(), 0);
+    assert_eq!(duration.seconds(), 0);
+    assert_eq!(duration.milliseconds(), 0);
+    assert_eq!(duration.microseconds(), 39);
+    assert_eq!(duration.nanoseconds(), 600);
 
     let duration = Duration::from_str("PT0.999999999M").unwrap();
-    assert_eq!(duration.seconds(), FiniteF64(59.0));
-    assert_eq!(duration.milliseconds(), FiniteF64(999.0));
-    assert_eq!(duration.microseconds(), FiniteF64(999.0));
-    assert_eq!(duration.nanoseconds(), FiniteF64(940.0));
+    assert_eq!(duration.seconds(), 59);
+    assert_eq!(duration.milliseconds(), 999);
+    assert_eq!(duration.microseconds(), 999);
+    assert_eq!(duration.nanoseconds(), 940);
 }

--- a/src/builtins/core/duration/tests.rs
+++ b/src/builtins/core/duration/tests.rs
@@ -151,7 +151,7 @@ fn preserve_precision_loss() {
     const MAX_SAFE_INT: i64 = 9_007_199_254_740_991;
     let duration = Duration::from_partial_duration(PartialDuration {
         milliseconds: Some(MAX_SAFE_INT),
-        microseconds: Some(MAX_SAFE_INT),
+        microseconds: Some(MAX_SAFE_INT as i128),
         ..Default::default()
     })
     .unwrap();

--- a/src/builtins/core/duration/tests.rs
+++ b/src/builtins/core/duration/tests.rs
@@ -1,6 +1,11 @@
 use core::str::FromStr;
 
-use crate::{options::{RoundingOptions, ToStringRoundingOptions, Unit}, parsers::Precision, partial::PartialDuration, provider::NeverProvider};
+use crate::{
+    options::{RoundingOptions, ToStringRoundingOptions, Unit},
+    parsers::Precision,
+    partial::PartialDuration,
+    provider::NeverProvider,
+};
 
 use super::Duration;
 
@@ -185,33 +190,78 @@ fn duration_from_str() {
     assert_eq!(duration.nanoseconds(), 940);
 }
 
+// Temporal/Duration/max.js
 #[test]
 fn duration_max() {
     let cases = [
-        (Duration::new(0, 0, 0, 104249991374, 7, 36, 31, 999, 999, 999).unwrap(), "max days", 9007199254740991.999999999),
-        (Duration::new(0, 0, 0, 0, 2501999792983, 36, 31, 999, 999, 999).unwrap(), "max hours", 9007199254740991.999999999),
-        (Duration::new(0, 0, 0, 0, 0, 150119987579016, 31, 999, 999, 999).unwrap(), "max minutes", 9007199254740991.999999999),
-        (Duration::new(0, 0, 0, 0, 0, 0, 9007199254740991, 999, 999, 999).unwrap(), "max seconds", 9007199254740991.999999999),
-        (Duration::new(0, 0, 0, -104249991374, -7, -36, -31, -999, -999, -999).unwrap(), "min days", -9007199254740991.999999999),
-        (Duration::new(0, 0, 0, 0, -2501999792983, -36, -31, -999, -999, -999).unwrap(), "min hours", -9007199254740991.999999999),
-        (Duration::new(0, 0, 0, 0, 0, -150119987579016, -31, -999, -999, -999).unwrap(), "min minutes", -9007199254740991.999999999),
-        (Duration::new(0, 0, 0, 0, 0, 0, -9007199254740991, -999, -999, -999).unwrap(), "min seconds", -9007199254740991.999999999),
-      ];
+        (
+            Duration::new(0, 0, 0, 104249991374, 7, 36, 31, 999, 999, 999).unwrap(),
+            "max days",
+            9007199254740991.999999999,
+        ),
+        (
+            Duration::new(0, 0, 0, 0, 2501999792983, 36, 31, 999, 999, 999).unwrap(),
+            "max hours",
+            9007199254740991.999999999,
+        ),
+        (
+            Duration::new(0, 0, 0, 0, 0, 150119987579016, 31, 999, 999, 999).unwrap(),
+            "max minutes",
+            9007199254740991.999999999,
+        ),
+        (
+            Duration::new(0, 0, 0, 0, 0, 0, 9007199254740991, 999, 999, 999).unwrap(),
+            "max seconds",
+            9007199254740991.999999999,
+        ),
+        (
+            Duration::new(0, 0, 0, -104249991374, -7, -36, -31, -999, -999, -999).unwrap(),
+            "min days",
+            -9007199254740991.999999999,
+        ),
+        (
+            Duration::new(0, 0, 0, 0, -2501999792983, -36, -31, -999, -999, -999).unwrap(),
+            "min hours",
+            -9007199254740991.999999999,
+        ),
+        (
+            Duration::new(0, 0, 0, 0, 0, -150119987579016, -31, -999, -999, -999).unwrap(),
+            "min minutes",
+            -9007199254740991.999999999,
+        ),
+        (
+            Duration::new(0, 0, 0, 0, 0, 0, -9007199254740991, -999, -999, -999).unwrap(),
+            "min seconds",
+            -9007199254740991.999999999,
+        ),
+    ];
 
     for (duration, description, result) in cases {
-        assert_eq!(duration.total_with_provider(Unit::Second, None, &NeverProvider).unwrap().0, result, "{description}");
+        assert_eq!(
+            duration
+                .total_with_provider(Unit::Second, None, &NeverProvider)
+                .unwrap()
+                .0,
+            result,
+            "{description}"
+        );
     }
 }
 
 #[test]
 fn duration_round_negative() {
     let duration = Duration::new(0, 0, 0, 0, -60, 0, 0, 0, 0, 0).unwrap();
-    let result = duration.round_with_provider(RoundingOptions {
-        smallest_unit: Some(Unit::Day),
-        ..Default::default()
-    }, None, &NeverProvider).unwrap();
+    let result = duration
+        .round_with_provider(
+            RoundingOptions {
+                smallest_unit: Some(Unit::Day),
+                ..Default::default()
+            },
+            None,
+            &NeverProvider,
+        )
+        .unwrap();
     assert_eq!(result.days(), -3);
-
 }
 
 /*

--- a/src/builtins/core/duration/time.rs
+++ b/src/builtins/core/duration/time.rs
@@ -24,9 +24,9 @@ pub struct TimeDuration {
     /// `TimeDuration`'s internal millisecond value.
     pub milliseconds: i64,
     /// `TimeDuration`'s internal microsecond value.
-    pub microseconds: i64,
+    pub microseconds: i128,
     /// `TimeDuration`'s internal nanosecond value.
-    pub nanoseconds: i64,
+    pub nanoseconds: i128,
 }
 // ==== TimeDuration Private API ====
 
@@ -38,8 +38,8 @@ impl TimeDuration {
         minutes: i64,
         seconds: i64,
         milliseconds: i64,
-        microseconds: i64,
-        nanoseconds: i64,
+        microseconds: i128,
+        nanoseconds: i128,
     ) -> Self {
         Self {
             hours,
@@ -192,8 +192,8 @@ impl TimeDuration {
             minutes as i64 * sign,
             seconds as i64 * sign,
             milliseconds as i64 * sign,
-            microseconds as i64 * sign,
-            nanoseconds as i64 * sign,
+            microseconds * sign as i128,
+            nanoseconds * sign as i128,
         );
 
         if !is_valid_duration(
@@ -230,8 +230,8 @@ impl TimeDuration {
             self.minutes,
             self.seconds,
             self.milliseconds,
-            self.microseconds,
-            self.nanoseconds,
+            self.microseconds.signum() as i64,
+            self.nanoseconds.signum() as i64,
         ]
     }
 }
@@ -245,8 +245,8 @@ impl TimeDuration {
         minutes: i64,
         seconds: i64,
         milliseconds: i64,
-        microseconds: i64,
-        nanoseconds: i64,
+        microseconds: i128,
+        nanoseconds: i128,
     ) -> TemporalResult<Self> {
         let result = Self::new_unchecked(
             hours,

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -310,7 +310,7 @@ impl FromStr for Instant {
             ixdtf_record.time.second.clamp(0, 59).into(),
             millisecond.into(),
             microsecond.into(),
-            nanosecond as i64 - ns_offset,
+            i128::from(nanosecond) - i128::from(ns_offset),
         );
 
         let nanoseconds = balanced.as_nanoseconds()?;
@@ -431,19 +431,20 @@ mod tests {
             }
         };
 
-        let assert_time_duration = |td: &TimeDuration, expected: (i64, i64, i64, i64, i64, i64)| {
-            assert_eq!(
-                td,
-                &TimeDuration {
-                    hours: expected.0,
-                    minutes: expected.1,
-                    seconds: expected.2,
-                    milliseconds: expected.3,
-                    microseconds: expected.4,
-                    nanoseconds: expected.5,
-                }
-            )
-        };
+        let assert_time_duration =
+            |td: &TimeDuration, expected: (i64, i64, i64, i64, i128, i128)| {
+                assert_eq!(
+                    td,
+                    &TimeDuration {
+                        hours: expected.0,
+                        minutes: expected.1,
+                        seconds: expected.2,
+                        milliseconds: expected.3,
+                        microseconds: expected.4,
+                        nanoseconds: expected.5,
+                    }
+                )
+            };
 
         let earlier = Instant::try_new(
             217_178_610_123_456_789, /* 1976-11-18T15:23:30.123456789Z */
@@ -504,19 +505,20 @@ mod tests {
             }
         };
 
-        let assert_time_duration = |td: &TimeDuration, expected: (i64, i64, i64, i64, i64, i64)| {
-            assert_eq!(
-                td,
-                &TimeDuration {
-                    hours: expected.0,
-                    minutes: expected.1,
-                    seconds: expected.2,
-                    milliseconds: expected.3,
-                    microseconds: expected.4,
-                    nanoseconds: expected.5,
-                }
-            )
-        };
+        let assert_time_duration =
+            |td: &TimeDuration, expected: (i64, i64, i64, i64, i128, i128)| {
+                assert_eq!(
+                    td,
+                    &TimeDuration {
+                        hours: expected.0,
+                        minutes: expected.1,
+                        seconds: expected.2,
+                        milliseconds: expected.3,
+                        microseconds: expected.4,
+                        nanoseconds: expected.5,
+                    }
+                )
+            };
 
         let earlier = Instant::try_new(
             217_178_610_123_456_789, /* 1976-11-18T15:23:30.123456789Z */

--- a/src/builtins/core/now.rs
+++ b/src/builtins/core/now.rs
@@ -231,10 +231,10 @@ mod tests {
         let duration = now
             .until(&now_plus_5, DifferenceSettings::default())
             .unwrap();
-        assert!(duration.hours().is_zero());
-        assert!(duration.minutes().is_zero());
-        assert_eq!(duration.seconds().as_inner(), 5.0);
-        assert!(duration.milliseconds().is_zero());
+        assert_eq!(duration.hours(), 0);
+        assert_eq!(duration.minutes(), 0);
+        assert_eq!(duration.seconds(), 5);
+        assert_eq!(duration.milliseconds(), 0);
     }
 
     #[cfg(all(feature = "tzdb", feature = "sys", feature = "compiled_data"))]
@@ -251,14 +251,14 @@ mod tests {
 
         let diff = after.since(&before, DifferenceSettings::default()).unwrap();
 
-        let sleep_base = sleep as f64;
-        let tolerable_range = sleep_base..=sleep_base + 5.0;
+        let sleep_base = sleep as i64;
+        let tolerable_range = sleep_base..=sleep_base + 5;
 
         // We assert a tolerable range of sleep + 5 because std::thread::sleep
         // is only guaranteed to be >= the value to sleep. So to prevent sporadic
         // errors, we only assert a range.
-        assert!(tolerable_range.contains(&diff.seconds().as_inner()));
-        assert!(diff.hours().is_zero());
-        assert!(diff.minutes().is_zero());
+        assert!(tolerable_range.contains(&diff.seconds()));
+        assert_eq!(diff.hours(), 0);
+        assert_eq!(diff.minutes(), 0);
     }
 }

--- a/src/builtins/core/time.rs
+++ b/src/builtins/core/time.rs
@@ -8,12 +8,10 @@ use crate::{
         RoundingIncrement, RoundingMode, ToStringRoundingOptions, Unit, UnitGroup,
     },
     parsers::{parse_time, IxdtfStringBuilder},
-    primitive::FiniteF64,
     TemporalError, TemporalResult,
 };
 use alloc::string::String;
 use core::str::FromStr;
-use num_traits::AsPrimitive;
 
 use super::{duration::normalized::NormalizedTimeDuration, PlainDateTime};
 
@@ -108,7 +106,7 @@ impl PlainTime {
     }
 
     /// Specification equivalent to `AddTime`
-    pub(crate) fn add_normalized_time_duration(&self, norm: NormalizedTimeDuration) -> (i32, Self) {
+    pub(crate) fn add_normalized_time_duration(&self, norm: NormalizedTimeDuration) -> (i64, Self) {
         // 1. Set second to second + NormalizedTimeDurationSeconds(norm).
         let second = i64::from(self.second()) + norm.seconds();
         // 2. Set nanosecond to nanosecond + NormalizedTimeDurationSubseconds(norm).
@@ -131,24 +129,12 @@ impl PlainTime {
     /// Spec Equivalent: `AddDurationToOrSubtractDurationFromPlainTime`.
     pub(crate) fn add_to_time(&self, duration: &TimeDuration) -> TemporalResult<Self> {
         let (_, result) = IsoTime::balance(
-            FiniteF64::from(self.hour())
-                .checked_add(&duration.hours)?
-                .as_(),
-            FiniteF64::from(self.minute())
-                .checked_add(&duration.minutes)?
-                .as_(),
-            FiniteF64::from(self.second())
-                .checked_add(&duration.seconds)?
-                .as_(),
-            FiniteF64::from(self.millisecond())
-                .checked_add(&duration.milliseconds)?
-                .as_(),
-            FiniteF64::from(self.microsecond())
-                .checked_add(&duration.microseconds)?
-                .as_(),
-            FiniteF64::from(self.nanosecond())
-                .checked_add(&duration.nanoseconds)?
-                .as_(),
+            i64::from(self.hour()).saturating_add(duration.hours),
+            i64::from(self.minute()).saturating_add(duration.minutes),
+            i64::from(self.second()).saturating_add(duration.seconds),
+            i64::from(self.millisecond()).saturating_add(duration.milliseconds),
+            i64::from(self.microsecond()).saturating_add(duration.microseconds),
+            i64::from(self.nanosecond()).saturating_add(duration.nanoseconds),
         );
 
         // NOTE (nekevss): IsoTime::balance should never return an invalid `IsoTime`
@@ -187,9 +173,8 @@ impl PlainTime {
             || resolved.increment != RoundingIncrement::ONE
         {
             // a. Let roundRecord be ! RoundDuration(0, 0, 0, 0, norm, settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
-            let (round_record, _) = normalized_time.round(FiniteF64::default(), resolved)?;
             // b. Set norm to roundRecord.[[NormalizedDuration]].[[NormalizedTime]].
-            normalized_time = round_record.normalized_time_duration()
+            normalized_time = normalized_time.round(resolved)?;
         };
 
         // 7. Let result be BalanceTimeDuration(norm, settings.[[LargestUnit]]).
@@ -540,15 +525,11 @@ mod tests {
 
     fn assert_duration(
         result: Duration,
-        values: (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32),
+        values: (i64, i64, i64, i64, i64, i64, i64, i64, i64, i64),
     ) {
-        let fields = result
-            .fields()
-            .iter()
-            .map(|v| v.as_date_value().unwrap())
-            .collect::<alloc::vec::Vec<i32>>();
+        let fields = result.fields();
         assert_eq!(
-            fields,
+            &fields,
             &[
                 values.0, values.1, values.2, values.3, values.4, values.5, values.6, values.7,
                 values.8, values.9
@@ -654,18 +635,18 @@ mod tests {
                 .unwrap();
 
         let result = one.since(&two, DifferenceSettings::default()).unwrap();
-        assert_eq!(result.hours(), 1.0);
+        assert_eq!(result.hours(), 1);
 
         let result = two.since(&one, DifferenceSettings::default()).unwrap();
-        assert_eq!(result.hours(), -1.0);
+        assert_eq!(result.hours(), -1);
 
         let result = one.since(&three, DifferenceSettings::default()).unwrap();
-        assert_eq!(result.hours(), 1.0);
-        assert_eq!(result.minutes(), 53.0);
+        assert_eq!(result.hours(), 1);
+        assert_eq!(result.minutes(), 53);
 
         let result = three.since(&one, DifferenceSettings::default()).unwrap();
-        assert_eq!(result.hours(), -1.0);
-        assert_eq!(result.minutes(), -53.0);
+        assert_eq!(result.hours(), -1);
+        assert_eq!(result.minutes(), -53);
     }
 
     #[test]
@@ -681,18 +662,18 @@ mod tests {
                 .unwrap();
 
         let result = one.until(&two, DifferenceSettings::default()).unwrap();
-        assert_eq!(result.hours(), 1.0);
+        assert_eq!(result.hours(), 1);
 
         let result = two.until(&one, DifferenceSettings::default()).unwrap();
-        assert_eq!(result.hours(), -1.0);
+        assert_eq!(result.hours(), -1);
 
         let result = one.until(&three, DifferenceSettings::default()).unwrap();
-        assert_eq!(result.hours(), 1.0);
-        assert_eq!(result.minutes(), 37.0);
+        assert_eq!(result.hours(), 1);
+        assert_eq!(result.minutes(), 37);
 
         let result = three.until(&one, DifferenceSettings::default()).unwrap();
-        assert_eq!(result.hours(), -1.0);
-        assert_eq!(result.minutes(), -37.0);
+        assert_eq!(result.hours(), -1);
+        assert_eq!(result.minutes(), -37);
     }
 
     #[test]

--- a/src/builtins/core/time.rs
+++ b/src/builtins/core/time.rs
@@ -133,8 +133,8 @@ impl PlainTime {
             i64::from(self.minute()).saturating_add(duration.minutes),
             i64::from(self.second()).saturating_add(duration.seconds),
             i64::from(self.millisecond()).saturating_add(duration.milliseconds),
-            i64::from(self.microsecond()).saturating_add(duration.microseconds),
-            i64::from(self.nanosecond()).saturating_add(duration.nanoseconds),
+            i128::from(self.microsecond()).saturating_add(duration.microseconds),
+            i128::from(self.nanosecond()).saturating_add(duration.nanoseconds),
         );
 
         // NOTE (nekevss): IsoTime::balance should never return an invalid `IsoTime`

--- a/src/builtins/core/time.rs
+++ b/src/builtins/core/time.rs
@@ -525,15 +525,22 @@ mod tests {
 
     fn assert_duration(
         result: Duration,
-        values: (i64, i64, i64, i64, i64, i64, i64, i64, i64, i64),
+        values: (i64, i64, i64, i64, i64, i64, i64, i64, i128, i128),
     ) {
-        let fields = result.fields();
         assert_eq!(
-            &fields,
-            &[
-                values.0, values.1, values.2, values.3, values.4, values.5, values.6, values.7,
-                values.8, values.9
-            ]
+            (
+                result.years(),
+                result.months(),
+                result.weeks(),
+                result.days(),
+                result.hours(),
+                result.minutes(),
+                result.seconds(),
+                result.milliseconds(),
+                result.microseconds(),
+                result.nanoseconds()
+            ),
+            values
         )
     }
 

--- a/src/builtins/core/timezone.rs
+++ b/src/builtins/core/timezone.rs
@@ -324,11 +324,11 @@ impl TimeZone {
             // c. Let earlierDate be BalanceISODate(isoDateTime.[[ISODate]].[[Year]],
             // isoDateTime.[[ISODate]].[[Month]],
             // isoDateTime.[[ISODate]].[[Day]] + earlierTime.[[Days]]).
-            let earlier_date = IsoDate::balance(
+            let earlier_date = IsoDate::try_balance(
                 iso.date.year,
                 iso.date.month.into(),
-                i32::from(iso.date.day) + earlier_time.0,
-            );
+                i64::from(iso.date.day) + earlier_time.0,
+            )?;
 
             // d. Let earlierDateTime be
             // CombineISODateAndTimeRecord(earlierDate, earlierTime).
@@ -346,11 +346,11 @@ impl TimeZone {
         let later_time = iso.time.add(time_duration);
         // 20. Let laterDate be BalanceISODate(isoDateTime.[[ISODate]].[[Year]],
         // isoDateTime.[[ISODate]].[[Month]], isoDateTime.[[ISODate]].[[Day]] + laterTime.[[Days]]).
-        let later_date = IsoDate::balance(
+        let later_date = IsoDate::try_balance(
             iso.date.year,
             iso.date.month.into(),
-            i32::from(iso.date.day) + later_time.0,
-        );
+            i64::from(iso.date.day) + later_time.0,
+        )?;
         // 21. Let laterDateTime be CombineISODateAndTimeRecord(laterDate, laterTime).
         let later = IsoDateTime::new_unchecked(later_date, later_time.1);
         // 22. Set possibleEpochNs to ? GetPossibleEpochNanoseconds(timeZone, laterDateTime).

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -407,13 +407,13 @@ mod tests {
             let until = earlier.until(&later, settings).unwrap();
             let since = earlier.since(&later, settings).unwrap();
 
-            assert_eq!(until.days(), 0.0);
-            assert_eq!(until.months(), 0.0);
-            assert_eq!(until.years(), 0.0);
+            assert_eq!(until.days(), 0);
+            assert_eq!(until.months(), 0);
+            assert_eq!(until.years(), 0);
 
-            assert_eq!(since.days(), 0.0);
-            assert_eq!(since.months(), 0.0);
-            assert_eq!(since.years(), 0.0);
+            assert_eq!(since.days(), 0);
+            assert_eq!(since.months(), 0);
+            assert_eq!(since.years(), 0);
         }
 
         // One month apart
@@ -428,11 +428,11 @@ mod tests {
             let until = earlier.until(&later, settings).unwrap();
             let since = earlier.since(&later, settings).unwrap();
 
-            assert_eq!(until.months(), 1.0);
-            assert_eq!(until.years(), 0.0);
+            assert_eq!(until.months(), 1);
+            assert_eq!(until.years(), 0);
 
-            assert_eq!(since.months(), -1.0);
-            assert_eq!(since.years(), 0.0);
+            assert_eq!(since.months(), -1);
+            assert_eq!(since.years(), 0);
         }
 
         // Crossing year boundary
@@ -447,11 +447,11 @@ mod tests {
             let until = earlier.until(&later, settings).unwrap();
             let since = earlier.since(&later, settings).unwrap();
 
-            assert_eq!(until.months(), 3.0);
-            assert_eq!(until.years(), 0.0);
+            assert_eq!(until.months(), 3);
+            assert_eq!(until.years(), 0);
 
-            assert_eq!(since.months(), -3.0);
-            assert_eq!(since.years(), 0.0);
+            assert_eq!(since.months(), -3);
+            assert_eq!(since.years(), 0);
         }
 
         // One year and one month
@@ -466,13 +466,13 @@ mod tests {
             let until = earlier.until(&later, settings).unwrap();
             let since = earlier.since(&later, settings).unwrap();
 
-            assert_eq!(until.years(), 1.0);
-            assert_eq!(until.months(), 1.0);
-            assert_eq!(until.days(), 0.0);
+            assert_eq!(until.years(), 1);
+            assert_eq!(until.months(), 1);
+            assert_eq!(until.days(), 0);
 
-            assert_eq!(since.years(), -1.0);
-            assert_eq!(since.months(), -1.0);
-            assert_eq!(since.days(), 0.0);
+            assert_eq!(since.years(), -1);
+            assert_eq!(since.months(), -1);
+            assert_eq!(since.days(), 0);
         }
 
         // One year apart with unit = Year
@@ -487,11 +487,11 @@ mod tests {
             let until = earlier.until(&later, settings).unwrap();
             let since = earlier.since(&later, settings).unwrap();
 
-            assert_eq!(until.years(), 1.0);
-            assert_eq!(until.months(), 0.0);
+            assert_eq!(until.years(), 1);
+            assert_eq!(until.months(), 0);
 
-            assert_eq!(since.years(), -1.0);
-            assert_eq!(since.months(), 0.0);
+            assert_eq!(since.years(), -1);
+            assert_eq!(since.months(), 0);
         }
 
         // Large year gap
@@ -506,8 +506,8 @@ mod tests {
             let until = earlier.until(&later, settings).unwrap();
             let since = earlier.since(&later, settings).unwrap();
 
-            assert_eq!(until.years(), 1000.0);
-            assert_eq!(since.years(), -1000.0);
+            assert_eq!(until.years(), 1000);
+            assert_eq!(since.years(), -1000);
         }
 
         // Lower ISO limit
@@ -522,8 +522,8 @@ mod tests {
             let until = earlier.until(&later, settings).unwrap();
             let since = earlier.since(&later, settings).unwrap();
 
-            assert_eq!(until.years(), 1.0);
-            assert_eq!(since.years(), -1.0);
+            assert_eq!(until.years(), 1);
+            assert_eq!(since.years(), -1);
         }
     }
     #[test]
@@ -569,8 +569,8 @@ mod tests {
         };
 
         let diff = ym1.until(&ym2, settings).unwrap();
-        assert_eq!(diff.months(), 1.0);
-        assert_eq!(diff.years(), 2.0);
+        assert_eq!(diff.months(), 1);
+        assert_eq!(diff.years(), 2);
     }
     #[test]
     fn test_diff_with_smallest_unit_year() {
@@ -583,8 +583,8 @@ mod tests {
         };
 
         let diff = ym1.until(&ym2, settings).unwrap();
-        assert_eq!(diff.years(), 2.0); // Rounded to the nearest year
-        assert_eq!(diff.months(), 0.0); // Months are ignored
+        assert_eq!(diff.years(), 2); // Rounded to the nearest year
+        assert_eq!(diff.months(), 0); // Months are ignored
     }
 
     #[test]
@@ -633,8 +633,8 @@ mod tests {
         };
 
         let diff = ym1.until(&ym2, settings).unwrap();
-        assert_eq!(diff.months(), 1.0); // Exact difference in months
-        assert_eq!(diff.years(), 2.0); // Exact difference in years
+        assert_eq!(diff.months(), 1); // Exact difference in months
+        assert_eq!(diff.years(), 2); // Exact difference in years
     }
 
     #[test]

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -1129,7 +1129,7 @@ pub(crate) fn interpret_isodatetime_offset(
                 time.second.into(),
                 time.millisecond.into(),
                 time.microsecond.into(),
-                i64::from(time.nanosecond) - offset,
+                (i64::from(time.nanosecond) - offset).into(),
             );
 
             // b. Perform ? CheckISODaysRange(balanced.[[ISODate]]).

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -1229,7 +1229,6 @@ mod tests {
     use crate::{
         options::{DifferenceSettings, Disambiguation, OffsetDisambiguation, Unit},
         partial::{PartialDate, PartialTime, PartialZonedDateTime},
-        primitive::FiniteF64,
         time::EpochNanoseconds,
         tzdb::FsTzdbProvider,
         Calendar, MonthCode, TimeZone,
@@ -1356,16 +1355,15 @@ mod tests {
                 },
             )
             .unwrap();
-        let zero = FiniteF64::from(0);
-        assert_eq!(diff.years(), zero);
-        assert_eq!(diff.months(), zero);
-        assert_eq!(diff.weeks(), zero);
-        assert_eq!(diff.days(), zero);
-        assert_eq!(diff.hours(), zero);
-        assert_eq!(diff.minutes(), FiniteF64::from(30));
-        assert_eq!(diff.seconds(), zero);
-        assert_eq!(diff.milliseconds(), zero);
-        assert_eq!(diff.microseconds(), zero);
-        assert_eq!(diff.nanoseconds(), zero);
+        assert_eq!(diff.years(), 0);
+        assert_eq!(diff.months(), 0);
+        assert_eq!(diff.weeks(), 0);
+        assert_eq!(diff.days(), 0);
+        assert_eq!(diff.hours(), 0);
+        assert_eq!(diff.minutes(), 30);
+        assert_eq!(diff.seconds(), 0);
+        assert_eq!(diff.milliseconds(), 0);
+        assert_eq!(diff.microseconds(), 0);
+        assert_eq!(diff.nanoseconds(), 0);
     }
 }

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -170,7 +170,10 @@ impl IsoDateTime {
             date_duration.years,
             date_duration.months,
             date_duration.weeks,
-            date_duration.days.saturating_add(t_result.0),
+            date_duration
+                .days
+                .checked_add(t_result.0)
+                .ok_or(TemporalError::range())?,
         )?;
         let duration = Duration::from(date_duration);
 

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -72,13 +72,6 @@ impl FiniteF64 {
         }
     }
 
-    pub(crate) fn as_date_value(&self) -> TemporalResult<i32> {
-        if !(f64::from(i32::MIN)..=f64::from(i32::MAX)).contains(&self.0) {
-            return Err(TemporalError::range().with_message("number exceeds a valid date value."));
-        }
-        Ok(self.0 as i32)
-    }
-
     /// Returns an integer of type `T` if if value is integral
     pub fn as_integer_if_integral<T: PrimInt + AsPrimitive<f64>>(&self) -> TemporalResult<T>
     where

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -117,6 +117,28 @@ impl Roundable for f64 {
     }
 }
 
+impl Roundable for i64 {
+    fn is_exact(dividend: Self, divisor: Self) -> bool {
+        dividend.rem_euclid(divisor) == 0
+    }
+
+    fn compare_remainder(dividend: Self, divisor: Self) -> Option<Ordering> {
+        Some((dividend.abs() % divisor).cmp(&(divisor / 2)))
+    }
+
+    fn is_even_cardinal(dividend: Self, divisor: Self) -> bool {
+        Roundable::result_floor(dividend, divisor).rem_euclid(2) == 0
+    }
+
+    fn result_floor(dividend: Self, divisor: Self) -> u128 {
+        Roundable::quotient_abs(dividend, divisor) as u128
+    }
+
+    fn result_ceil(dividend: Self, divisor: Self) -> u128 {
+        Roundable::quotient_abs(dividend, divisor) as u128 + 1
+    }
+}
+
 /// Applies the unsigned rounding mode.
 fn apply_unsigned_rounding_mode<T: Roundable>(
     dividend: T,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,8 +19,8 @@ pub(crate) const MS_PER_MINUTE: i64 = 60_000;
 /// `EpochDaysToEpochMS`
 ///
 /// Functionally the same as Date's abstract operation `MakeDate`
-pub(crate) fn epoch_days_to_epoch_ms(day: i32, time: i64) -> i64 {
-    (day as i64 * MS_PER_DAY as i64) + time
+pub(crate) fn epoch_days_to_epoch_ms(day: i64, time: i64) -> i64 {
+    (day * MS_PER_DAY as i64) + time
 }
 
 /// 3.5.11 PadISOYear ( y )

--- a/temporal_capi/Cargo.toml
+++ b/temporal_capi/Cargo.toml
@@ -20,5 +20,6 @@ include = [
 [dependencies]
 diplomat = "0.10.0"
 diplomat-runtime = "0.10.0"
+num-traits.workspace = true
 temporal_rs = { workspace = true, default-features = false }
 icu_calendar = { version = "2.0.0-beta2", default-features = false }

--- a/temporal_capi/bindings/cpp/temporal_rs/DateDuration.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/DateDuration.d.hpp
@@ -28,7 +28,7 @@ namespace temporal_rs {
 class DateDuration {
 public:
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::DateDuration>, temporal_rs::TemporalError> new_(double years, double months, double weeks, double days);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::DateDuration>, temporal_rs::TemporalError> new_(int64_t years, int64_t months, int64_t weeks, int64_t days);
 
   inline std::unique_ptr<temporal_rs::DateDuration> abs() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/DateDuration.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/DateDuration.hpp
@@ -20,7 +20,7 @@ namespace capi {
     extern "C" {
     
     typedef struct temporal_rs_DateDuration_new_result {union {temporal_rs::capi::DateDuration* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_DateDuration_new_result;
-    temporal_rs_DateDuration_new_result temporal_rs_DateDuration_new(double years, double months, double weeks, double days);
+    temporal_rs_DateDuration_new_result temporal_rs_DateDuration_new(int64_t years, int64_t months, int64_t weeks, int64_t days);
     
     temporal_rs::capi::DateDuration* temporal_rs_DateDuration_abs(const temporal_rs::capi::DateDuration* self);
     
@@ -35,7 +35,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline diplomat::result<std::unique_ptr<temporal_rs::DateDuration>, temporal_rs::TemporalError> temporal_rs::DateDuration::new_(double years, double months, double weeks, double days) {
+inline diplomat::result<std::unique_ptr<temporal_rs::DateDuration>, temporal_rs::TemporalError> temporal_rs::DateDuration::new_(int64_t years, int64_t months, int64_t weeks, int64_t days) {
   auto result = temporal_rs::capi::temporal_rs_DateDuration_new(years,
     months,
     weeks,

--- a/temporal_capi/bindings/cpp/temporal_rs/Duration.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Duration.d.hpp
@@ -33,7 +33,7 @@ namespace temporal_rs {
 class Duration {
 public:
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> create(int64_t years, int64_t months, int64_t weeks, int64_t days, int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, int64_t microseconds, int64_t nanoseconds);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> create(int64_t years, int64_t months, int64_t weeks, int64_t days, int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, double microseconds, double nanoseconds);
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> from_day_and_time(int64_t day, const temporal_rs::TimeDuration& time);
 
@@ -61,9 +61,9 @@ public:
 
   inline int64_t milliseconds() const;
 
-  inline int64_t microseconds() const;
+  inline std::optional<double> microseconds() const;
 
-  inline int64_t nanoseconds() const;
+  inline std::optional<double> nanoseconds() const;
 
   inline temporal_rs::Sign sign() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/Duration.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Duration.d.hpp
@@ -33,9 +33,9 @@ namespace temporal_rs {
 class Duration {
 public:
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> create(double years, double months, double weeks, double days, double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> create(int64_t years, int64_t months, int64_t weeks, int64_t days, int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, int64_t microseconds, int64_t nanoseconds);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> from_day_and_time(double day, const temporal_rs::TimeDuration& time);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> from_day_and_time(int64_t day, const temporal_rs::TimeDuration& time);
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> from_partial_duration(temporal_rs::PartialDuration partial);
 
@@ -45,25 +45,25 @@ public:
 
   inline const temporal_rs::DateDuration& date() const;
 
-  inline double years() const;
+  inline int64_t years() const;
 
-  inline double months() const;
+  inline int64_t months() const;
 
-  inline double weeks() const;
+  inline int64_t weeks() const;
 
-  inline double days() const;
+  inline int64_t days() const;
 
-  inline double hours() const;
+  inline int64_t hours() const;
 
-  inline double minutes() const;
+  inline int64_t minutes() const;
 
-  inline double seconds() const;
+  inline int64_t seconds() const;
 
-  inline double milliseconds() const;
+  inline int64_t milliseconds() const;
 
-  inline double microseconds() const;
+  inline int64_t microseconds() const;
 
-  inline double nanoseconds() const;
+  inline int64_t nanoseconds() const;
 
   inline temporal_rs::Sign sign() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/Duration.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Duration.hpp
@@ -23,10 +23,10 @@ namespace capi {
     extern "C" {
     
     typedef struct temporal_rs_Duration_create_result {union {temporal_rs::capi::Duration* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Duration_create_result;
-    temporal_rs_Duration_create_result temporal_rs_Duration_create(double years, double months, double weeks, double days, double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds);
+    temporal_rs_Duration_create_result temporal_rs_Duration_create(int64_t years, int64_t months, int64_t weeks, int64_t days, int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, int64_t microseconds, int64_t nanoseconds);
     
     typedef struct temporal_rs_Duration_from_day_and_time_result {union {temporal_rs::capi::Duration* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Duration_from_day_and_time_result;
-    temporal_rs_Duration_from_day_and_time_result temporal_rs_Duration_from_day_and_time(double day, const temporal_rs::capi::TimeDuration* time);
+    temporal_rs_Duration_from_day_and_time_result temporal_rs_Duration_from_day_and_time(int64_t day, const temporal_rs::capi::TimeDuration* time);
     
     typedef struct temporal_rs_Duration_from_partial_duration_result {union {temporal_rs::capi::Duration* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Duration_from_partial_duration_result;
     temporal_rs_Duration_from_partial_duration_result temporal_rs_Duration_from_partial_duration(temporal_rs::capi::PartialDuration partial);
@@ -37,25 +37,25 @@ namespace capi {
     
     const temporal_rs::capi::DateDuration* temporal_rs_Duration_date(const temporal_rs::capi::Duration* self);
     
-    double temporal_rs_Duration_years(const temporal_rs::capi::Duration* self);
+    int64_t temporal_rs_Duration_years(const temporal_rs::capi::Duration* self);
     
-    double temporal_rs_Duration_months(const temporal_rs::capi::Duration* self);
+    int64_t temporal_rs_Duration_months(const temporal_rs::capi::Duration* self);
     
-    double temporal_rs_Duration_weeks(const temporal_rs::capi::Duration* self);
+    int64_t temporal_rs_Duration_weeks(const temporal_rs::capi::Duration* self);
     
-    double temporal_rs_Duration_days(const temporal_rs::capi::Duration* self);
+    int64_t temporal_rs_Duration_days(const temporal_rs::capi::Duration* self);
     
-    double temporal_rs_Duration_hours(const temporal_rs::capi::Duration* self);
+    int64_t temporal_rs_Duration_hours(const temporal_rs::capi::Duration* self);
     
-    double temporal_rs_Duration_minutes(const temporal_rs::capi::Duration* self);
+    int64_t temporal_rs_Duration_minutes(const temporal_rs::capi::Duration* self);
     
-    double temporal_rs_Duration_seconds(const temporal_rs::capi::Duration* self);
+    int64_t temporal_rs_Duration_seconds(const temporal_rs::capi::Duration* self);
     
-    double temporal_rs_Duration_milliseconds(const temporal_rs::capi::Duration* self);
+    int64_t temporal_rs_Duration_milliseconds(const temporal_rs::capi::Duration* self);
     
-    double temporal_rs_Duration_microseconds(const temporal_rs::capi::Duration* self);
+    int64_t temporal_rs_Duration_microseconds(const temporal_rs::capi::Duration* self);
     
-    double temporal_rs_Duration_nanoseconds(const temporal_rs::capi::Duration* self);
+    int64_t temporal_rs_Duration_nanoseconds(const temporal_rs::capi::Duration* self);
     
     temporal_rs::capi::Sign temporal_rs_Duration_sign(const temporal_rs::capi::Duration* self);
     
@@ -78,7 +78,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> temporal_rs::Duration::create(double years, double months, double weeks, double days, double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds) {
+inline diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> temporal_rs::Duration::create(int64_t years, int64_t months, int64_t weeks, int64_t days, int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, int64_t microseconds, int64_t nanoseconds) {
   auto result = temporal_rs::capi::temporal_rs_Duration_create(years,
     months,
     weeks,
@@ -92,7 +92,7 @@ inline diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::Tem
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::Duration>>(std::unique_ptr<temporal_rs::Duration>(temporal_rs::Duration::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> temporal_rs::Duration::from_day_and_time(double day, const temporal_rs::TimeDuration& time) {
+inline diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> temporal_rs::Duration::from_day_and_time(int64_t day, const temporal_rs::TimeDuration& time) {
   auto result = temporal_rs::capi::temporal_rs_Duration_from_day_and_time(day,
     time.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::Duration>>(std::unique_ptr<temporal_rs::Duration>(temporal_rs::Duration::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
@@ -118,52 +118,52 @@ inline const temporal_rs::DateDuration& temporal_rs::Duration::date() const {
   return *temporal_rs::DateDuration::FromFFI(result);
 }
 
-inline double temporal_rs::Duration::years() const {
+inline int64_t temporal_rs::Duration::years() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_years(this->AsFFI());
   return result;
 }
 
-inline double temporal_rs::Duration::months() const {
+inline int64_t temporal_rs::Duration::months() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_months(this->AsFFI());
   return result;
 }
 
-inline double temporal_rs::Duration::weeks() const {
+inline int64_t temporal_rs::Duration::weeks() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_weeks(this->AsFFI());
   return result;
 }
 
-inline double temporal_rs::Duration::days() const {
+inline int64_t temporal_rs::Duration::days() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_days(this->AsFFI());
   return result;
 }
 
-inline double temporal_rs::Duration::hours() const {
+inline int64_t temporal_rs::Duration::hours() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_hours(this->AsFFI());
   return result;
 }
 
-inline double temporal_rs::Duration::minutes() const {
+inline int64_t temporal_rs::Duration::minutes() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_minutes(this->AsFFI());
   return result;
 }
 
-inline double temporal_rs::Duration::seconds() const {
+inline int64_t temporal_rs::Duration::seconds() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_seconds(this->AsFFI());
   return result;
 }
 
-inline double temporal_rs::Duration::milliseconds() const {
+inline int64_t temporal_rs::Duration::milliseconds() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_milliseconds(this->AsFFI());
   return result;
 }
 
-inline double temporal_rs::Duration::microseconds() const {
+inline int64_t temporal_rs::Duration::microseconds() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_microseconds(this->AsFFI());
   return result;
 }
 
-inline double temporal_rs::Duration::nanoseconds() const {
+inline int64_t temporal_rs::Duration::nanoseconds() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_nanoseconds(this->AsFFI());
   return result;
 }

--- a/temporal_capi/bindings/cpp/temporal_rs/Duration.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Duration.hpp
@@ -23,7 +23,7 @@ namespace capi {
     extern "C" {
     
     typedef struct temporal_rs_Duration_create_result {union {temporal_rs::capi::Duration* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Duration_create_result;
-    temporal_rs_Duration_create_result temporal_rs_Duration_create(int64_t years, int64_t months, int64_t weeks, int64_t days, int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, int64_t microseconds, int64_t nanoseconds);
+    temporal_rs_Duration_create_result temporal_rs_Duration_create(int64_t years, int64_t months, int64_t weeks, int64_t days, int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, double microseconds, double nanoseconds);
     
     typedef struct temporal_rs_Duration_from_day_and_time_result {union {temporal_rs::capi::Duration* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Duration_from_day_and_time_result;
     temporal_rs_Duration_from_day_and_time_result temporal_rs_Duration_from_day_and_time(int64_t day, const temporal_rs::capi::TimeDuration* time);
@@ -53,9 +53,11 @@ namespace capi {
     
     int64_t temporal_rs_Duration_milliseconds(const temporal_rs::capi::Duration* self);
     
-    int64_t temporal_rs_Duration_microseconds(const temporal_rs::capi::Duration* self);
+    typedef struct temporal_rs_Duration_microseconds_result {union {double ok; }; bool is_ok;} temporal_rs_Duration_microseconds_result;
+    temporal_rs_Duration_microseconds_result temporal_rs_Duration_microseconds(const temporal_rs::capi::Duration* self);
     
-    int64_t temporal_rs_Duration_nanoseconds(const temporal_rs::capi::Duration* self);
+    typedef struct temporal_rs_Duration_nanoseconds_result {union {double ok; }; bool is_ok;} temporal_rs_Duration_nanoseconds_result;
+    temporal_rs_Duration_nanoseconds_result temporal_rs_Duration_nanoseconds(const temporal_rs::capi::Duration* self);
     
     temporal_rs::capi::Sign temporal_rs_Duration_sign(const temporal_rs::capi::Duration* self);
     
@@ -78,7 +80,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> temporal_rs::Duration::create(int64_t years, int64_t months, int64_t weeks, int64_t days, int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, int64_t microseconds, int64_t nanoseconds) {
+inline diplomat::result<std::unique_ptr<temporal_rs::Duration>, temporal_rs::TemporalError> temporal_rs::Duration::create(int64_t years, int64_t months, int64_t weeks, int64_t days, int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, double microseconds, double nanoseconds) {
   auto result = temporal_rs::capi::temporal_rs_Duration_create(years,
     months,
     weeks,
@@ -158,14 +160,14 @@ inline int64_t temporal_rs::Duration::milliseconds() const {
   return result;
 }
 
-inline int64_t temporal_rs::Duration::microseconds() const {
+inline std::optional<double> temporal_rs::Duration::microseconds() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_microseconds(this->AsFFI());
-  return result;
+  return result.is_ok ? std::optional<double>(result.ok) : std::nullopt;
 }
 
-inline int64_t temporal_rs::Duration::nanoseconds() const {
+inline std::optional<double> temporal_rs::Duration::nanoseconds() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_nanoseconds(this->AsFFI());
-  return result;
+  return result.is_ok ? std::optional<double>(result.ok) : std::nullopt;
 }
 
 inline temporal_rs::Sign temporal_rs::Duration::sign() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PartialDuration.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PartialDuration.d.hpp
@@ -22,8 +22,8 @@ namespace capi {
       diplomat::capi::OptionI64 minutes;
       diplomat::capi::OptionI64 seconds;
       diplomat::capi::OptionI64 milliseconds;
-      diplomat::capi::OptionI64 microseconds;
-      diplomat::capi::OptionI64 nanoseconds;
+      diplomat::capi::OptionF64 microseconds;
+      diplomat::capi::OptionF64 nanoseconds;
     };
     
     typedef struct PartialDuration_option {union { PartialDuration ok; }; bool is_ok; } PartialDuration_option;
@@ -41,8 +41,8 @@ struct PartialDuration {
   std::optional<int64_t> minutes;
   std::optional<int64_t> seconds;
   std::optional<int64_t> milliseconds;
-  std::optional<int64_t> microseconds;
-  std::optional<int64_t> nanoseconds;
+  std::optional<double> microseconds;
+  std::optional<double> nanoseconds;
 
   inline bool is_empty();
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PartialDuration.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PartialDuration.d.hpp
@@ -14,16 +14,16 @@
 namespace temporal_rs {
 namespace capi {
     struct PartialDuration {
-      diplomat::capi::OptionF64 years;
-      diplomat::capi::OptionF64 months;
-      diplomat::capi::OptionF64 weeks;
-      diplomat::capi::OptionF64 days;
-      diplomat::capi::OptionF64 hours;
-      diplomat::capi::OptionF64 minutes;
-      diplomat::capi::OptionF64 seconds;
-      diplomat::capi::OptionF64 milliseconds;
-      diplomat::capi::OptionF64 microseconds;
-      diplomat::capi::OptionF64 nanoseconds;
+      diplomat::capi::OptionI64 years;
+      diplomat::capi::OptionI64 months;
+      diplomat::capi::OptionI64 weeks;
+      diplomat::capi::OptionI64 days;
+      diplomat::capi::OptionI64 hours;
+      diplomat::capi::OptionI64 minutes;
+      diplomat::capi::OptionI64 seconds;
+      diplomat::capi::OptionI64 milliseconds;
+      diplomat::capi::OptionI64 microseconds;
+      diplomat::capi::OptionI64 nanoseconds;
     };
     
     typedef struct PartialDuration_option {union { PartialDuration ok; }; bool is_ok; } PartialDuration_option;
@@ -33,16 +33,16 @@ namespace capi {
 
 namespace temporal_rs {
 struct PartialDuration {
-  std::optional<double> years;
-  std::optional<double> months;
-  std::optional<double> weeks;
-  std::optional<double> days;
-  std::optional<double> hours;
-  std::optional<double> minutes;
-  std::optional<double> seconds;
-  std::optional<double> milliseconds;
-  std::optional<double> microseconds;
-  std::optional<double> nanoseconds;
+  std::optional<int64_t> years;
+  std::optional<int64_t> months;
+  std::optional<int64_t> weeks;
+  std::optional<int64_t> days;
+  std::optional<int64_t> hours;
+  std::optional<int64_t> minutes;
+  std::optional<int64_t> seconds;
+  std::optional<int64_t> milliseconds;
+  std::optional<int64_t> microseconds;
+  std::optional<int64_t> nanoseconds;
 
   inline bool is_empty();
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PartialDuration.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PartialDuration.hpp
@@ -32,16 +32,16 @@ inline bool temporal_rs::PartialDuration::is_empty() {
 
 inline temporal_rs::capi::PartialDuration temporal_rs::PartialDuration::AsFFI() const {
   return temporal_rs::capi::PartialDuration {
-    /* .years = */ years.has_value() ? (diplomat::capi::OptionF64{ { years.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
-    /* .months = */ months.has_value() ? (diplomat::capi::OptionF64{ { months.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
-    /* .weeks = */ weeks.has_value() ? (diplomat::capi::OptionF64{ { weeks.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
-    /* .days = */ days.has_value() ? (diplomat::capi::OptionF64{ { days.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
-    /* .hours = */ hours.has_value() ? (diplomat::capi::OptionF64{ { hours.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
-    /* .minutes = */ minutes.has_value() ? (diplomat::capi::OptionF64{ { minutes.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
-    /* .seconds = */ seconds.has_value() ? (diplomat::capi::OptionF64{ { seconds.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
-    /* .milliseconds = */ milliseconds.has_value() ? (diplomat::capi::OptionF64{ { milliseconds.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
-    /* .microseconds = */ microseconds.has_value() ? (diplomat::capi::OptionF64{ { microseconds.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
-    /* .nanoseconds = */ nanoseconds.has_value() ? (diplomat::capi::OptionF64{ { nanoseconds.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
+    /* .years = */ years.has_value() ? (diplomat::capi::OptionI64{ { years.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
+    /* .months = */ months.has_value() ? (diplomat::capi::OptionI64{ { months.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
+    /* .weeks = */ weeks.has_value() ? (diplomat::capi::OptionI64{ { weeks.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
+    /* .days = */ days.has_value() ? (diplomat::capi::OptionI64{ { days.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
+    /* .hours = */ hours.has_value() ? (diplomat::capi::OptionI64{ { hours.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
+    /* .minutes = */ minutes.has_value() ? (diplomat::capi::OptionI64{ { minutes.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
+    /* .seconds = */ seconds.has_value() ? (diplomat::capi::OptionI64{ { seconds.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
+    /* .milliseconds = */ milliseconds.has_value() ? (diplomat::capi::OptionI64{ { milliseconds.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
+    /* .microseconds = */ microseconds.has_value() ? (diplomat::capi::OptionI64{ { microseconds.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
+    /* .nanoseconds = */ nanoseconds.has_value() ? (diplomat::capi::OptionI64{ { nanoseconds.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
   };
 }
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PartialDuration.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PartialDuration.hpp
@@ -40,8 +40,8 @@ inline temporal_rs::capi::PartialDuration temporal_rs::PartialDuration::AsFFI() 
     /* .minutes = */ minutes.has_value() ? (diplomat::capi::OptionI64{ { minutes.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
     /* .seconds = */ seconds.has_value() ? (diplomat::capi::OptionI64{ { seconds.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
     /* .milliseconds = */ milliseconds.has_value() ? (diplomat::capi::OptionI64{ { milliseconds.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
-    /* .microseconds = */ microseconds.has_value() ? (diplomat::capi::OptionI64{ { microseconds.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
-    /* .nanoseconds = */ nanoseconds.has_value() ? (diplomat::capi::OptionI64{ { nanoseconds.value() }, true }) : (diplomat::capi::OptionI64{ {}, false }),
+    /* .microseconds = */ microseconds.has_value() ? (diplomat::capi::OptionF64{ { microseconds.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
+    /* .nanoseconds = */ nanoseconds.has_value() ? (diplomat::capi::OptionF64{ { nanoseconds.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
   };
 }
 

--- a/temporal_capi/bindings/cpp/temporal_rs/TimeDuration.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/TimeDuration.d.hpp
@@ -28,7 +28,7 @@ namespace temporal_rs {
 class TimeDuration {
 public:
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::TimeDuration>, temporal_rs::TemporalError> new_(int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, int64_t microseconds, int64_t nanoseconds);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::TimeDuration>, temporal_rs::TemporalError> new_(int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, double microseconds, double nanoseconds);
 
   inline std::unique_ptr<temporal_rs::TimeDuration> abs() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/TimeDuration.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/TimeDuration.d.hpp
@@ -28,7 +28,7 @@ namespace temporal_rs {
 class TimeDuration {
 public:
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::TimeDuration>, temporal_rs::TemporalError> new_(double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::TimeDuration>, temporal_rs::TemporalError> new_(int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, int64_t microseconds, int64_t nanoseconds);
 
   inline std::unique_ptr<temporal_rs::TimeDuration> abs() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/TimeDuration.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/TimeDuration.hpp
@@ -20,7 +20,7 @@ namespace capi {
     extern "C" {
     
     typedef struct temporal_rs_TimeDuration_new_result {union {temporal_rs::capi::TimeDuration* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeDuration_new_result;
-    temporal_rs_TimeDuration_new_result temporal_rs_TimeDuration_new(double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds);
+    temporal_rs_TimeDuration_new_result temporal_rs_TimeDuration_new(int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, int64_t microseconds, int64_t nanoseconds);
     
     temporal_rs::capi::TimeDuration* temporal_rs_TimeDuration_abs(const temporal_rs::capi::TimeDuration* self);
     
@@ -37,7 +37,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline diplomat::result<std::unique_ptr<temporal_rs::TimeDuration>, temporal_rs::TemporalError> temporal_rs::TimeDuration::new_(double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds) {
+inline diplomat::result<std::unique_ptr<temporal_rs::TimeDuration>, temporal_rs::TemporalError> temporal_rs::TimeDuration::new_(int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, int64_t microseconds, int64_t nanoseconds) {
   auto result = temporal_rs::capi::temporal_rs_TimeDuration_new(hours,
     minutes,
     seconds,

--- a/temporal_capi/bindings/cpp/temporal_rs/TimeDuration.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/TimeDuration.hpp
@@ -20,7 +20,7 @@ namespace capi {
     extern "C" {
     
     typedef struct temporal_rs_TimeDuration_new_result {union {temporal_rs::capi::TimeDuration* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeDuration_new_result;
-    temporal_rs_TimeDuration_new_result temporal_rs_TimeDuration_new(int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, int64_t microseconds, int64_t nanoseconds);
+    temporal_rs_TimeDuration_new_result temporal_rs_TimeDuration_new(int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, double microseconds, double nanoseconds);
     
     temporal_rs::capi::TimeDuration* temporal_rs_TimeDuration_abs(const temporal_rs::capi::TimeDuration* self);
     
@@ -37,7 +37,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline diplomat::result<std::unique_ptr<temporal_rs::TimeDuration>, temporal_rs::TemporalError> temporal_rs::TimeDuration::new_(int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, int64_t microseconds, int64_t nanoseconds) {
+inline diplomat::result<std::unique_ptr<temporal_rs::TimeDuration>, temporal_rs::TemporalError> temporal_rs::TimeDuration::new_(int64_t hours, int64_t minutes, int64_t seconds, int64_t milliseconds, double microseconds, double nanoseconds) {
   auto result = temporal_rs::capi::temporal_rs_TimeDuration_new(hours,
     minutes,
     seconds,

--- a/temporal_capi/src/duration.rs
+++ b/temporal_capi/src/duration.rs
@@ -19,16 +19,16 @@ pub mod ffi {
     pub struct DateDuration(pub(crate) temporal_rs::DateDuration);
 
     pub struct PartialDuration {
-        pub years: DiplomatOption<f64>,
-        pub months: DiplomatOption<f64>,
-        pub weeks: DiplomatOption<f64>,
-        pub days: DiplomatOption<f64>,
-        pub hours: DiplomatOption<f64>,
-        pub minutes: DiplomatOption<f64>,
-        pub seconds: DiplomatOption<f64>,
-        pub milliseconds: DiplomatOption<f64>,
-        pub microseconds: DiplomatOption<f64>,
-        pub nanoseconds: DiplomatOption<f64>,
+        pub years: DiplomatOption<i64>,
+        pub months: DiplomatOption<i64>,
+        pub weeks: DiplomatOption<i64>,
+        pub days: DiplomatOption<i64>,
+        pub hours: DiplomatOption<i64>,
+        pub minutes: DiplomatOption<i64>,
+        pub seconds: DiplomatOption<i64>,
+        pub milliseconds: DiplomatOption<i64>,
+        pub microseconds: DiplomatOption<i64>,
+        pub nanoseconds: DiplomatOption<i64>,
     }
 
     #[diplomat::enum_convert(temporal_rs::Sign)]
@@ -48,20 +48,20 @@ pub mod ffi {
 
     impl TimeDuration {
         pub fn new(
-            hours: f64,
-            minutes: f64,
-            seconds: f64,
-            milliseconds: f64,
-            microseconds: f64,
-            nanoseconds: f64,
+            hours: i64,
+            minutes: i64,
+            seconds: i64,
+            milliseconds: i64,
+            microseconds: i64,
+            nanoseconds: i64,
         ) -> Result<Box<Self>, TemporalError> {
             temporal_rs::TimeDuration::new(
-                hours.try_into()?,
-                minutes.try_into()?,
-                seconds.try_into()?,
-                milliseconds.try_into()?,
-                microseconds.try_into()?,
-                nanoseconds.try_into()?,
+                hours,
+                minutes,
+                seconds,
+                milliseconds,
+                microseconds,
+                nanoseconds,
             )
             .map(|x| Box::new(TimeDuration(x)))
             .map_err(Into::into)
@@ -84,19 +84,14 @@ pub mod ffi {
 
     impl DateDuration {
         pub fn new(
-            years: f64,
-            months: f64,
-            weeks: f64,
-            days: f64,
+            years: i64,
+            months: i64,
+            weeks: i64,
+            days: i64,
         ) -> Result<Box<Self>, TemporalError> {
-            temporal_rs::DateDuration::new(
-                years.try_into()?,
-                months.try_into()?,
-                weeks.try_into()?,
-                days.try_into()?,
-            )
-            .map(|x| Box::new(DateDuration(x)))
-            .map_err(Into::into)
+            temporal_rs::DateDuration::new(years, months, weeks, days)
+                .map(|x| Box::new(DateDuration(x)))
+                .map_err(Into::into)
         }
 
         pub fn abs(&self) -> Box<Self> {
@@ -112,39 +107,39 @@ pub mod ffi {
     }
     impl Duration {
         pub fn create(
-            years: f64,
-            months: f64,
-            weeks: f64,
-            days: f64,
-            hours: f64,
-            minutes: f64,
-            seconds: f64,
-            milliseconds: f64,
-            microseconds: f64,
-            nanoseconds: f64,
+            years: i64,
+            months: i64,
+            weeks: i64,
+            days: i64,
+            hours: i64,
+            minutes: i64,
+            seconds: i64,
+            milliseconds: i64,
+            microseconds: i64,
+            nanoseconds: i64,
         ) -> Result<Box<Self>, TemporalError> {
             temporal_rs::Duration::new(
-                years.try_into()?,
-                months.try_into()?,
-                weeks.try_into()?,
-                days.try_into()?,
-                hours.try_into()?,
-                minutes.try_into()?,
-                seconds.try_into()?,
-                milliseconds.try_into()?,
-                microseconds.try_into()?,
-                nanoseconds.try_into()?,
+                years,
+                months,
+                weeks,
+                days,
+                hours,
+                minutes,
+                seconds,
+                milliseconds,
+                microseconds,
+                nanoseconds,
             )
             .map(|x| Box::new(Duration(x)))
             .map_err(Into::into)
         }
 
         pub fn from_day_and_time(
-            day: f64,
+            day: i64,
             time: &TimeDuration,
         ) -> Result<Box<Self>, TemporalError> {
             Ok(Box::new(Duration(
-                temporal_rs::Duration::from_day_and_time(day.try_into()?, &time.0),
+                temporal_rs::Duration::from_day_and_time(day, &time.0),
             )))
         }
         pub fn from_partial_duration(partial: PartialDuration) -> Result<Box<Self>, TemporalError> {
@@ -167,35 +162,35 @@ pub mod ffi {
         // Diplomat plans to make this a hard error.
         // If needed, implement it as with_time_duration(&self, TimeDuration) -> Self
 
-        pub fn years(&self) -> f64 {
-            self.0.years().as_inner()
+        pub fn years(&self) -> i64 {
+            self.0.years()
         }
-        pub fn months(&self) -> f64 {
-            self.0.months().as_inner()
+        pub fn months(&self) -> i64 {
+            self.0.months()
         }
-        pub fn weeks(&self) -> f64 {
-            self.0.weeks().as_inner()
+        pub fn weeks(&self) -> i64 {
+            self.0.weeks()
         }
-        pub fn days(&self) -> f64 {
-            self.0.days().as_inner()
+        pub fn days(&self) -> i64 {
+            self.0.days()
         }
-        pub fn hours(&self) -> f64 {
-            self.0.hours().as_inner()
+        pub fn hours(&self) -> i64 {
+            self.0.hours()
         }
-        pub fn minutes(&self) -> f64 {
-            self.0.minutes().as_inner()
+        pub fn minutes(&self) -> i64 {
+            self.0.minutes()
         }
-        pub fn seconds(&self) -> f64 {
-            self.0.seconds().as_inner()
+        pub fn seconds(&self) -> i64 {
+            self.0.seconds()
         }
-        pub fn milliseconds(&self) -> f64 {
-            self.0.milliseconds().as_inner()
+        pub fn milliseconds(&self) -> i64 {
+            self.0.milliseconds()
         }
-        pub fn microseconds(&self) -> f64 {
-            self.0.microseconds().as_inner()
+        pub fn microseconds(&self) -> i64 {
+            self.0.microseconds()
         }
-        pub fn nanoseconds(&self) -> f64 {
-            self.0.nanoseconds().as_inner()
+        pub fn nanoseconds(&self) -> i64 {
+            self.0.nanoseconds()
         }
 
         pub fn sign(&self) -> Sign {
@@ -236,56 +231,16 @@ impl TryFrom<ffi::PartialDuration> for temporal_rs::partial::PartialDuration {
     type Error = TemporalError;
     fn try_from(other: ffi::PartialDuration) -> Result<Self, TemporalError> {
         Ok(Self {
-            years: other
-                .years
-                .into_option()
-                .map(TryFrom::try_from)
-                .transpose()?,
-            months: other
-                .months
-                .into_option()
-                .map(TryFrom::try_from)
-                .transpose()?,
-            weeks: other
-                .weeks
-                .into_option()
-                .map(TryFrom::try_from)
-                .transpose()?,
-            days: other
-                .days
-                .into_option()
-                .map(TryFrom::try_from)
-                .transpose()?,
-            hours: other
-                .hours
-                .into_option()
-                .map(TryFrom::try_from)
-                .transpose()?,
-            minutes: other
-                .minutes
-                .into_option()
-                .map(TryFrom::try_from)
-                .transpose()?,
-            seconds: other
-                .seconds
-                .into_option()
-                .map(TryFrom::try_from)
-                .transpose()?,
-            milliseconds: other
-                .milliseconds
-                .into_option()
-                .map(TryFrom::try_from)
-                .transpose()?,
-            microseconds: other
-                .microseconds
-                .into_option()
-                .map(TryFrom::try_from)
-                .transpose()?,
-            nanoseconds: other
-                .nanoseconds
-                .into_option()
-                .map(TryFrom::try_from)
-                .transpose()?,
+            years: other.years.into_option(),
+            months: other.months.into_option(),
+            weeks: other.weeks.into_option(),
+            days: other.days.into_option(),
+            hours: other.hours.into_option(),
+            minutes: other.minutes.into_option(),
+            seconds: other.seconds.into_option(),
+            milliseconds: other.milliseconds.into_option(),
+            microseconds: other.microseconds.into_option(),
+            nanoseconds: other.nanoseconds.into_option(),
         })
     }
 }

--- a/temporal_capi/src/duration.rs
+++ b/temporal_capi/src/duration.rs
@@ -27,8 +27,8 @@ pub mod ffi {
         pub minutes: DiplomatOption<i64>,
         pub seconds: DiplomatOption<i64>,
         pub milliseconds: DiplomatOption<i64>,
-        pub microseconds: DiplomatOption<i64>,
-        pub nanoseconds: DiplomatOption<i64>,
+        pub microseconds: DiplomatOption<i128>,
+        pub nanoseconds: DiplomatOption<i128>,
     }
 
     #[diplomat::enum_convert(temporal_rs::Sign)]
@@ -52,8 +52,8 @@ pub mod ffi {
             minutes: i64,
             seconds: i64,
             milliseconds: i64,
-            microseconds: i64,
-            nanoseconds: i64,
+            microseconds: i128,
+            nanoseconds: i128,
         ) -> Result<Box<Self>, TemporalError> {
             temporal_rs::TimeDuration::new(
                 hours,
@@ -115,8 +115,8 @@ pub mod ffi {
             minutes: i64,
             seconds: i64,
             milliseconds: i64,
-            microseconds: i64,
-            nanoseconds: i64,
+            microseconds: i128,
+            nanoseconds: i128,
         ) -> Result<Box<Self>, TemporalError> {
             temporal_rs::Duration::new(
                 years,
@@ -186,10 +186,10 @@ pub mod ffi {
         pub fn milliseconds(&self) -> i64 {
             self.0.milliseconds()
         }
-        pub fn microseconds(&self) -> i64 {
+        pub fn microseconds(&self) -> i128 {
             self.0.microseconds()
         }
-        pub fn nanoseconds(&self) -> i64 {
+        pub fn nanoseconds(&self) -> i128 {
             self.0.nanoseconds()
         }
 

--- a/temporal_capi/src/error.rs
+++ b/temporal_capi/src/error.rs
@@ -24,6 +24,12 @@ pub mod ffi {
                 kind: ErrorKind::Syntax,
             }
         }
+
+        pub(crate) fn range() -> Self {
+            TemporalError {
+                kind: ErrorKind::Range,
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This begins to address #189 and closes #250.

This completely updates the inner representation for `Duration`, migrating from `FiniteF64`s to `i64`. Due to the change there were also some fairly robust changes across the internals for `Duration`.

There were also some related updates made to some parts of rounding to bring it more in line with the specification and also calculate values without needing fractional values.