### PR TITLE
Correctly validate largestUnit when constructing from DifferenceSettings

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -183,10 +183,11 @@ impl ResolvedRoundingOptions {
     ) -> TemporalResult<Self> {
         // 1. NOTE: The following steps read options and perform independent validation in alphabetical order.
         // 2. Let largestUnit be ? GetUnitValuedOption(options, "largestUnit", unitGroup, auto).
+        unit_group.validate_unit(options.largest_unit, Some(Unit::Auto))?;
 
         // 4. Let resolvedOptions be ? SnapshotOwnProperties(? GetOptionsObject(options), null).
         // 5. Let settings be ? GetDifferenceSettings(operation, resolvedOptions, DATE, « », "day", "day").
-        unit_group.validate_unit(options.largest_unit, None)?;
+
         // 3. If disallowedUnits contains largestUnit, throw a RangeError exception.
         // 4. Let roundingIncrement be ? GetRoundingIncrementOption(options).
         let increment = options.increment.unwrap_or_default();


### PR DESCRIPTION
Without this, `instance.since(instant2, {})` fails since it disallows Auto