### PR TITLE
Implement a builder API for Now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ web-time = { workspace = true, optional =  true }
 core_maths = "0.1.1"
 
 [features]
-default = ["sys"]
+default = ["sys", "compiled_data"]
 log = ["dep:log"]
 compiled_data = ["tzdb"]
 sys = ["std", "dep:web-time", "dep:iana-time-zone"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ web-time = { workspace = true, optional =  true }
 core_maths = "0.1.1"
 
 [features]
-default = ["sys", "compiled_data"]
+default = ["sys"]
 log = ["dep:log"]
 compiled_data = ["tzdb"]
 sys = ["std", "dep:web-time", "dep:iana-time-zone"]

--- a/src/builtins/compiled/now.rs
+++ b/src/builtins/compiled/now.rs
@@ -1,52 +1,40 @@
-#![cfg(feature = "sys")]
-
 use crate::builtins::{
     core::{Now, PlainDate, PlainDateTime, PlainTime},
     TZ_PROVIDER,
 };
-use crate::sys;
-use crate::{time::EpochNanoseconds, TemporalError, TemporalResult, TimeZone};
+use crate::{TemporalError, TemporalResult, TimeZone};
 
 impl Now {
     /// Returns the current system time as a [`PlainDateTime`] with an optional
     /// [`TimeZone`].
     ///
     /// Enable with the `compiled_data` and `sys` feature flags.
-    pub fn plain_datetime_iso(timezone: Option<TimeZone>) -> TemporalResult<PlainDateTime> {
+    pub fn plain_date_time_iso(self, time_zone: Option<TimeZone>) -> TemporalResult<PlainDateTime> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        let timezone = timezone.unwrap_or(TimeZone::IanaIdentifier(sys::get_system_timezone()?));
-        let system_nanos = sys::get_system_nanoseconds()?;
-        let epoch_nanos = EpochNanoseconds::try_from(system_nanos)?;
-        Now::plain_datetime_iso_with_provider_and_system_info(epoch_nanos, timezone, &*provider)
+        self.plain_date_time_iso_with_provider(time_zone, &*provider)
     }
 
     /// Returns the current system time as a [`PlainDate`] with an optional
     /// [`TimeZone`].
     ///
     /// Enable with the `compiled_data` and `sys` feature flags.
-    pub fn plain_date_iso(timezone: Option<TimeZone>) -> TemporalResult<PlainDate> {
+    pub fn plain_date_iso(self, time_zone: Option<TimeZone>) -> TemporalResult<PlainDate> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        let timezone = timezone.unwrap_or(TimeZone::IanaIdentifier(sys::get_system_timezone()?));
-        let system_nanos = sys::get_system_nanoseconds()?;
-        let epoch_nanos = EpochNanoseconds::try_from(system_nanos)?;
-        Now::plain_date_iso_with_provider_and_system_info(epoch_nanos, timezone, &*provider)
+        self.plain_date_iso_with_provider(time_zone, &*provider)
     }
 
     /// Returns the current system time as a [`PlainTime`] with an optional
     /// [`TimeZone`].
     ///
     /// Enable with the `compiled_data` and `sys` feature flags.
-    pub fn plain_time_iso(timezone: Option<TimeZone>) -> TemporalResult<PlainTime> {
+    pub fn plain_time_iso(self, time_zone: Option<TimeZone>) -> TemporalResult<PlainTime> {
         let provider = TZ_PROVIDER
             .lock()
             .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        let timezone = timezone.unwrap_or(TimeZone::IanaIdentifier(sys::get_system_timezone()?));
-        let system_nanos = sys::get_system_nanoseconds()?;
-        let epoch_nanos = EpochNanoseconds::try_from(system_nanos)?;
-        Now::plain_time_iso_with_provider_and_system_info(epoch_nanos, timezone, &*provider)
+        self.plain_time_with_provider(time_zone, &*provider)
     }
 }

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -15,7 +15,7 @@ use crate::{
     parsers::{parse_instant, IxdtfStringBuilder},
     provider::TimeZoneProvider,
     rounding::{IncrementRounder, Round},
-    time::EpochNanoseconds,
+    unix_time::EpochNanoseconds,
     Calendar, TemporalError, TemporalResult, TemporalUnwrap, TimeZone,
 };
 
@@ -329,7 +329,7 @@ mod tests {
     use crate::{
         builtins::core::{duration::TimeDuration, Instant},
         options::{DifferenceSettings, RoundingMode, Unit},
-        time::EpochNanoseconds,
+        unix_time::EpochNanoseconds,
         NS_MAX_INSTANT, NS_MIN_INSTANT,
     };
 

--- a/src/builtins/core/mod.rs
+++ b/src/builtins/core/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod zoneddatetime;
 mod now;
 
 #[doc(inline)]
-pub use now::Now;
+pub use now::{Now, NowBuilder};
 
 #[doc(inline)]
 pub use date::{PartialDate, PlainDate};

--- a/src/builtins/core/now.rs
+++ b/src/builtins/core/now.rs
@@ -36,7 +36,6 @@ impl NowBuilder {
 }
 
 #[derive(Debug)]
-#[non_exhaustive] // Not constructable by external means
 pub struct Now {
     clock: Option<EpochNanoseconds>,
     zone: TimeZone,

--- a/src/builtins/core/now.rs
+++ b/src/builtins/core/now.rs
@@ -1,180 +1,127 @@
 //! The Temporal Now component
 
-use crate::iso::IsoDateTime;
 use crate::provider::TimeZoneProvider;
-use crate::time::EpochNanoseconds;
+use crate::unix_time::EpochNanoseconds;
 use crate::TemporalResult;
-
-#[cfg(feature = "sys")]
-use alloc::string::String;
+use crate::{iso::IsoDateTime, TemporalError};
 
 use super::{
     calendar::Calendar, timezone::TimeZone, Instant, PlainDate, PlainDateTime, PlainTime,
     ZonedDateTime,
 };
 
-/// The Temporal Now object.
-pub struct Now;
+#[derive(Debug, Default)]
+pub struct NowBuilder {
+    clock: Option<EpochNanoseconds>,
+    zone: Option<TimeZone>,
+}
 
-impl Now {
-    /// Returns the current system `DateTime` based off the provided system args
-    ///
-    /// ## Order of operations
-    ///
-    /// The order of operations for this method requires the `GetSystemTimeZone` call
-    /// to occur prior to calling system time and resolving the `EpochNanoseconds`
-    /// value.
-    ///
-    /// A correct implementation will follow the following steps:
-    ///
-    ///   1. Resolve user input `TimeZone` with the `SystemTimeZone`.
-    ///   2. Get the `SystemNanoseconds`
-    pub(crate) fn system_datetime_with_provider(
-        system_epoch_nanoseconds: EpochNanoseconds,
-        system_timezone: TimeZone,
-        provider: &impl TimeZoneProvider,
-    ) -> TemporalResult<IsoDateTime> {
-        // 1. If temporalTimeZoneLike is undefined, then
-        // a. Let timeZone be SystemTimeZoneIdentifier().
-        // 2. Else,
-        // a. Let timeZone be ? ToTemporalTimeZoneIdentifier(temporalTimeZoneLike).
-        // 3. Let epochNs be SystemUTCEpochNanoseconds().
-        // 4. Return GetISODateTimeFor(timeZone, epochNs).
-        system_timezone.get_iso_datetime_for(&Instant::from(system_epoch_nanoseconds), provider)
+impl NowBuilder {
+    pub fn with_system_nanoseconds(mut self, nanoseconds: EpochNanoseconds) -> Self {
+        self.clock = Some(nanoseconds);
+        self
     }
 
-    /// Returns the current system time as a `ZonedDateTime` with an ISO8601 calendar.
-    ///
-    /// The time zone will be set to either the `TimeZone` if a value is provided, or
-    /// according to the system timezone if no value is provided.
-    ///
-    /// ## Order of operations
-    ///
-    /// The order of operations for this method requires the `GetSystemTimeZone` call
-    /// to occur prior to calling system time and resolving the `EpochNanoseconds`
-    /// value.
-    ///
-    /// A correct implementation will follow the following steps:
-    ///
-    ///   1. Resolve user input `TimeZone` with the `SystemTimeZone`.
-    ///   2. Get the `SystemNanoseconds`
-    ///
-    /// For an example implementation, see `Now::zoneddatetime_iso`; available with
-    /// the `compiled_data` feature flag.
-    pub fn zoneddatetime_iso_with_system_info(
-        sys_epoch_nanos: EpochNanoseconds,
-        sys_timezone: TimeZone,
-    ) -> TemporalResult<ZonedDateTime> {
-        let instant = Instant::from(sys_epoch_nanos);
+    pub fn with_system_zone(mut self, zone: TimeZone) -> Self {
+        self.zone = Some(zone);
+        self
+    }
+
+    pub fn build(self) -> Now {
+        Now {
+            clock: self.clock,
+            zone: self.zone.unwrap_or_default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive] // Not constructable by external means
+pub struct Now {
+    clock: Option<EpochNanoseconds>,
+    zone: TimeZone,
+}
+
+impl Now {
+    pub(crate) fn clock(self) -> TemporalResult<EpochNanoseconds> {
+        self.clock
+            .ok_or(TemporalError::general("system clock unavailable"))
+    }
+
+    pub(crate) fn system_datetime_with_provider(
+        self,
+        time_zone: Option<TimeZone>,
+        provider: &impl TimeZoneProvider,
+    ) -> TemporalResult<IsoDateTime> {
+        let Now { clock, zone } = self;
+        let system_nanoseconds = clock.ok_or(TemporalError::general("system clock unavailable"))?;
+        let time_zone = time_zone.unwrap_or(zone);
+        time_zone.get_iso_datetime_for(&Instant::from(system_nanoseconds), provider)
+    }
+}
+
+impl Now {
+    /// Converts the current [`Now`] into a [`TimeZone`].
+    pub fn time_zone(self) -> TimeZone {
+        self.zone
+    }
+
+    /// Converts the current [`Now`] into an [`Instant`].
+    pub fn instant(self) -> TemporalResult<Instant> {
+        Ok(Instant::from(self.clock()?))
+    }
+
+    /// Converts the current [`Now`] into an [`ZonedDateTime`] with an ISO8601 calendar.
+    pub fn zoned_date_time_iso(self, time_zone: Option<TimeZone>) -> TemporalResult<ZonedDateTime> {
+        let Now { clock, zone } = self;
+        let system_nanoseconds = clock.ok_or(TemporalError::general("system clock unavailable"))?;
+        let time_zone = time_zone.unwrap_or(zone);
+        let instant = Instant::from(system_nanoseconds);
         Ok(ZonedDateTime::new_unchecked(
             instant,
-            Calendar::default(),
-            sys_timezone,
+            Calendar::ISO,
+            time_zone,
         ))
     }
 }
 
-#[cfg(feature = "sys")]
 impl Now {
-    /// Returns the current instant
+    /// Converts `Now` into the current system [`PlainDateTime`] with an ISO8601 calendar.
     ///
-    /// Enable with the `sys` feature flag.
-    pub fn instant() -> TemporalResult<Instant> {
-        let system_nanos = crate::sys::get_system_nanoseconds()?;
-        let epoch_nanos = EpochNanoseconds::try_from(system_nanos)?;
-        Ok(Instant::from(epoch_nanos))
-    }
-
-    /// Returns the current time zone.
-    ///
-    /// Enable with the `sys` feature flag.
-    pub fn time_zone_identifier() -> TemporalResult<String> {
-        crate::sys::get_system_timezone()
-    }
-
-    /// Returns the current system time as a [`PlainDateTime`] with an optional
-    /// [`TimeZone`].
-    ///
-    /// Enable with the `sys` feature flag.
-    pub fn zoneddatetime_iso(timezone: Option<TimeZone>) -> TemporalResult<ZonedDateTime> {
-        let timezone =
-            timezone.unwrap_or(TimeZone::IanaIdentifier(crate::sys::get_system_timezone()?));
-        let system_nanos = crate::sys::get_system_nanoseconds()?;
-        let epoch_nanos = EpochNanoseconds::try_from(system_nanos)?;
-        Now::zoneddatetime_iso_with_system_info(epoch_nanos, timezone)
-    }
-}
-
-impl Now {
-    /// Returns the current system time as a `PlainDateTime` with an ISO8601 calendar.
-    ///
-    /// ## Order of operations
-    ///
-    /// The order of operations for this method requires the `GetSystemTimeZone` call
-    /// to occur prior to calling system time and resolving the `EpochNanoseconds`
-    /// value.
-    ///
-    /// A correct implementation will follow the following steps:
-    ///
-    ///   1. Resolve user input `TimeZone` with the `SystemTimeZone`.
-    ///   2. Get the `SystemNanoseconds`
-    ///
-    /// For an example implementation, see `Now::plain_datetime_iso`; available with the
-    /// `compiled_data` feature flag.
-    pub fn plain_datetime_iso_with_provider_and_system_info(
-        sys_epoch_nanos: EpochNanoseconds,
-        sys_timezone: TimeZone,
+    /// When `TimeZone` is `None`, the value will default to the
+    /// system time zone or UTC if the system zone is unavailable.
+    pub fn plain_date_time_iso_with_provider(
+        self,
+        time_zone: Option<TimeZone>,
         provider: &impl TimeZoneProvider,
     ) -> TemporalResult<PlainDateTime> {
-        let iso = Self::system_datetime_with_provider(sys_epoch_nanos, sys_timezone, provider)?;
-        Ok(PlainDateTime::new_unchecked(iso, Calendar::default()))
+        let iso = self.system_datetime_with_provider(time_zone, provider)?;
+        Ok(PlainDateTime::new_unchecked(iso, Calendar::ISO))
     }
 
-    /// Returns the current system time as a `PlainDate` with an ISO8601 calendar.
+    /// Converts `Now` into the current system [`PlainDate`] with an ISO8601 calendar.
     ///
-    /// ## Order of operations
-    ///
-    /// The order of operations for this method requires the `GetSystemTimeZone` call
-    /// to occur prior to calling system time and resolving the `EpochNanoseconds`
-    /// value.
-    ///
-    /// A correct implementation will follow the following steps:
-    ///
-    ///   1. Resolve user input `TimeZone` with the `SystemTimeZone`.
-    ///   2. Get the `SystemNanoseconds`
-    ///
-    /// For an example implementation, see `Now::plain_date_iso`; available
-    /// with the `compiled_data` feature flag.
-    pub fn plain_date_iso_with_provider_and_system_info(
-        sys_epoch_nanos: EpochNanoseconds,
-        sys_timezone: TimeZone,
+    /// When `TimeZone` is `None`, the value will default to the
+    /// system time zone or UTC if the system zone is unavailable.
+    pub fn plain_date_iso_with_provider(
+        self,
+        time_zone: Option<TimeZone>,
         provider: &impl TimeZoneProvider,
     ) -> TemporalResult<PlainDate> {
-        let iso = Self::system_datetime_with_provider(sys_epoch_nanos, sys_timezone, provider)?;
-        Ok(PlainDate::new_unchecked(iso.date, Calendar::default()))
+        let iso = self.system_datetime_with_provider(time_zone, provider)?;
+        Ok(PlainDate::new_unchecked(iso.date, Calendar::ISO))
     }
 
-    /// Returns the current system time as a `PlainTime` according to an ISO8601 calendar.
+    /// Converts `Now` into the current system [`PlainTime`].
     ///
-    /// ## Order of operations
-    ///
-    /// The order of operations for this method requires the `GetSystemTimeZone` call
-    /// to occur prior to calling system time and resolving the `EpochNanoseconds`
-    /// value.
-    ///
-    /// A correct implementation will follow the following steps:
-    ///
-    ///   1. Resolve user input `TimeZone` with the `SystemTimeZone`.
-    ///   2. Get the `SystemNanoseconds`
-    ///
-    /// For an example implementation, see `Now::plain_time_iso`; available with the
-    /// `compiled_data` feature flag.
-    pub fn plain_time_iso_with_provider_and_system_info(
-        sys_epoch_nanos: EpochNanoseconds,
-        sys_timezone: TimeZone,
+    /// When `TimeZone` is `None`, the value will default to the
+    /// system time zone or UTC if the system zone is unavailable.
+    pub fn plain_time_with_provider(
+        self,
+        time_zone: Option<TimeZone>,
         provider: &impl TimeZoneProvider,
     ) -> TemporalResult<PlainTime> {
-        let iso = Self::system_datetime_with_provider(sys_epoch_nanos, sys_timezone, provider)?;
+        let iso = self.system_datetime_with_provider(time_zone, provider)?;
         Ok(PlainTime::new_unchecked(iso.time))
     }
 }
@@ -183,16 +130,14 @@ impl Now {
 mod tests {
 
     #[cfg(feature = "tzdb")]
-    use crate::builtins::core::Now;
-    #[cfg(feature = "tzdb")]
     use crate::options::DifferenceSettings;
     #[cfg(feature = "tzdb")]
-    use crate::time::EpochNanoseconds;
+    use crate::unix_time::EpochNanoseconds;
 
     #[cfg(feature = "tzdb")]
     #[test]
     fn mocked_datetime() {
-        use crate::{tzdb::FsTzdbProvider, TimeZone};
+        use crate::{now::NowBuilder, tzdb::FsTzdbProvider, TimeZone};
         let provider = FsTzdbProvider::default();
 
         // 2025-03-11T10:47-06:00
@@ -202,34 +147,46 @@ mod tests {
         let uschi = TimeZone::try_from_identifier_str("America/Chicago").unwrap();
 
         let base = EpochNanoseconds::try_from(TIME_BASE).unwrap();
-        let now =
-            Now::plain_datetime_iso_with_provider_and_system_info(base, cdt.clone(), &provider)
-                .unwrap();
-        assert_eq!(now.year(), 2025);
-        assert_eq!(now.month(), 3);
-        assert_eq!(now.month_code().as_str(), "M03");
-        assert_eq!(now.day(), 11);
-        assert_eq!(now.hour(), 22);
-        assert_eq!(now.minute(), 46);
-        assert_eq!(now.second(), 28);
-        assert_eq!(now.millisecond(), 77);
-        assert_eq!(now.microsecond(), 363);
-        assert_eq!(now.nanosecond(), 694);
+        let now = NowBuilder::default()
+            .with_system_nanoseconds(base)
+            .with_system_zone(cdt.clone())
+            .build();
+        let cdt_datetime = now
+            .plain_date_time_iso_with_provider(None, &provider)
+            .unwrap();
+        assert_eq!(cdt_datetime.year(), 2025);
+        assert_eq!(cdt_datetime.month(), 3);
+        assert_eq!(cdt_datetime.month_code().as_str(), "M03");
+        assert_eq!(cdt_datetime.day(), 11);
+        assert_eq!(cdt_datetime.hour(), 22);
+        assert_eq!(cdt_datetime.minute(), 46);
+        assert_eq!(cdt_datetime.second(), 28);
+        assert_eq!(cdt_datetime.millisecond(), 77);
+        assert_eq!(cdt_datetime.microsecond(), 363);
+        assert_eq!(cdt_datetime.nanosecond(), 694);
 
-        let now_iana =
-            Now::plain_datetime_iso_with_provider_and_system_info(base, uschi.clone(), &provider)
-                .unwrap();
-        assert_eq!(now, now_iana);
+        let now_cdt = NowBuilder::default()
+            .with_system_nanoseconds(base)
+            .with_system_zone(cdt.clone())
+            .build();
+        let uschi_datetime = now_cdt
+            .plain_date_time_iso_with_provider(Some(uschi), &provider)
+            .unwrap();
+        assert_eq!(cdt_datetime, uschi_datetime);
 
         let plus_5_secs = TIME_BASE + (5 * 1_000_000_000);
         let plus_5_epoch = EpochNanoseconds::try_from(plus_5_secs).unwrap();
-        let now_plus_5 =
-            Now::plain_datetime_iso_with_provider_and_system_info(plus_5_epoch, cdt, &provider)
-                .unwrap();
-        assert_eq!(now_plus_5.second(), 33);
+        let plus_5_now = NowBuilder::default()
+            .with_system_nanoseconds(plus_5_epoch)
+            .with_system_zone(cdt)
+            .build();
+        let plus_5_pdt = plus_5_now
+            .plain_date_time_iso_with_provider(None, &provider)
+            .unwrap();
+        assert_eq!(plus_5_pdt.second(), 33);
 
-        let duration = now
-            .until(&now_plus_5, DifferenceSettings::default())
+        let duration = cdt_datetime
+            .until(&plus_5_pdt, DifferenceSettings::default())
             .unwrap();
         assert_eq!(duration.hours(), 0);
         assert_eq!(duration.minutes(), 0);
@@ -240,14 +197,15 @@ mod tests {
     #[cfg(all(feature = "tzdb", feature = "sys", feature = "compiled_data"))]
     #[test]
     fn now_datetime_test() {
+        use crate::Temporal;
         use std::thread;
         use std::time::Duration as StdDuration;
 
         let sleep = 2;
 
-        let before = Now::plain_datetime_iso(None).unwrap();
+        let before = Temporal::now().plain_date_time_iso(None).unwrap();
         thread::sleep(StdDuration::from_secs(sleep));
-        let after = Now::plain_datetime_iso(None).unwrap();
+        let after = Temporal::now().plain_date_time_iso(None).unwrap();
 
         let diff = after.since(&before, DifferenceSettings::default()).unwrap();
 

--- a/src/builtins/core/timezone.rs
+++ b/src/builtins/core/timezone.rs
@@ -16,7 +16,7 @@ use crate::{
     builtins::core::{duration::normalized::NormalizedTimeDuration, Instant},
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::Disambiguation,
-    time::EpochNanoseconds,
+    unix_time::EpochNanoseconds,
     TemporalError, TemporalResult, ZonedDateTime,
 };
 use crate::{Calendar, Sign};

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -26,7 +26,7 @@ use crate::{
     provider::{TimeZoneProvider, TransitionDirection},
     rounding::{IncrementRounder, Round},
     temporal_assert,
-    time::EpochNanoseconds,
+    unix_time::EpochNanoseconds,
     MonthCode, Sign, TemporalError, TemporalResult, TemporalUnwrap,
 };
 
@@ -1394,8 +1394,8 @@ mod tests {
             RoundingIncrement, RoundingMode, RoundingOptions, Unit,
         },
         partial::{PartialDate, PartialTime, PartialZonedDateTime},
-        time::EpochNanoseconds,
         tzdb::FsTzdbProvider,
+        unix_time::EpochNanoseconds,
         Calendar, MonthCode, TimeZone,
     };
     use core::str::FromStr;

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -38,7 +38,7 @@ use crate::{
     options::{ArithmeticOverflow, ResolvedRoundingOptions, Unit},
     rounding::{IncrementRounder, Round},
     temporal_assert,
-    time::EpochNanoseconds,
+    unix_time::EpochNanoseconds,
     utils, TemporalResult, TemporalUnwrap, NS_PER_DAY,
 };
 use icu_calendar::{Date as IcuDate, Iso};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,11 +86,15 @@ use core::cmp::Ordering;
 /// Re-export of `TinyAsciiStr` from `tinystr`.
 pub use tinystr::TinyAsciiStr;
 
+/// The `Temporal` result type
+pub type TemporalResult<T> = Result<T, TemporalError>;
+
 #[doc(inline)]
 pub use error::TemporalError;
 
-/// The `Temporal` result type
-pub type TemporalResult<T> = Result<T, TemporalError>;
+#[cfg(feature = "sys")]
+#[doc(inline)]
+pub use sys::Temporal;
 
 pub mod partial {
     //! Partial Date/Time component records.
@@ -103,15 +107,21 @@ pub mod partial {
 }
 
 // TODO: Potentially bikeshed how `EpochNanoseconds` should be exported.
-pub mod time {
+pub mod unix_time {
     pub use crate::epoch_nanoseconds::EpochNanoseconds;
+}
+
+/// The `Now` module includes type for building a Now.
+pub mod now {
+    pub use crate::builtins::{Now, NowBuilder};
 }
 
 pub use crate::builtins::{
     calendar::{Calendar, MonthCode},
     core::timezone::{TimeZone, UtcOffset},
-    DateDuration, Duration, Instant, Now, PlainDate, PlainDateTime, PlainMonthDay, PlainTime,
-    PlainYearMonth, TimeDuration, ZonedDateTime,
+    core::DateDuration,
+    Duration, Instant, PlainDate, PlainDateTime, PlainMonthDay, PlainTime, PlainYearMonth,
+    TimeDuration, ZonedDateTime,
 };
 
 /// A library specific trait for unwrapping assertions.

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -2,7 +2,7 @@
 
 use core::str::FromStr;
 
-use crate::{iso::IsoDateTime, time::EpochNanoseconds, TemporalResult};
+use crate::{iso::IsoDateTime, unix_time::EpochNanoseconds, TemporalResult};
 use alloc::vec::Vec;
 
 /// `TimeZoneOffset` represents the number of seconds to be added to UT in order to determine local time.

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,23 +1,66 @@
-use alloc::string::String;
-
+use crate::builtins::Now;
+use crate::builtins::NowBuilder;
 use crate::TemporalResult;
 
+use crate::unix_time::EpochNanoseconds;
 use crate::TemporalError;
+use crate::TimeZone;
 use alloc::string::ToString;
 use web_time::{SystemTime, UNIX_EPOCH};
 
 // TODO: Need to implement SystemTime handling for non_std.
 
+// TODO: Look into and potentially implement a `SystemTime` struct allows
+// providing closures or trait implementations that can then
+// be used to construct [`Now`]. Basically `Temporal` but with
+// traits or closures.
+//
+// Temporal could then be something like:
+//
+// pub struct Temporal(SystemTime<DefaultSystemClock, DefaultSystemTimeZone>)
+//
+
+#[cfg(feature = "sys")]
+pub struct Temporal;
+
+#[cfg(feature = "sys")]
+impl Temporal {
+    /// Returns a [`Now`] with the default system time and time zone.
+    ///
+    /// ## Panics
+    ///
+    /// This API can panic if reading the values from the system
+    /// fails or the retreived values are not valid.
+    ///
+    /// For the non-panicking version of this API, see [`Self::try_now`].
+    pub fn now() -> Now {
+        Self::try_now().expect("failed to retrieve and validate system values.")
+    }
+
+    /// Returns a [`Now`] with the default system time and time zone.
+    pub fn try_now() -> TemporalResult<Now> {
+        Ok(NowBuilder::default()
+            .with_system_zone(get_system_timezone()?)
+            .with_system_nanoseconds(get_system_nanoseconds()?)
+            .build())
+    }
+}
+
+#[cfg(feature = "sys")]
 #[inline]
-pub(crate) fn get_system_timezone() -> TemporalResult<String> {
-    iana_time_zone::get_timezone().map_err(|e| TemporalError::general(e.to_string()))
+pub(crate) fn get_system_timezone() -> TemporalResult<TimeZone> {
+    iana_time_zone::get_timezone()
+        .map(|s| TimeZone::try_from_identifier_str(&s))
+        .map_err(|e| TemporalError::general(e.to_string()))?
 }
 
 /// Returns the system time in nanoseconds.
 #[cfg(feature = "sys")]
-pub(crate) fn get_system_nanoseconds() -> TemporalResult<u128> {
+pub(crate) fn get_system_nanoseconds() -> TemporalResult<EpochNanoseconds> {
+    use crate::unix_time::EpochNanoseconds;
+
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|e| TemporalError::general(e.to_string()))
-        .map(|d| d.as_nanos())
+        .map(|d| EpochNanoseconds::try_from(d.as_nanos()))?
 }

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -52,7 +52,7 @@ use tzif::{
 use crate::{
     iso::IsoDateTime,
     provider::{TimeZoneOffset, TimeZoneProvider, TransitionDirection},
-    time::EpochNanoseconds,
+    unix_time::EpochNanoseconds,
     utils, TemporalError, TemporalResult,
 };
 


### PR DESCRIPTION
This PR implements a builder API for now and closes #249.

It has some notable changes to the approach to `Now`.

Mainly `Now` is essentially cannot be built without using the new `NowBuilder` and any method called on `Now` consumes it.

For general purpose, a `Temporal` namespace struct was created with `now` and `try_now` methods, which uses the `NowBuilder` to construct a `Now` with values from the system.

This does differ a bit from the specification in that we are eagerly calling the host system time zone, rather than lazily when the user time zone is `None`. But I think this can still be worked around on the engine side if lazily calling is preferred and is more a place where the native Rust API will differ from the engine implementation. The work around to this is a trait based approach that is available to see on the `now-builder` branch, but I think this a simpler and cleaner approach than leaning on traits.

List of changes:

- `Now` updated and `NowBuilder` added.
- Feature flagged `Temporal` struct
- `time` module renamed to `unix_time`