### PR TITLE
Make duration capi getters non-optional

### DIFF
--- a/temporal_capi/bindings/cpp/temporal_rs/Duration.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Duration.d.hpp
@@ -67,9 +67,9 @@ public:
 
   inline int64_t milliseconds() const;
 
-  inline std::optional<double> microseconds() const;
+  inline double microseconds() const;
 
-  inline std::optional<double> nanoseconds() const;
+  inline double nanoseconds() const;
 
   inline temporal_rs::Sign sign() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/Duration.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Duration.hpp
@@ -61,11 +61,9 @@ namespace capi {
 
     int64_t temporal_rs_Duration_milliseconds(const temporal_rs::capi::Duration* self);
 
-    typedef struct temporal_rs_Duration_microseconds_result {union {double ok; }; bool is_ok;} temporal_rs_Duration_microseconds_result;
-    temporal_rs_Duration_microseconds_result temporal_rs_Duration_microseconds(const temporal_rs::capi::Duration* self);
+    double temporal_rs_Duration_microseconds(const temporal_rs::capi::Duration* self);
 
-    typedef struct temporal_rs_Duration_nanoseconds_result {union {double ok; }; bool is_ok;} temporal_rs_Duration_nanoseconds_result;
-    temporal_rs_Duration_nanoseconds_result temporal_rs_Duration_nanoseconds(const temporal_rs::capi::Duration* self);
+    double temporal_rs_Duration_nanoseconds(const temporal_rs::capi::Duration* self);
 
     temporal_rs::capi::Sign temporal_rs_Duration_sign(const temporal_rs::capi::Duration* self);
 
@@ -180,14 +178,14 @@ inline int64_t temporal_rs::Duration::milliseconds() const {
   return result;
 }
 
-inline std::optional<double> temporal_rs::Duration::microseconds() const {
+inline double temporal_rs::Duration::microseconds() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_microseconds(this->AsFFI());
-  return result.is_ok ? std::optional<double>(result.ok) : std::nullopt;
+  return result;
 }
 
-inline std::optional<double> temporal_rs::Duration::nanoseconds() const {
+inline double temporal_rs::Duration::nanoseconds() const {
   auto result = temporal_rs::capi::temporal_rs_Duration_nanoseconds(this->AsFFI());
-  return result.is_ok ? std::optional<double>(result.ok) : std::nullopt;
+  return result;
 }
 
 inline temporal_rs::Sign temporal_rs::Duration::sign() const {

--- a/temporal_capi/src/duration.rs
+++ b/temporal_capi/src/duration.rs
@@ -207,11 +207,19 @@ pub mod ffi {
         pub fn milliseconds(&self) -> i64 {
             self.0.milliseconds()
         }
-        pub fn microseconds(&self) -> Option<f64> {
-            f64::from_i128(self.0.microseconds())
+        pub fn microseconds(&self) -> f64 {
+            // The error case should never occur since
+            // duration values are clamped within range
+            //
+            // https://github.com/boa-dev/temporal/issues/189
+            f64::from_i128(self.0.microseconds()).unwrap_or(0.)
         }
-        pub fn nanoseconds(&self) -> Option<f64> {
-            f64::from_i128(self.0.nanoseconds())
+        pub fn nanoseconds(&self) -> f64 {
+            // The error case should never occur since
+            // duration values are clamped within range
+            //
+            // https://github.com/boa-dev/temporal/issues/189
+            f64::from_i128(self.0.nanoseconds()).unwrap_or(0.)
         }
 
         pub fn sign(&self) -> Sign {


### PR DESCRIPTION
Alternative to https://github.com/boa-dev/temporal/pull/313


This should only be merged if the `temporal_capi 0.0.8` release has not happened yet, since these APIs are not yet used in v8 but will be very shortly.


(In general, if the C++ API is changing I'd love to have a heads up and perhaps a gradual migration in cases where v8 uses the API since it makes upgrades a bit more annoying)