### PR TITLE
Make iana-time-zone optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ tinystr.workspace = true
 icu_calendar = { workspace = true, features = ["compiled_data"] }
 num-traits.workspace = true
 ixdtf = { workspace = true, features = ["duration"]}
-iana-time-zone.workspace = true
 writeable = "0.6.1"
 
 # log feature
@@ -71,12 +70,13 @@ combine = { workspace = true, optional = true }
 
 # System time feature
 web-time = { workspace = true, optional =  true }
+iana-time-zone = { workspace = true, optional =  true }
 
 [features]
 default = ["sys"]
 log = ["dep:log"]
 compiled_data = ["tzdb"]
-sys = ["std", "dep:web-time"]
+sys = ["std", "dep:web-time", "dep:iana-time-zone"]
 tzdb = ["dep:tzif", "std", "dep:jiff-tzdb", "dep:combine", "dep:temporal_provider"]
 std = []
 


### PR DESCRIPTION
This dependency should be optional behind the `sys` feature.