### PR TITLE
Bump to icu_calendar 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "calendrical_calculations"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97f73e95d668625c9b28a3072e6326773785a0cf807de9f3d632778438f3d38"
+checksum = "9f6df87e869fb08be61c7e97ced8e69ab802df1d8bc612ed67dba78c07fbc12c"
 dependencies = [
  "core_maths",
  "displaydoc",
@@ -422,13 +422,14 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "2.0.0-beta2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f664d19093224c9de27db5d1797b4105ae9545c0c540faf0d351884d1b24ca6"
+checksum = "ecdccbb1b3e5f9fb6fdd83053a93220dccbe770b063cf32fc1691bd9e8eec45f"
 dependencies = [
  "calendrical_calculations",
  "displaydoc",
  "icu_calendar_data",
+ "icu_locale",
  "icu_locale_core",
  "icu_provider",
  "tinystr",
@@ -438,19 +439,15 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar_data"
-version = "2.0.0-beta2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd70bb6c7a5d0d24c94fa18309118879bbde09052b18eec96fc75aa4c6dbf659"
-dependencies = [
- "icu_locale",
- "icu_provider_baked",
-]
+checksum = "7219c8639ab936713a87b571eed2bc2615aa9137e8af6eb221446ee5644acc18"
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0-beta2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63df3227b8f369b3f7cc4003f0bdd9ca0083b871e2672811f699d69b473cc174"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -461,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale"
-version = "2.0.0-beta2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa4c80f106c1cf0f1b66e0ae9806f603f1c2c41d004229af1b0c6cebe84c74a"
+checksum = "6ae5921528335e91da1b6c695dbf1ec37df5ac13faa3f91e5640be93aa2fbefd"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -477,12 +474,12 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0-beta2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b80161b66511e4eb415ef110c67ea8cab4400b749f9e30c8691fff1354934b6b"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
- "litemap",
+ "litemap 0.8.0",
  "tinystr",
  "writeable",
  "zerovec",
@@ -490,18 +487,15 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_data"
-version = "2.0.0-beta2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1adc94a0bde584f8751381c0427d763ef5068fd388d670fabf966569f01465"
-dependencies = [
- "icu_provider_baked",
-]
+checksum = "4fdef0c124749d06a743c69e938350816554eb63ac979166590e2b4ee4252765"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0-beta2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d462aad52985bb71e3140fcc44e54d816cf7f2c3f25cd9b090cc77a9798504"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -510,17 +504,6 @@ dependencies = [
  "writeable",
  "yoke",
  "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_baked"
-version = "2.0.0-beta2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2794f00ee1999495f4f1a1e35aee8f54fe7cfcbcf909ec05b60522377200aecb"
-dependencies = [
- "icu_provider",
- "writeable",
  "zerotrie",
  "zerovec",
 ]
@@ -604,6 +587,12 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
@@ -883,6 +872,7 @@ dependencies = [
  "core_maths",
  "iana-time-zone",
  "icu_calendar",
+ "icu_locale",
  "ixdtf",
  "jiff-tzdb",
  "log",
@@ -1224,7 +1214,7 @@ checksum = "8b7a6cf4865aac8394f19ad46e37f60b929c1ba5eed798b96a32820aa9392929"
 dependencies = [
  "databake",
  "displaydoc",
- "litemap",
+ "litemap 0.7.5",
  "serde",
  "zerovec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "diplomat",
  "diplomat-runtime",
  "icu_calendar",
+ "icu_locale",
  "num-traits",
  "temporal_rs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ timezone_provider = { version = "~0.0.6", path = "./provider" }
 
 # Dependencies
 tinystr = "0.8.1"
-icu_calendar = { version = "2.0.0-beta2", default-features = false }
+icu_calendar = { version = "2.0.0", default-features = false }
+icu_locale = "2.0.0"
 rustc-hash = "2.1.0"
 num-traits = { version = "0.2.19", default-features = false }
 ixdtf = "0.4.0"
@@ -55,6 +56,7 @@ exclude.workspace = true
 
 tinystr.workspace = true
 icu_calendar = { workspace = true, features = ["compiled_data"] }
+icu_locale.workspace = true
 num-traits.workspace = true
 ixdtf = { workspace = true, features = ["duration"]}
 iana-time-zone = { workspace = true, optional = true }

--- a/src/builtins/compiled/zoneddatetime.rs
+++ b/src/builtins/compiled/zoneddatetime.rs
@@ -202,7 +202,7 @@ impl ZonedDateTime {
     /// Returns the calendar week of year value.
     ///
     /// Enable with the `compiled_data` feature flag.
-    pub fn week_of_year(&self) -> TemporalResult<Option<u16>> {
+    pub fn week_of_year(&self) -> TemporalResult<Option<u8>> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -14,20 +14,22 @@ use crate::{
     TemporalError, TemporalResult,
 };
 use core::str::FromStr;
+use std::string::ToString;
 
-use icu_calendar::types::{Era as IcuEra, MonthCode as IcuMonthCode, MonthInfo, YearInfo};
 use icu_calendar::{
-    any_calendar::AnyDateInner,
     cal::{
-        Buddhist, Chinese, Coptic, Dangi, Ethiopian, EthiopianEraStyle, Hebrew, Indian,
-        IslamicCivil, IslamicObservational, IslamicTabular, IslamicUmmAlQura, Japanese,
-        JapaneseExtended, Persian, Roc,
+        Buddhist, Chinese, Coptic, Dangi, Ethiopian, EthiopianEraStyle, Hebrew, HijriSimulated,
+        HijriTabular, HijriUmmAlQura, Indian, Japanese, JapaneseExtended, Persian, Roc,
     },
-    types::{DayOfMonth, DayOfYearInfo},
-    week::{RelativeUnit, WeekCalculator},
-    AnyCalendar, AnyCalendarKind, Calendar as IcuCalendar, DateDuration as IcuDateDuration,
-    DateDurationUnit as IcuDateDurationUnit, Gregorian, Iso, Ref,
+    AnyCalendar, AnyCalendarKind, Calendar as IcuCalendar, Iso, Ref,
 };
+use icu_calendar::{
+    cal::{HijriTabularEpoch, HijriTabularLeapYears},
+    preferences::CalendarAlgorithm,
+    types::MonthCode as IcuMonthCode,
+    Gregorian,
+};
+use icu_locale::extensions::unicode::Value;
 use tinystr::{tinystr, TinyAsciiStr};
 
 use super::{PartialDate, ZonedDateTime};
@@ -40,12 +42,16 @@ pub use types::{MonthCode, ResolvedCalendarFields};
 
 use era::EraInfo;
 
+/// The core `Calendar` type for `temporal_rs`
+///
+/// A `Calendar` in `temporal_rs` can be any calendar that is currently
+/// supported by [`icu_calendar`].
 #[derive(Debug, Clone)]
 pub struct Calendar(Ref<'static, AnyCalendar>);
 
 impl Default for Calendar {
     fn default() -> Self {
-        Calendar::new(AnyCalendarKind::Iso)
+        Self::ISO
     }
 }
 
@@ -57,82 +63,11 @@ impl PartialEq for Calendar {
 
 impl Eq for Calendar {}
 
-impl IcuCalendar for Calendar {
-    type DateInner = AnyDateInner;
-
-    fn date_from_codes(
-        &self,
-        era: Option<icu_calendar::types::Era>,
-        year: i32,
-        month_code: icu_calendar::types::MonthCode,
-        day: u8,
-    ) -> Result<Self::DateInner, icu_calendar::DateError> {
-        self.0.date_from_codes(era, year, month_code, day)
-    }
-
-    fn date_from_iso(&self, iso: icu_calendar::Date<Iso>) -> Self::DateInner {
-        self.0.date_from_iso(iso)
-    }
-
-    fn date_to_iso(&self, date: &Self::DateInner) -> icu_calendar::Date<Iso> {
-        self.0.date_to_iso(date)
-    }
-
-    fn months_in_year(&self, date: &Self::DateInner) -> u8 {
-        self.0.months_in_year(date)
-    }
-
-    fn days_in_year(&self, date: &Self::DateInner) -> u16 {
-        self.0.days_in_year(date)
-    }
-
-    fn days_in_month(&self, date: &Self::DateInner) -> u8 {
-        self.0.days_in_month(date)
-    }
-
-    fn offset_date(&self, date: &mut Self::DateInner, offset: IcuDateDuration<Self>) {
-        self.0.offset_date(date, offset.cast_unit())
-    }
-
-    fn until(
-        &self,
-        date1: &Self::DateInner,
-        date2: &Self::DateInner,
-        calendar2: &Self,
-        largest_unit: IcuDateDurationUnit,
-        smallest_unit: IcuDateDurationUnit,
-    ) -> IcuDateDuration<Self> {
-        self.0
-            .until(date1, date2, &calendar2.0, largest_unit, smallest_unit)
-            .cast_unit()
-    }
-
-    fn debug_name(&self) -> &'static str {
-        self.0.debug_name()
-    }
-
-    fn year(&self, date: &Self::DateInner) -> YearInfo {
-        self.0.year(date)
-    }
-
-    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
-        self.0.is_in_leap_year(date)
-    }
-
-    fn month(&self, date: &Self::DateInner) -> MonthInfo {
-        self.0.month(date)
-    }
-
-    fn day_of_month(&self, date: &Self::DateInner) -> DayOfMonth {
-        self.0.day_of_month(date)
-    }
-
-    fn day_of_year_info(&self, date: &Self::DateInner) -> DayOfYearInfo {
-        self.0.day_of_year_info(date)
-    }
-}
-
 impl Calendar {
+    /// The ISO 8601 calendar
+    pub const ISO: Self = Self::new(AnyCalendarKind::Iso);
+
+    /// Create a `Calendar` from an ICU [`AnyCalendarKind`].
     #[warn(clippy::wildcard_enum_match_arm)] // Warns if the calendar kind gets out of sync.
     pub const fn new(kind: AnyCalendarKind) -> Self {
         let cal = match kind {
@@ -157,13 +92,27 @@ impl Calendar {
             AnyCalendarKind::Gregorian => &AnyCalendar::Gregorian(Gregorian),
             AnyCalendarKind::Hebrew => &AnyCalendar::Hebrew(Hebrew),
             AnyCalendarKind::Indian => &AnyCalendar::Indian(Indian),
-            AnyCalendarKind::IslamicCivil => &AnyCalendar::IslamicCivil(IslamicCivil),
-            AnyCalendarKind::IslamicObservational => {
-                const { &AnyCalendar::IslamicObservational(IslamicObservational::new()) }
+            AnyCalendarKind::HijriTabularTypeIIFriday => {
+                const {
+                    &AnyCalendar::HijriTabular(HijriTabular::new(
+                        HijriTabularLeapYears::TypeII,
+                        HijriTabularEpoch::Friday,
+                    ))
+                }
             }
-            AnyCalendarKind::IslamicTabular => &AnyCalendar::IslamicTabular(IslamicTabular),
-            AnyCalendarKind::IslamicUmmAlQura => {
-                const { &AnyCalendar::IslamicUmmAlQura(IslamicUmmAlQura::new()) }
+            AnyCalendarKind::HijriSimulatedMecca => {
+                const { &AnyCalendar::HijriSimulated(HijriSimulated::new_mecca()) }
+            }
+            AnyCalendarKind::HijriTabularTypeIIThursday => {
+                const {
+                    &AnyCalendar::HijriTabular(HijriTabular::new(
+                        HijriTabularLeapYears::TypeII,
+                        HijriTabularEpoch::Thursday,
+                    ))
+                }
+            }
+            AnyCalendarKind::HijriUmmAlQura => {
+                const { &AnyCalendar::HijriUmmAlQura(HijriUmmAlQura::new()) }
             }
             AnyCalendarKind::Iso => &AnyCalendar::Iso(Iso),
             AnyCalendarKind::Japanese => const { &AnyCalendar::Japanese(Japanese::new()) },
@@ -179,18 +128,31 @@ impl Calendar {
         Self(Ref(cal))
     }
 
-    /// Returns a `Calendar`` from the a slice of UTF-8 encoded bytes.
-    pub fn from_utf8(bytes: &[u8]) -> TemporalResult<Self> {
-        // NOTE(nekesss): Catch the iso identifier here, as `iso8601` is not a valid ID below.
-        if bytes.to_ascii_lowercase() == "iso8601".as_bytes() {
-            return Ok(Self::default());
-        }
-
-        let Some(cal) = AnyCalendarKind::get_for_bcp47_bytes(&bytes.to_ascii_lowercase()) else {
-            return Err(TemporalError::range().with_message("Not a builtin calendar."));
+    /// Create a `Calendar` from an ICU [`CalendarAlgorithm`].
+    pub fn try_from_calendar_algorithm(algorithm: CalendarAlgorithm) -> TemporalResult<Self> {
+        let calendar_kind = match AnyCalendarKind::try_from(algorithm) {
+            Ok(c) => c,
+            // Handle `islamic` calendar idenitifier.
+            //
+            // This should be updated depending on `icu_calendar` support and
+            // intl-era-monthcode.
+            Err(()) if algorithm == CalendarAlgorithm::Hijri(None) => {
+                AnyCalendarKind::HijriTabularTypeIIFriday
+            }
+            Err(()) => return Err(TemporalError::range().with_message("unknown calendar")),
         };
+        Ok(Calendar::new(calendar_kind))
+    }
 
-        Ok(Calendar::new(cal))
+    /// Returns a `Calendar` from the a slice of UTF-8 encoded bytes.
+    pub fn try_from_utf8(bytes: &[u8]) -> TemporalResult<Self> {
+        // TODO: Determine the best way to handle "julian" here.
+        // Not supported by `CalendarAlgorithm`
+        let icu_locale_value = Value::try_from_utf8(&bytes.to_ascii_lowercase())
+            .map_err(|e| TemporalError::general(e.to_string()))?;
+        let algorithm = CalendarAlgorithm::try_from(&icu_locale_value)
+            .map_err(|e| TemporalError::general(e.to_string()))?;
+        Self::try_from_calendar_algorithm(algorithm)
     }
 }
 
@@ -200,9 +162,9 @@ impl FromStr for Calendar {
     // 13.34 ParseTemporalCalendarString ( string )
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match parse_allowed_calendar_formats(s) {
-            Some([]) => Ok(Calendar::default()),
-            Some(result) => Calendar::from_utf8(result),
-            None => Calendar::from_utf8(s.as_bytes()),
+            Some([]) => Ok(Calendar::ISO),
+            Some(result) => Calendar::try_from_utf8(result),
+            None => Calendar::try_from_utf8(s.as_bytes()),
         }
     }
 }
@@ -238,18 +200,18 @@ impl Calendar {
 
         let calendar_date = self
             .0
-            .date_from_codes(
-                Some(IcuEra(resolved_fields.era_year.era.0)),
+            .from_codes(
+                Some(resolved_fields.era_year.era.0.as_str()),
                 resolved_fields.era_year.year,
                 IcuMonthCode(resolved_fields.month_code.0),
                 resolved_fields.day,
             )
             .map_err(TemporalError::from_icu4x)?;
-        let iso = self.0.date_to_iso(&calendar_date);
+        let iso = self.0.to_iso(&calendar_date);
         PlainDate::new_with_overflow(
-            iso.year().extended_year,
-            iso.month().ordinal,
-            iso.day_of_month().0,
+            Iso.extended_year(&iso),
+            Iso.month(&iso).ordinal,
+            Iso.day_of_month(&iso).0,
             self.clone(),
             overflow,
         )
@@ -299,18 +261,18 @@ impl Calendar {
         // NOTE: This might preemptively throw as `ICU4X` does not support regulating.
         let calendar_date = self
             .0
-            .date_from_codes(
-                Some(IcuEra(resolved_fields.era_year.era.0)),
+            .from_codes(
+                Some(resolved_fields.era_year.era.0.as_str()),
                 resolved_fields.era_year.year,
                 IcuMonthCode(resolved_fields.month_code.0),
                 resolved_fields.day,
             )
             .map_err(TemporalError::from_icu4x)?;
-        let iso = self.0.date_to_iso(&calendar_date);
+        let iso = self.0.to_iso(&calendar_date);
         PlainYearMonth::new_with_overflow(
-            iso.year().extended_year,
-            iso.month().ordinal,
-            Some(iso.day_of_month().0),
+            Iso.year_info(&iso).year,
+            Iso.month(&iso).ordinal,
+            Some(Iso.days_in_month(&iso)),
             self.clone(),
             overflow,
         )
@@ -370,8 +332,11 @@ impl Calendar {
         if self.is_iso() {
             return None;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
-        self.0.year(&calendar_date).standard_era().map(|era| era.0)
+        let calendar_date = self.0.from_iso(*iso_date.to_icu4x().inner());
+        self.0
+            .year_info(&calendar_date)
+            .era()
+            .map(|era_info| era_info.era)
     }
 
     /// `CalendarEraYear`
@@ -379,8 +344,11 @@ impl Calendar {
         if self.is_iso() {
             return None;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
-        self.0.year(&calendar_date).era_year()
+        let calendar_date = self.0.from_iso(*iso_date.to_icu4x().inner());
+        self.0
+            .year_info(&calendar_date)
+            .era()
+            .map(|era_info| era_info.year)
     }
 
     /// `CalendarYear`
@@ -388,8 +356,8 @@ impl Calendar {
         if self.is_iso() {
             return iso_date.year;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
-        self.0.year(&calendar_date).extended_year
+        let calendar_date = self.0.from_iso(*iso_date.to_icu4x().inner());
+        self.0.year_info(&calendar_date).era_year_or_related_iso()
     }
 
     /// `CalendarMonth`
@@ -397,7 +365,7 @@ impl Calendar {
         if self.is_iso() {
             return iso_date.month;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        let calendar_date = self.0.from_iso(*iso_date.to_icu4x().inner());
         self.0.month(&calendar_date).month_number()
     }
 
@@ -407,7 +375,7 @@ impl Calendar {
             let mc = iso_date.to_icu4x().month().standard_code.0;
             return MonthCode(mc);
         }
-        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        let calendar_date = self.0.from_iso(*iso_date.to_icu4x().inner());
         MonthCode(self.0.month(&calendar_date).standard_code.0)
     }
 
@@ -416,58 +384,44 @@ impl Calendar {
         if self.is_iso() {
             return iso_date.day;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        let calendar_date = self.0.from_iso(*iso_date.to_icu4x().inner());
         self.0.day_of_month(&calendar_date).0
     }
 
     /// `CalendarDayOfWeek`
-    pub fn day_of_week(&self, iso_date: &IsoDate) -> u16 {
+    pub fn day_of_week(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
         if self.is_iso() {
-            return iso_date.to_icu4x().day_of_week() as u16;
+            return Ok(iso_date.to_icu4x().day_of_week() as u16);
         }
-        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
-        // TODO: Understand ICU4X's decision for `IsoWeekDay` to be `i8`
-        self.0.day_of_week(&calendar_date) as u16
+        // TODO: Update or update in icu_calendar
+        Err(TemporalError::range().with_message("dayOfWeek is not for the provided calendar."))
     }
 
     /// `CalendarDayOfYear`
     pub fn day_of_year(&self, iso_date: &IsoDate) -> u16 {
         if self.is_iso() {
-            return iso_date.to_icu4x().day_of_year_info().day_of_year;
+            return iso_date.to_icu4x().day_of_year().0;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
-        self.0.day_of_year_info(&calendar_date).day_of_year
+        let calendar_date = self.0.from_iso(*iso_date.to_icu4x().inner());
+        self.0.day_of_year(&calendar_date).0
     }
 
     /// `CalendarWeekOfYear`
-    pub fn week_of_year(&self, iso_date: &IsoDate) -> TemporalResult<Option<u16>> {
+    pub fn week_of_year(&self, iso_date: &IsoDate) -> Option<u8> {
         if self.is_iso() {
-            let date = iso_date.to_icu4x();
-            let week_calculator = WeekCalculator::default();
-            let week_of = date.week_of_year(&week_calculator);
-            return Ok(Some(week_of.week as u16));
+            return Some(iso_date.to_icu4x().week_of_year().week_number);
         }
         // TODO: Research in ICU4X and determine best approach.
-        Err(TemporalError::range().with_message("Not yet implemented."))
+        None
     }
 
     /// `CalendarYearOfWeek`
-    pub fn year_of_week(&self, iso_date: &IsoDate) -> TemporalResult<Option<i32>> {
+    pub fn year_of_week(&self, iso_date: &IsoDate) -> Option<i32> {
         if self.is_iso() {
-            let date = iso_date.to_icu4x();
-
-            let week_calculator = WeekCalculator::default();
-
-            let week_of = date.week_of_year(&week_calculator);
-
-            return match week_of.unit {
-                RelativeUnit::Previous => Ok(Some(date.year().extended_year - 1)),
-                RelativeUnit::Current => Ok(Some(date.year().extended_year)),
-                RelativeUnit::Next => Ok(Some(date.year().extended_year + 1)),
-            };
+            return Some(iso_date.to_icu4x().week_of_year().iso_year);
         }
         // TODO: Research in ICU4X and determine best approach.
-        Err(TemporalError::range().with_message("Not yet implemented."))
+        None
     }
 
     /// `CalendarDaysInWeek`
@@ -484,7 +438,7 @@ impl Calendar {
         if self.is_iso() {
             return iso_date.to_icu4x().days_in_month() as u16;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        let calendar_date = self.0.from_iso(*iso_date.to_icu4x().inner());
         self.0.days_in_month(&calendar_date) as u16
     }
 
@@ -493,7 +447,7 @@ impl Calendar {
         if self.is_iso() {
             return iso_date.to_icu4x().days_in_year();
         }
-        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        let calendar_date = self.0.from_iso(*iso_date.to_icu4x().inner());
         self.0.days_in_year(&calendar_date)
     }
 
@@ -502,7 +456,7 @@ impl Calendar {
         if self.is_iso() {
             return 12;
         }
-        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        let calendar_date = self.0.from_iso(*iso_date.to_icu4x().inner());
         self.0.months_in_year(&calendar_date) as u16
     }
 
@@ -511,16 +465,18 @@ impl Calendar {
         if self.is_iso() {
             return iso_date.to_icu4x().is_in_leap_year();
         }
-        let calendar_date = self.0.date_from_iso(iso_date.to_icu4x());
+        let calendar_date = self.0.from_iso(*iso_date.to_icu4x().inner());
         self.0.is_in_leap_year(&calendar_date)
     }
 
     /// Returns the identifier of this calendar slot.
     pub fn identifier(&self) -> &'static str {
-        if self.is_iso() {
-            return "iso8601";
+        // icu_calendar lists iso8601 and julian as None
+        match self.0.calendar_algorithm() {
+            Some(c) => c.as_str(),
+            None if self.is_iso() => "iso8601",
+            None => "julian",
         }
-        self.0 .0.kind().as_bcp47_string()
     }
 }
 
@@ -568,22 +524,22 @@ impl Calendar {
                 Some(era::INDIAN_ERA)
             }
             // TODO: Determine whether observational is islamic or islamic-rgsa
-            AnyCalendarKind::IslamicCivil
+            AnyCalendarKind::HijriTabularTypeIIFriday
                 if era::ISLAMIC_CIVIL_ERA_IDENTIFIERS.contains(era_alias) =>
             {
                 Some(era::ISLAMIC_CIVIL_ERA)
             }
-            AnyCalendarKind::IslamicObservational
+            AnyCalendarKind::HijriSimulatedMecca
                 if era::ISLAMIC_ERA_IDENTIFIERS.contains(era_alias) =>
             {
                 Some(era::ISLAMIC_ERA)
             }
-            AnyCalendarKind::IslamicTabular
+            AnyCalendarKind::HijriTabularTypeIIThursday
                 if era::ISLAMIC_TBLA_ERA_IDENTIFIERS.contains(era_alias) =>
             {
                 Some(era::ISLAMIC_TBLA_ERA)
             }
-            AnyCalendarKind::IslamicUmmAlQura
+            AnyCalendarKind::HijriUmmAlQura
                 if era::ISLAMIC_UMALQURA_ERA_IDENTIFIERS.contains(era_alias) =>
             {
                 Some(era::ISLAMIC_UMALQURA_ERA)
@@ -633,10 +589,10 @@ impl Calendar {
             AnyCalendarKind::EthiopianAmeteAlem => Some(era::ETHIOAA_ERA),
             AnyCalendarKind::Hebrew => Some(era::HEBREW_ERA),
             AnyCalendarKind::Indian => Some(era::INDIAN_ERA),
-            AnyCalendarKind::IslamicCivil => Some(era::ISLAMIC_CIVIL_ERA),
-            AnyCalendarKind::IslamicObservational => Some(era::ISLAMIC_ERA),
-            AnyCalendarKind::IslamicTabular => Some(era::ISLAMIC_TBLA_ERA),
-            AnyCalendarKind::IslamicUmmAlQura => Some(era::ISLAMIC_UMALQURA_ERA),
+            AnyCalendarKind::HijriSimulatedMecca => Some(era::ISLAMIC_ERA),
+            AnyCalendarKind::HijriTabularTypeIIFriday => Some(era::ISLAMIC_CIVIL_ERA),
+            AnyCalendarKind::HijriTabularTypeIIThursday => Some(era::ISLAMIC_TBLA_ERA),
+            AnyCalendarKind::HijriUmmAlQura => Some(era::ISLAMIC_UMALQURA_ERA),
             AnyCalendarKind::Iso => Some(era::ISO_ERA),
             AnyCalendarKind::Persian => Some(era::PERSIAN_ERA),
             _ => None,
@@ -684,11 +640,11 @@ mod tests {
     #[test]
     fn calendar_from_str_is_case_insensitive() {
         let cal_str = "iSo8601";
-        let calendar = Calendar::from_utf8(cal_str.as_bytes()).unwrap();
+        let calendar = Calendar::try_from_utf8(cal_str.as_bytes()).unwrap();
         assert_eq!(calendar, Calendar::default());
 
         let cal_str = "iSO8601";
-        let calendar = Calendar::from_utf8(cal_str.as_bytes()).unwrap();
+        let calendar = Calendar::try_from_utf8(cal_str.as_bytes()).unwrap();
         assert_eq!(calendar, Calendar::default());
     }
 

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -13,8 +13,8 @@ use crate::{
     parsers::parse_allowed_calendar_formats,
     TemporalError, TemporalResult,
 };
+use alloc::string::ToString;
 use core::str::FromStr;
-use std::string::ToString;
 
 use icu_calendar::{
     cal::{

--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -563,7 +563,7 @@ impl PlainDate {
     }
 
     /// Returns the calendar day of week value.
-    pub fn day_of_week(&self) -> u16 {
+    pub fn day_of_week(&self) -> TemporalResult<u16> {
         self.calendar.day_of_week(&self.iso)
     }
 
@@ -573,12 +573,12 @@ impl PlainDate {
     }
 
     /// Returns the calendar week of year value.
-    pub fn week_of_year(&self) -> TemporalResult<Option<u16>> {
+    pub fn week_of_year(&self) -> Option<u8> {
         self.calendar.week_of_year(&self.iso)
     }
 
     /// Returns the calendar year of week value.
-    pub fn year_of_week(&self) -> TemporalResult<Option<i32>> {
+    pub fn year_of_week(&self) -> Option<i32> {
         self.calendar.year_of_week(&self.iso)
     }
 
@@ -730,7 +730,7 @@ impl FromStr for PlainDate {
 
         let calendar = parse_record
             .calendar
-            .map(Calendar::from_utf8)
+            .map(Calendar::try_from_utf8)
             .transpose()?
             .unwrap_or_default();
 

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -636,7 +636,7 @@ impl PlainDateTime {
     }
 
     /// Returns the calendar day of week value.
-    pub fn day_of_week(&self) -> u16 {
+    pub fn day_of_week(&self) -> TemporalResult<u16> {
         self.calendar.day_of_week(&self.iso.date)
     }
 
@@ -646,12 +646,12 @@ impl PlainDateTime {
     }
 
     /// Returns the calendar week of year value.
-    pub fn week_of_year(&self) -> TemporalResult<Option<u16>> {
+    pub fn week_of_year(&self) -> Option<u8> {
         self.calendar.week_of_year(&self.iso.date)
     }
 
     /// Returns the calendar year of week value.
-    pub fn year_of_week(&self) -> TemporalResult<Option<i32>> {
+    pub fn year_of_week(&self) -> Option<i32> {
         self.calendar.year_of_week(&self.iso.date)
     }
 
@@ -820,7 +820,7 @@ impl FromStr for PlainDateTime {
 
         let calendar = parse_record
             .calendar
-            .map(Calendar::from_utf8)
+            .map(Calendar::try_from_utf8)
             .transpose()?
             .unwrap_or_default();
 

--- a/src/builtins/core/month_day.rs
+++ b/src/builtins/core/month_day.rs
@@ -122,7 +122,7 @@ impl FromStr for PlainMonthDay {
 
         let calendar = record
             .calendar
-            .map(Calendar::from_utf8)
+            .map(Calendar::try_from_utf8)
             .transpose()?
             .unwrap_or_default();
 

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -394,7 +394,7 @@ impl FromStr for PlainYearMonth {
         let record = crate::parsers::parse_year_month(s)?;
         let calendar = record
             .calendar
-            .map(Calendar::from_utf8)
+            .map(Calendar::try_from_utf8)
             .transpose()?
             .unwrap_or_default();
 

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -825,7 +825,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        Ok(self.calendar.day_of_week(&pdt.iso.date))
+        self.calendar.day_of_week(&pdt.iso.date)
     }
 
     /// Returns the calendar day of year value.
@@ -842,10 +842,10 @@ impl ZonedDateTime {
     pub fn week_of_year_with_provider(
         &self,
         provider: &impl TimeZoneProvider,
-    ) -> TemporalResult<Option<u16>> {
+    ) -> TemporalResult<Option<u8>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.week_of_year(&pdt.iso.date)
+        Ok(self.calendar.week_of_year(&pdt.iso.date))
     }
 
     /// Returns the calendar year of week value.
@@ -855,7 +855,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<Option<i32>> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.year_of_week(&pdt.iso.date)
+        Ok(self.calendar.year_of_week(&pdt.iso.date))
     }
 
     /// Returns the calendar days in week value.
@@ -1210,7 +1210,7 @@ impl ZonedDateTime {
 
         let calendar = parse_result
             .calendar
-            .map(Calendar::from_utf8)
+            .map(Calendar::try_from_utf8)
             .transpose()?
             .unwrap_or_default();
 

--- a/src/options/relative_to.rs
+++ b/src/options/relative_to.rs
@@ -47,7 +47,7 @@ impl RelativeTo {
 
             let calendar = result
                 .calendar
-                .map(Calendar::from_utf8)
+                .map(Calendar::try_from_utf8)
                 .transpose()?
                 .unwrap_or_default();
 
@@ -87,7 +87,7 @@ impl RelativeTo {
 
         let calendar = result
             .calendar
-            .map(Calendar::from_utf8)
+            .map(Calendar::try_from_utf8)
             .transpose()?
             .unwrap_or_default();
 

--- a/temporal_capi/Cargo.toml
+++ b/temporal_capi/Cargo.toml
@@ -22,7 +22,8 @@ diplomat = "0.10.0"
 diplomat-runtime = "0.10.0"
 num-traits.workspace = true
 temporal_rs = { workspace = true, default-features = false }
-icu_calendar = { version = "2.0.0-beta2", default-features = false }
+icu_calendar = { version = "2.0.0", default-features = false }
+icu_locale = { version = "2.0.0" }
 
 [features]
 compiled_data = ["temporal_rs/compiled_data"]

--- a/temporal_capi/bindings/cpp/temporal_rs/AnyCalendarKind.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/AnyCalendarKind.d.hpp
@@ -27,10 +27,10 @@ namespace capi {
       AnyCalendarKind_Gregorian = 6,
       AnyCalendarKind_Hebrew = 7,
       AnyCalendarKind_Indian = 8,
-      AnyCalendarKind_IslamicCivil = 9,
-      AnyCalendarKind_IslamicObservational = 10,
-      AnyCalendarKind_IslamicTabular = 11,
-      AnyCalendarKind_IslamicUmmAlQura = 12,
+      AnyCalendarKind_HijriTabularTypeIIFriday = 9,
+      AnyCalendarKind_HijriSimulatedMecca = 10,
+      AnyCalendarKind_HijriTabularTypeIIThursday = 11,
+      AnyCalendarKind_HijriUmmAlQura = 12,
       AnyCalendarKind_Iso = 13,
       AnyCalendarKind_Japanese = 14,
       AnyCalendarKind_JapaneseExtended = 15,
@@ -55,10 +55,10 @@ public:
     Gregorian = 6,
     Hebrew = 7,
     Indian = 8,
-    IslamicCivil = 9,
-    IslamicObservational = 10,
-    IslamicTabular = 11,
-    IslamicUmmAlQura = 12,
+    HijriTabularTypeIIFriday = 9,
+    HijriSimulatedMecca = 10,
+    HijriTabularTypeIIThursday = 11,
+    HijriUmmAlQura = 12,
     Iso = 13,
     Japanese = 14,
     JapaneseExtended = 15,
@@ -73,7 +73,7 @@ public:
   // Prevent usage as boolean value
   explicit operator bool() const = delete;
 
-  inline static std::optional<temporal_rs::AnyCalendarKind> get_for_bcp47_string(std::string_view s);
+  inline static std::optional<temporal_rs::AnyCalendarKind> get_for_str(std::string_view s);
 
   inline temporal_rs::capi::AnyCalendarKind AsFFI() const;
   inline static temporal_rs::AnyCalendarKind FromFFI(temporal_rs::capi::AnyCalendarKind c_enum);

--- a/temporal_capi/bindings/cpp/temporal_rs/AnyCalendarKind.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/AnyCalendarKind.hpp
@@ -17,8 +17,8 @@ namespace temporal_rs {
 namespace capi {
     extern "C" {
     
-    typedef struct temporal_rs_AnyCalendarKind_get_for_bcp47_string_result {union {temporal_rs::capi::AnyCalendarKind ok; }; bool is_ok;} temporal_rs_AnyCalendarKind_get_for_bcp47_string_result;
-    temporal_rs_AnyCalendarKind_get_for_bcp47_string_result temporal_rs_AnyCalendarKind_get_for_bcp47_string(diplomat::capi::DiplomatStringView s);
+    typedef struct temporal_rs_AnyCalendarKind_get_for_str_result {union {temporal_rs::capi::AnyCalendarKind ok; }; bool is_ok;} temporal_rs_AnyCalendarKind_get_for_str_result;
+    temporal_rs_AnyCalendarKind_get_for_str_result temporal_rs_AnyCalendarKind_get_for_str(diplomat::capi::DiplomatStringView s);
     
     
     } // extern "C"
@@ -40,10 +40,10 @@ inline temporal_rs::AnyCalendarKind temporal_rs::AnyCalendarKind::FromFFI(tempor
     case temporal_rs::capi::AnyCalendarKind_Gregorian:
     case temporal_rs::capi::AnyCalendarKind_Hebrew:
     case temporal_rs::capi::AnyCalendarKind_Indian:
-    case temporal_rs::capi::AnyCalendarKind_IslamicCivil:
-    case temporal_rs::capi::AnyCalendarKind_IslamicObservational:
-    case temporal_rs::capi::AnyCalendarKind_IslamicTabular:
-    case temporal_rs::capi::AnyCalendarKind_IslamicUmmAlQura:
+    case temporal_rs::capi::AnyCalendarKind_HijriTabularTypeIIFriday:
+    case temporal_rs::capi::AnyCalendarKind_HijriSimulatedMecca:
+    case temporal_rs::capi::AnyCalendarKind_HijriTabularTypeIIThursday:
+    case temporal_rs::capi::AnyCalendarKind_HijriUmmAlQura:
     case temporal_rs::capi::AnyCalendarKind_Iso:
     case temporal_rs::capi::AnyCalendarKind_Japanese:
     case temporal_rs::capi::AnyCalendarKind_JapaneseExtended:
@@ -55,8 +55,8 @@ inline temporal_rs::AnyCalendarKind temporal_rs::AnyCalendarKind::FromFFI(tempor
   }
 }
 
-inline std::optional<temporal_rs::AnyCalendarKind> temporal_rs::AnyCalendarKind::get_for_bcp47_string(std::string_view s) {
-  auto result = temporal_rs::capi::temporal_rs_AnyCalendarKind_get_for_bcp47_string({s.data(), s.size()});
+inline std::optional<temporal_rs::AnyCalendarKind> temporal_rs::AnyCalendarKind::get_for_str(std::string_view s) {
+  auto result = temporal_rs::capi::temporal_rs_AnyCalendarKind_get_for_str({s.data(), s.size()});
   return result.is_ok ? std::optional<temporal_rs::AnyCalendarKind>(temporal_rs::AnyCalendarKind::FromFFI(result.ok)) : std::nullopt;
 }
 #endif // temporal_rs_AnyCalendarKind_HPP

--- a/temporal_capi/bindings/cpp/temporal_rs/Calendar.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Calendar.d.hpp
@@ -70,13 +70,13 @@ public:
 
   inline uint8_t day(temporal_rs::IsoDate date) const;
 
-  inline uint16_t day_of_week(temporal_rs::IsoDate date) const;
+  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_week(temporal_rs::IsoDate date) const;
 
   inline uint16_t day_of_year(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError> week_of_year(temporal_rs::IsoDate date) const;
+  inline std::optional<uint8_t> week_of_year(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> year_of_week(temporal_rs::IsoDate date) const;
+  inline std::optional<int32_t> year_of_week(temporal_rs::IsoDate date) const;
 
   inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_week(temporal_rs::IsoDate date) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/Calendar.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Calendar.hpp
@@ -66,14 +66,15 @@ namespace capi {
     
     uint8_t temporal_rs_Calendar_day(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
-    uint16_t temporal_rs_Calendar_day_of_week(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
+    typedef struct temporal_rs_Calendar_day_of_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_day_of_week_result;
+    temporal_rs_Calendar_day_of_week_result temporal_rs_Calendar_day_of_week(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
     uint16_t temporal_rs_Calendar_day_of_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
-    typedef struct temporal_rs_Calendar_week_of_year_result {union {diplomat::capi::OptionU16 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_week_of_year_result;
+    typedef struct temporal_rs_Calendar_week_of_year_result {union {uint8_t ok; }; bool is_ok;} temporal_rs_Calendar_week_of_year_result;
     temporal_rs_Calendar_week_of_year_result temporal_rs_Calendar_week_of_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
-    typedef struct temporal_rs_Calendar_year_of_week_result {union {diplomat::capi::OptionI32 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_year_of_week_result;
+    typedef struct temporal_rs_Calendar_year_of_week_result {union {int32_t ok; }; bool is_ok;} temporal_rs_Calendar_year_of_week_result;
     temporal_rs_Calendar_year_of_week_result temporal_rs_Calendar_year_of_week(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
     
     typedef struct temporal_rs_Calendar_days_in_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_days_in_week_result;
@@ -193,10 +194,10 @@ inline uint8_t temporal_rs::Calendar::day(temporal_rs::IsoDate date) const {
   return result;
 }
 
-inline uint16_t temporal_rs::Calendar::day_of_week(temporal_rs::IsoDate date) const {
+inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::Calendar::day_of_week(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_day_of_week(this->AsFFI(),
     date.AsFFI());
-  return result;
+  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
 inline uint16_t temporal_rs::Calendar::day_of_year(temporal_rs::IsoDate date) const {
@@ -205,16 +206,16 @@ inline uint16_t temporal_rs::Calendar::day_of_year(temporal_rs::IsoDate date) co
   return result;
 }
 
-inline diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError> temporal_rs::Calendar::week_of_year(temporal_rs::IsoDate date) const {
+inline std::optional<uint8_t> temporal_rs::Calendar::week_of_year(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_week_of_year(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError>(diplomat::Ok<std::optional<uint16_t>>(result.ok.is_ok ? std::optional(result.ok.ok) : std::nullopt)) : diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? std::optional<uint8_t>(result.ok) : std::nullopt;
 }
 
-inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> temporal_rs::Calendar::year_of_week(temporal_rs::IsoDate date) const {
+inline std::optional<int32_t> temporal_rs::Calendar::year_of_week(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_year_of_week(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Ok<std::optional<int32_t>>(result.ok.is_ok ? std::optional(result.ok.ok) : std::nullopt)) : diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
 }
 
 inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::Calendar::days_in_week(temporal_rs::IsoDate date) const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
@@ -89,13 +89,13 @@ public:
 
   inline uint8_t day() const;
 
-  inline uint16_t day_of_week() const;
+  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_week() const;
 
   inline uint16_t day_of_year() const;
 
-  inline diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError> week_of_year() const;
+  inline std::optional<uint8_t> week_of_year() const;
 
-  inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> year_of_week() const;
+  inline std::optional<int32_t> year_of_week() const;
 
   inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_week() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
@@ -86,14 +86,15 @@ namespace capi {
     
     uint8_t temporal_rs_PlainDate_day(const temporal_rs::capi::PlainDate* self);
     
-    uint16_t temporal_rs_PlainDate_day_of_week(const temporal_rs::capi::PlainDate* self);
+    typedef struct temporal_rs_PlainDate_day_of_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_day_of_week_result;
+    temporal_rs_PlainDate_day_of_week_result temporal_rs_PlainDate_day_of_week(const temporal_rs::capi::PlainDate* self);
     
     uint16_t temporal_rs_PlainDate_day_of_year(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_week_of_year_result {union {diplomat::capi::OptionU16 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_week_of_year_result;
+    typedef struct temporal_rs_PlainDate_week_of_year_result {union {uint8_t ok; }; bool is_ok;} temporal_rs_PlainDate_week_of_year_result;
     temporal_rs_PlainDate_week_of_year_result temporal_rs_PlainDate_week_of_year(const temporal_rs::capi::PlainDate* self);
     
-    typedef struct temporal_rs_PlainDate_year_of_week_result {union {diplomat::capi::OptionI32 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_year_of_week_result;
+    typedef struct temporal_rs_PlainDate_year_of_week_result {union {int32_t ok; }; bool is_ok;} temporal_rs_PlainDate_year_of_week_result;
     temporal_rs_PlainDate_year_of_week_result temporal_rs_PlainDate_year_of_week(const temporal_rs::capi::PlainDate* self);
     
     typedef struct temporal_rs_PlainDate_days_in_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_days_in_week_result;
@@ -272,9 +273,9 @@ inline uint8_t temporal_rs::PlainDate::day() const {
   return result;
 }
 
-inline uint16_t temporal_rs::PlainDate::day_of_week() const {
+inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDate::day_of_week() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_day_of_week(this->AsFFI());
-  return result;
+  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
 inline uint16_t temporal_rs::PlainDate::day_of_year() const {
@@ -282,14 +283,14 @@ inline uint16_t temporal_rs::PlainDate::day_of_year() const {
   return result;
 }
 
-inline diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError> temporal_rs::PlainDate::week_of_year() const {
+inline std::optional<uint8_t> temporal_rs::PlainDate::week_of_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_week_of_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError>(diplomat::Ok<std::optional<uint16_t>>(result.ok.is_ok ? std::optional(result.ok.ok) : std::nullopt)) : diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? std::optional<uint8_t>(result.ok) : std::nullopt;
 }
 
-inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> temporal_rs::PlainDate::year_of_week() const {
+inline std::optional<int32_t> temporal_rs::PlainDate::year_of_week() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_year_of_week(this->AsFFI());
-  return result.is_ok ? diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Ok<std::optional<int32_t>>(result.ok.is_ok ? std::optional(result.ok.ok) : std::nullopt)) : diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
 }
 
 inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDate::days_in_week() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
@@ -85,13 +85,13 @@ public:
 
   inline uint8_t day() const;
 
-  inline uint16_t day_of_week() const;
+  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_week() const;
 
   inline uint16_t day_of_year() const;
 
-  inline diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError> week_of_year() const;
+  inline std::optional<uint8_t> week_of_year() const;
 
-  inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> year_of_week() const;
+  inline std::optional<int32_t> year_of_week() const;
 
   inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_week() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
@@ -80,14 +80,15 @@ namespace capi {
     
     uint8_t temporal_rs_PlainDateTime_day(const temporal_rs::capi::PlainDateTime* self);
     
-    uint16_t temporal_rs_PlainDateTime_day_of_week(const temporal_rs::capi::PlainDateTime* self);
+    typedef struct temporal_rs_PlainDateTime_day_of_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_day_of_week_result;
+    temporal_rs_PlainDateTime_day_of_week_result temporal_rs_PlainDateTime_day_of_week(const temporal_rs::capi::PlainDateTime* self);
     
     uint16_t temporal_rs_PlainDateTime_day_of_year(const temporal_rs::capi::PlainDateTime* self);
     
-    typedef struct temporal_rs_PlainDateTime_week_of_year_result {union {diplomat::capi::OptionU16 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_week_of_year_result;
+    typedef struct temporal_rs_PlainDateTime_week_of_year_result {union {uint8_t ok; }; bool is_ok;} temporal_rs_PlainDateTime_week_of_year_result;
     temporal_rs_PlainDateTime_week_of_year_result temporal_rs_PlainDateTime_week_of_year(const temporal_rs::capi::PlainDateTime* self);
     
-    typedef struct temporal_rs_PlainDateTime_year_of_week_result {union {diplomat::capi::OptionI32 ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_year_of_week_result;
+    typedef struct temporal_rs_PlainDateTime_year_of_week_result {union {int32_t ok; }; bool is_ok;} temporal_rs_PlainDateTime_year_of_week_result;
     temporal_rs_PlainDateTime_year_of_week_result temporal_rs_PlainDateTime_year_of_week(const temporal_rs::capi::PlainDateTime* self);
     
     typedef struct temporal_rs_PlainDateTime_days_in_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_days_in_week_result;
@@ -277,9 +278,9 @@ inline uint8_t temporal_rs::PlainDateTime::day() const {
   return result;
 }
 
-inline uint16_t temporal_rs::PlainDateTime::day_of_week() const {
+inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDateTime::day_of_week() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_day_of_week(this->AsFFI());
-  return result;
+  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
 inline uint16_t temporal_rs::PlainDateTime::day_of_year() const {
@@ -287,14 +288,14 @@ inline uint16_t temporal_rs::PlainDateTime::day_of_year() const {
   return result;
 }
 
-inline diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::week_of_year() const {
+inline std::optional<uint8_t> temporal_rs::PlainDateTime::week_of_year() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_week_of_year(this->AsFFI());
-  return result.is_ok ? diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError>(diplomat::Ok<std::optional<uint16_t>>(result.ok.is_ok ? std::optional(result.ok.ok) : std::nullopt)) : diplomat::result<std::optional<uint16_t>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? std::optional<uint8_t>(result.ok) : std::nullopt;
 }
 
-inline diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::year_of_week() const {
+inline std::optional<int32_t> temporal_rs::PlainDateTime::year_of_week() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_year_of_week(this->AsFFI());
-  return result.is_ok ? diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Ok<std::optional<int32_t>>(result.ok.is_ok ? std::optional(result.ok.ok) : std::nullopt)) : diplomat::result<std::optional<int32_t>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
 }
 
 inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDateTime::days_in_week() const {

--- a/temporal_capi/src/calendar.rs
+++ b/temporal_capi/src/calendar.rs
@@ -12,8 +12,9 @@ pub mod ffi {
     use alloc::boxed::Box;
     use core::fmt::Write;
     use diplomat_runtime::DiplomatStr;
+    use icu_calendar::preferences::CalendarAlgorithm;
 
-    #[diplomat::enum_convert(icu_calendar::any_calendar::AnyCalendarKind, needs_wildcard)]
+    #[diplomat::enum_convert(icu_calendar::AnyCalendarKind, needs_wildcard)]
     pub enum AnyCalendarKind {
         Buddhist,
         Chinese,
@@ -24,10 +25,10 @@ pub mod ffi {
         Gregorian,
         Hebrew,
         Indian,
-        IslamicCivil,
-        IslamicObservational,
-        IslamicTabular,
-        IslamicUmmAlQura,
+        HijriTabularTypeIIFriday,
+        HijriSimulatedMecca,
+        HijriTabularTypeIIThursday,
+        HijriUmmAlQura,
         Iso,
         Japanese,
         JapaneseExtended,
@@ -36,8 +37,16 @@ pub mod ffi {
     }
 
     impl AnyCalendarKind {
-        pub fn get_for_bcp47_string(s: &DiplomatStr) -> Option<Self> {
-            icu_calendar::any_calendar::AnyCalendarKind::get_for_bcp47_bytes(s).map(Into::into)
+        pub fn get_for_str(s: &DiplomatStr) -> Option<Self> {
+            let value = icu_locale::extensions::unicode::Value::try_from_utf8(s).ok()?;
+            let algorithm = CalendarAlgorithm::try_from(&value).ok()?;
+            match icu_calendar::AnyCalendarKind::try_from(algorithm) {
+                Ok(c) => Some(c.into()),
+                Err(()) if algorithm == CalendarAlgorithm::Hijri(None) => {
+                    Some(Self::HijriTabularTypeIIFriday)
+                }
+                Err(()) => None,
+            }
         }
     }
 
@@ -151,17 +160,17 @@ pub mod ffi {
         pub fn day(&self, date: IsoDate) -> u8 {
             self.0.day(&date.into())
         }
-        pub fn day_of_week(&self, date: IsoDate) -> u16 {
-            self.0.day_of_week(&date.into())
+        pub fn day_of_week(&self, date: IsoDate) -> Result<u16, TemporalError> {
+            self.0.day_of_week(&date.into()).map_err(Into::into)
         }
         pub fn day_of_year(&self, date: IsoDate) -> u16 {
             self.0.day_of_year(&date.into())
         }
-        pub fn week_of_year(&self, date: IsoDate) -> Result<Option<u16>, TemporalError> {
-            self.0.week_of_year(&date.into()).map_err(Into::into)
+        pub fn week_of_year(&self, date: IsoDate) -> Option<u8> {
+            self.0.week_of_year(&date.into())
         }
-        pub fn year_of_week(&self, date: IsoDate) -> Result<Option<i32>, TemporalError> {
-            self.0.year_of_week(&date.into()).map_err(Into::into)
+        pub fn year_of_week(&self, date: IsoDate) -> Option<i32> {
+            self.0.year_of_week(&date.into())
         }
         pub fn days_in_week(&self, date: IsoDate) -> Result<u16, TemporalError> {
             self.0.days_in_week(&date.into()).map_err(Into::into)

--- a/temporal_capi/src/calendar.rs
+++ b/temporal_capi/src/calendar.rs
@@ -51,7 +51,7 @@ pub mod ffi {
         }
 
         pub fn from_utf8(s: &DiplomatStr) -> Result<Box<Self>, TemporalError> {
-            temporal_rs::Calendar::from_utf8(s)
+            temporal_rs::Calendar::try_from_utf8(s)
                 .map(|c| Box::new(Calendar(c)))
                 .map_err(Into::into)
         }

--- a/temporal_capi/src/plain_date.rs
+++ b/temporal_capi/src/plain_date.rs
@@ -201,17 +201,17 @@ pub mod ffi {
         pub fn day(&self) -> u8 {
             self.0.day()
         }
-        pub fn day_of_week(&self) -> u16 {
-            self.0.day_of_week()
+        pub fn day_of_week(&self) -> Result<u16, TemporalError> {
+            self.0.day_of_week().map_err(Into::into)
         }
         pub fn day_of_year(&self) -> u16 {
             self.0.day_of_year()
         }
-        pub fn week_of_year(&self) -> Result<Option<u16>, TemporalError> {
-            self.0.week_of_year().map_err(Into::into)
+        pub fn week_of_year(&self) -> Option<u8> {
+            self.0.week_of_year()
         }
-        pub fn year_of_week(&self) -> Result<Option<i32>, TemporalError> {
-            self.0.year_of_week().map_err(Into::into)
+        pub fn year_of_week(&self) -> Option<i32> {
+            self.0.year_of_week()
         }
         pub fn days_in_week(&self) -> Result<u16, TemporalError> {
             self.0.days_in_week().map_err(Into::into)

--- a/temporal_capi/src/plain_date_time.rs
+++ b/temporal_capi/src/plain_date_time.rs
@@ -181,17 +181,17 @@ pub mod ffi {
         pub fn day(&self) -> u8 {
             self.0.day()
         }
-        pub fn day_of_week(&self) -> u16 {
-            self.0.day_of_week()
+        pub fn day_of_week(&self) -> Result<u16, TemporalError> {
+            self.0.day_of_week().map_err(Into::into)
         }
         pub fn day_of_year(&self) -> u16 {
             self.0.day_of_year()
         }
-        pub fn week_of_year(&self) -> Result<Option<u16>, TemporalError> {
-            self.0.week_of_year().map_err(Into::into)
+        pub fn week_of_year(&self) -> Option<u8> {
+            self.0.week_of_year()
         }
-        pub fn year_of_week(&self) -> Result<Option<i32>, TemporalError> {
-            self.0.year_of_week().map_err(Into::into)
+        pub fn year_of_week(&self) -> Option<i32> {
+            self.0.year_of_week()
         }
         pub fn days_in_week(&self) -> Result<u16, TemporalError> {
             self.0.days_in_week().map_err(Into::into)


### PR DESCRIPTION
This PR bumps `icu_calendar` to 2.0.

There are a host of changes due to updates in `icu_calendar`.

The ICU calendar trait is now sealed, so we can not implement it anymore. Although, I'm not sure we need to anymore.

The way we handle `from_str` and `from_utf8` are also updated as well to use `CalendarAlgorithm`. This aligns better with our expected values, but it also means we are pulling in `icu_locale` as well.