### PR TITLE
Switch FFI calendar APIs over to using AnyCalendarKind for input

### DIFF
--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -178,6 +178,12 @@ impl Calendar {
         matches!(self.0 .0, AnyCalendar::Iso(_))
     }
 
+    /// Returns the kind of this calendar
+    #[inline]
+    pub fn kind(&self) -> AnyCalendarKind {
+        self.0 .0.kind()
+    }
+
     /// `CalendarDateFromFields`
     pub fn date_from_partial(
         &self,

--- a/temporal_capi/bindings/c/Calendar.h
+++ b/temporal_capi/bindings/c/Calendar.h
@@ -86,6 +86,8 @@ uint16_t temporal_rs_Calendar_months_in_year(const Calendar* self, IsoDate date)
 
 bool temporal_rs_Calendar_in_leap_year(const Calendar* self, IsoDate date);
 
+AnyCalendarKind temporal_rs_Calendar_kind(const Calendar* self);
+
 void temporal_rs_Calendar_destroy(Calendar* self);
 
 

--- a/temporal_capi/bindings/c/PlainDate.h
+++ b/temporal_capi/bindings/c/PlainDate.h
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
+#include "AnyCalendarKind.d.h"
 #include "ArithmeticOverflow.d.h"
 #include "Calendar.d.h"
 #include "DifferenceSettings.d.h"
@@ -27,13 +28,13 @@
 
 
 typedef struct temporal_rs_PlainDate_create_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_create_result;
-temporal_rs_PlainDate_create_result temporal_rs_PlainDate_create(int32_t year, uint8_t month, uint8_t day, const Calendar* calendar);
+temporal_rs_PlainDate_create_result temporal_rs_PlainDate_create(int32_t year, uint8_t month, uint8_t day, AnyCalendarKind calendar);
 
 typedef struct temporal_rs_PlainDate_try_create_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_try_create_result;
-temporal_rs_PlainDate_try_create_result temporal_rs_PlainDate_try_create(int32_t year, uint8_t month, uint8_t day, const Calendar* calendar);
+temporal_rs_PlainDate_try_create_result temporal_rs_PlainDate_try_create(int32_t year, uint8_t month, uint8_t day, AnyCalendarKind calendar);
 
 typedef struct temporal_rs_PlainDate_create_with_overflow_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_create_with_overflow_result;
-temporal_rs_PlainDate_create_with_overflow_result temporal_rs_PlainDate_create_with_overflow(int32_t year, uint8_t month, uint8_t day, const Calendar* calendar, ArithmeticOverflow overflow);
+temporal_rs_PlainDate_create_with_overflow_result temporal_rs_PlainDate_create_with_overflow(int32_t year, uint8_t month, uint8_t day, AnyCalendarKind calendar, ArithmeticOverflow overflow);
 
 typedef struct temporal_rs_PlainDate_from_partial_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_partial_result;
 temporal_rs_PlainDate_from_partial_result temporal_rs_PlainDate_from_partial(PartialDate partial, ArithmeticOverflow_option overflow);
@@ -42,7 +43,7 @@ typedef struct temporal_rs_PlainDate_with_result {union {PlainDate* ok; Temporal
 temporal_rs_PlainDate_with_result temporal_rs_PlainDate_with(const PlainDate* self, PartialDate partial, ArithmeticOverflow_option overflow);
 
 typedef struct temporal_rs_PlainDate_with_calendar_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_with_calendar_result;
-temporal_rs_PlainDate_with_calendar_result temporal_rs_PlainDate_with_calendar(const PlainDate* self, const Calendar* calendar);
+temporal_rs_PlainDate_with_calendar_result temporal_rs_PlainDate_with_calendar(const PlainDate* self, AnyCalendarKind calendar);
 
 typedef struct temporal_rs_PlainDate_from_utf8_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_utf8_result;
 temporal_rs_PlainDate_from_utf8_result temporal_rs_PlainDate_from_utf8(DiplomatStringView s);

--- a/temporal_capi/bindings/c/PlainDateTime.h
+++ b/temporal_capi/bindings/c/PlainDateTime.h
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
+#include "AnyCalendarKind.d.h"
 #include "ArithmeticOverflow.d.h"
 #include "Calendar.d.h"
 #include "DifferenceSettings.d.h"
@@ -27,10 +28,10 @@
 
 
 typedef struct temporal_rs_PlainDateTime_create_result {union {PlainDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_create_result;
-temporal_rs_PlainDateTime_create_result temporal_rs_PlainDateTime_create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, const Calendar* calendar);
+temporal_rs_PlainDateTime_create_result temporal_rs_PlainDateTime_create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, AnyCalendarKind calendar);
 
 typedef struct temporal_rs_PlainDateTime_try_create_result {union {PlainDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_try_create_result;
-temporal_rs_PlainDateTime_try_create_result temporal_rs_PlainDateTime_try_create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, const Calendar* calendar);
+temporal_rs_PlainDateTime_try_create_result temporal_rs_PlainDateTime_try_create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, AnyCalendarKind calendar);
 
 typedef struct temporal_rs_PlainDateTime_from_partial_result {union {PlainDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_partial_result;
 temporal_rs_PlainDateTime_from_partial_result temporal_rs_PlainDateTime_from_partial(PartialDateTime partial, ArithmeticOverflow_option overflow);
@@ -42,7 +43,7 @@ typedef struct temporal_rs_PlainDateTime_with_time_result {union {PlainDateTime*
 temporal_rs_PlainDateTime_with_time_result temporal_rs_PlainDateTime_with_time(const PlainDateTime* self, const PlainTime* time);
 
 typedef struct temporal_rs_PlainDateTime_with_calendar_result {union {PlainDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_with_calendar_result;
-temporal_rs_PlainDateTime_with_calendar_result temporal_rs_PlainDateTime_with_calendar(const PlainDateTime* self, const Calendar* calendar);
+temporal_rs_PlainDateTime_with_calendar_result temporal_rs_PlainDateTime_with_calendar(const PlainDateTime* self, AnyCalendarKind calendar);
 
 typedef struct temporal_rs_PlainDateTime_from_utf8_result {union {PlainDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_utf8_result;
 temporal_rs_PlainDateTime_from_utf8_result temporal_rs_PlainDateTime_from_utf8(DiplomatStringView s);

--- a/temporal_capi/bindings/c/PlainMonthDay.h
+++ b/temporal_capi/bindings/c/PlainMonthDay.h
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
+#include "AnyCalendarKind.d.h"
 #include "ArithmeticOverflow.d.h"
 #include "Calendar.d.h"
 #include "PartialDate.d.h"
@@ -21,7 +22,7 @@
 
 
 typedef struct temporal_rs_PlainMonthDay_create_with_overflow_result {union {PlainMonthDay* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_create_with_overflow_result;
-temporal_rs_PlainMonthDay_create_with_overflow_result temporal_rs_PlainMonthDay_create_with_overflow(uint8_t month, uint8_t day, const Calendar* calendar, ArithmeticOverflow overflow, OptionI32 ref_year);
+temporal_rs_PlainMonthDay_create_with_overflow_result temporal_rs_PlainMonthDay_create_with_overflow(uint8_t month, uint8_t day, AnyCalendarKind calendar, ArithmeticOverflow overflow, OptionI32 ref_year);
 
 typedef struct temporal_rs_PlainMonthDay_with_result {union {PlainMonthDay* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_with_result;
 temporal_rs_PlainMonthDay_with_result temporal_rs_PlainMonthDay_with(const PlainMonthDay* self, PartialDate partial, ArithmeticOverflow overflow);

--- a/temporal_capi/bindings/c/PlainYearMonth.h
+++ b/temporal_capi/bindings/c/PlainYearMonth.h
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
+#include "AnyCalendarKind.d.h"
 #include "ArithmeticOverflow.d.h"
 #include "Calendar.d.h"
 #include "DifferenceSettings.d.h"
@@ -23,7 +24,7 @@
 
 
 typedef struct temporal_rs_PlainYearMonth_create_with_overflow_result {union {PlainYearMonth* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_create_with_overflow_result;
-temporal_rs_PlainYearMonth_create_with_overflow_result temporal_rs_PlainYearMonth_create_with_overflow(int32_t year, uint8_t month, OptionU8 reference_day, const Calendar* calendar, ArithmeticOverflow overflow);
+temporal_rs_PlainYearMonth_create_with_overflow_result temporal_rs_PlainYearMonth_create_with_overflow(int32_t year, uint8_t month, OptionU8 reference_day, AnyCalendarKind calendar, ArithmeticOverflow overflow);
 
 typedef struct temporal_rs_PlainYearMonth_with_result {union {PlainYearMonth* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_with_result;
 temporal_rs_PlainYearMonth_with_result temporal_rs_PlainYearMonth_with(const PlainYearMonth* self, PartialDate partial, ArithmeticOverflow_option overflow);

--- a/temporal_capi/bindings/cpp/temporal_rs/Calendar.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Calendar.d.hpp
@@ -89,6 +89,11 @@ public:
 
   inline bool in_leap_year(temporal_rs::IsoDate date) const;
 
+  /**
+   * Returns the kind of this calendar
+   */
+  inline temporal_rs::AnyCalendarKind kind() const;
+
   inline const temporal_rs::capi::Calendar* AsFFI() const;
   inline temporal_rs::capi::Calendar* AsFFI();
   inline static const temporal_rs::Calendar* FromFFI(const temporal_rs::capi::Calendar* ptr);

--- a/temporal_capi/bindings/cpp/temporal_rs/Calendar.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Calendar.hpp
@@ -89,6 +89,8 @@ namespace capi {
 
     bool temporal_rs_Calendar_in_leap_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
 
+    temporal_rs::capi::AnyCalendarKind temporal_rs_Calendar_kind(const temporal_rs::capi::Calendar* self);
+
     void temporal_rs_Calendar_destroy(Calendar* self);
 
     } // extern "C"
@@ -246,6 +248,11 @@ inline bool temporal_rs::Calendar::in_leap_year(temporal_rs::IsoDate date) const
   auto result = temporal_rs::capi::temporal_rs_Calendar_in_leap_year(this->AsFFI(),
     date.AsFFI());
   return result;
+}
+
+inline temporal_rs::AnyCalendarKind temporal_rs::Calendar::kind() const {
+  auto result = temporal_rs::capi::temporal_rs_Calendar_kind(this->AsFFI());
+  return temporal_rs::AnyCalendarKind::FromFFI(result);
 }
 
 inline const temporal_rs::capi::Calendar* temporal_rs::Calendar::AsFFI() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
@@ -29,6 +29,7 @@ class PlainYearMonth;
 struct DifferenceSettings;
 struct PartialDate;
 struct TemporalError;
+class AnyCalendarKind;
 class ArithmeticOverflow;
 class DisplayCalendar;
 }
@@ -44,17 +45,17 @@ namespace temporal_rs {
 class PlainDate {
 public:
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> create(int32_t year, uint8_t month, uint8_t day, const temporal_rs::Calendar& calendar);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> create(int32_t year, uint8_t month, uint8_t day, temporal_rs::AnyCalendarKind calendar);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> try_create(int32_t year, uint8_t month, uint8_t day, const temporal_rs::Calendar& calendar);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> try_create(int32_t year, uint8_t month, uint8_t day, temporal_rs::AnyCalendarKind calendar);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> create_with_overflow(int32_t year, uint8_t month, uint8_t day, const temporal_rs::Calendar& calendar, temporal_rs::ArithmeticOverflow overflow);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> create_with_overflow(int32_t year, uint8_t month, uint8_t day, temporal_rs::AnyCalendarKind calendar, temporal_rs::ArithmeticOverflow overflow);
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_partial(temporal_rs::PartialDate partial, std::optional<temporal_rs::ArithmeticOverflow> overflow);
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> with(temporal_rs::PartialDate partial, std::optional<temporal_rs::ArithmeticOverflow> overflow) const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> with_calendar(const temporal_rs::Calendar& calendar) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> with_calendar(temporal_rs::AnyCalendarKind calendar) const;
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_utf8(std::string_view s);
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <cstdlib>
 #include "../diplomat_runtime.hpp"
+#include "AnyCalendarKind.hpp"
 #include "ArithmeticOverflow.hpp"
 #include "Calendar.hpp"
 #include "DifferenceSettings.hpp"
@@ -30,13 +31,13 @@ namespace capi {
     extern "C" {
 
     typedef struct temporal_rs_PlainDate_create_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_create_result;
-    temporal_rs_PlainDate_create_result temporal_rs_PlainDate_create(int32_t year, uint8_t month, uint8_t day, const temporal_rs::capi::Calendar* calendar);
+    temporal_rs_PlainDate_create_result temporal_rs_PlainDate_create(int32_t year, uint8_t month, uint8_t day, temporal_rs::capi::AnyCalendarKind calendar);
 
     typedef struct temporal_rs_PlainDate_try_create_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_try_create_result;
-    temporal_rs_PlainDate_try_create_result temporal_rs_PlainDate_try_create(int32_t year, uint8_t month, uint8_t day, const temporal_rs::capi::Calendar* calendar);
+    temporal_rs_PlainDate_try_create_result temporal_rs_PlainDate_try_create(int32_t year, uint8_t month, uint8_t day, temporal_rs::capi::AnyCalendarKind calendar);
 
     typedef struct temporal_rs_PlainDate_create_with_overflow_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_create_with_overflow_result;
-    temporal_rs_PlainDate_create_with_overflow_result temporal_rs_PlainDate_create_with_overflow(int32_t year, uint8_t month, uint8_t day, const temporal_rs::capi::Calendar* calendar, temporal_rs::capi::ArithmeticOverflow overflow);
+    temporal_rs_PlainDate_create_with_overflow_result temporal_rs_PlainDate_create_with_overflow(int32_t year, uint8_t month, uint8_t day, temporal_rs::capi::AnyCalendarKind calendar, temporal_rs::capi::ArithmeticOverflow overflow);
 
     typedef struct temporal_rs_PlainDate_from_partial_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_partial_result;
     temporal_rs_PlainDate_from_partial_result temporal_rs_PlainDate_from_partial(temporal_rs::capi::PartialDate partial, temporal_rs::capi::ArithmeticOverflow_option overflow);
@@ -45,7 +46,7 @@ namespace capi {
     temporal_rs_PlainDate_with_result temporal_rs_PlainDate_with(const temporal_rs::capi::PlainDate* self, temporal_rs::capi::PartialDate partial, temporal_rs::capi::ArithmeticOverflow_option overflow);
 
     typedef struct temporal_rs_PlainDate_with_calendar_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_with_calendar_result;
-    temporal_rs_PlainDate_with_calendar_result temporal_rs_PlainDate_with_calendar(const temporal_rs::capi::PlainDate* self, const temporal_rs::capi::Calendar* calendar);
+    temporal_rs_PlainDate_with_calendar_result temporal_rs_PlainDate_with_calendar(const temporal_rs::capi::PlainDate* self, temporal_rs::capi::AnyCalendarKind calendar);
 
     typedef struct temporal_rs_PlainDate_from_utf8_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_utf8_result;
     temporal_rs_PlainDate_from_utf8_result temporal_rs_PlainDate_from_utf8(diplomat::capi::DiplomatStringView s);
@@ -131,7 +132,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::create(int32_t year, uint8_t month, uint8_t day, const temporal_rs::Calendar& calendar) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::create(int32_t year, uint8_t month, uint8_t day, temporal_rs::AnyCalendarKind calendar) {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_create(year,
     month,
     day,
@@ -139,7 +140,7 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::Te
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::try_create(int32_t year, uint8_t month, uint8_t day, const temporal_rs::Calendar& calendar) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::try_create(int32_t year, uint8_t month, uint8_t day, temporal_rs::AnyCalendarKind calendar) {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_try_create(year,
     month,
     day,
@@ -147,7 +148,7 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::Te
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::create_with_overflow(int32_t year, uint8_t month, uint8_t day, const temporal_rs::Calendar& calendar, temporal_rs::ArithmeticOverflow overflow) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::create_with_overflow(int32_t year, uint8_t month, uint8_t day, temporal_rs::AnyCalendarKind calendar, temporal_rs::ArithmeticOverflow overflow) {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_create_with_overflow(year,
     month,
     day,
@@ -169,7 +170,7 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::Te
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::with_calendar(const temporal_rs::Calendar& calendar) const {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::with_calendar(temporal_rs::AnyCalendarKind calendar) const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_with_calendar(this->AsFFI(),
     calendar.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
@@ -27,6 +27,7 @@ struct PartialDateTime;
 struct RoundingOptions;
 struct TemporalError;
 struct ToStringRoundingOptions;
+class AnyCalendarKind;
 class ArithmeticOverflow;
 class DisplayCalendar;
 }
@@ -42,9 +43,9 @@ namespace temporal_rs {
 class PlainDateTime {
 public:
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, const temporal_rs::Calendar& calendar);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, temporal_rs::AnyCalendarKind calendar);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> try_create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, const temporal_rs::Calendar& calendar);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> try_create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, temporal_rs::AnyCalendarKind calendar);
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> from_partial(temporal_rs::PartialDateTime partial, std::optional<temporal_rs::ArithmeticOverflow> overflow);
 
@@ -52,7 +53,7 @@ public:
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> with_time(const temporal_rs::PlainTime& time) const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> with_calendar(const temporal_rs::Calendar& calendar) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> with_calendar(temporal_rs::AnyCalendarKind calendar) const;
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> from_utf8(std::string_view s);
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <cstdlib>
 #include "../diplomat_runtime.hpp"
+#include "AnyCalendarKind.hpp"
 #include "ArithmeticOverflow.hpp"
 #include "Calendar.hpp"
 #include "DifferenceSettings.hpp"
@@ -30,10 +31,10 @@ namespace capi {
     extern "C" {
 
     typedef struct temporal_rs_PlainDateTime_create_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_create_result;
-    temporal_rs_PlainDateTime_create_result temporal_rs_PlainDateTime_create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, const temporal_rs::capi::Calendar* calendar);
+    temporal_rs_PlainDateTime_create_result temporal_rs_PlainDateTime_create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, temporal_rs::capi::AnyCalendarKind calendar);
 
     typedef struct temporal_rs_PlainDateTime_try_create_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_try_create_result;
-    temporal_rs_PlainDateTime_try_create_result temporal_rs_PlainDateTime_try_create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, const temporal_rs::capi::Calendar* calendar);
+    temporal_rs_PlainDateTime_try_create_result temporal_rs_PlainDateTime_try_create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, temporal_rs::capi::AnyCalendarKind calendar);
 
     typedef struct temporal_rs_PlainDateTime_from_partial_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_partial_result;
     temporal_rs_PlainDateTime_from_partial_result temporal_rs_PlainDateTime_from_partial(temporal_rs::capi::PartialDateTime partial, temporal_rs::capi::ArithmeticOverflow_option overflow);
@@ -45,7 +46,7 @@ namespace capi {
     temporal_rs_PlainDateTime_with_time_result temporal_rs_PlainDateTime_with_time(const temporal_rs::capi::PlainDateTime* self, const temporal_rs::capi::PlainTime* time);
 
     typedef struct temporal_rs_PlainDateTime_with_calendar_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_with_calendar_result;
-    temporal_rs_PlainDateTime_with_calendar_result temporal_rs_PlainDateTime_with_calendar(const temporal_rs::capi::PlainDateTime* self, const temporal_rs::capi::Calendar* calendar);
+    temporal_rs_PlainDateTime_with_calendar_result temporal_rs_PlainDateTime_with_calendar(const temporal_rs::capi::PlainDateTime* self, temporal_rs::capi::AnyCalendarKind calendar);
 
     typedef struct temporal_rs_PlainDateTime_from_utf8_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_utf8_result;
     temporal_rs_PlainDateTime_from_utf8_result temporal_rs_PlainDateTime_from_utf8(diplomat::capi::DiplomatStringView s);
@@ -142,7 +143,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, const temporal_rs::Calendar& calendar) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, temporal_rs::AnyCalendarKind calendar) {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_create(year,
     month,
     day,
@@ -156,7 +157,7 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDateTime>>(std::unique_ptr<temporal_rs::PlainDateTime>(temporal_rs::PlainDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::try_create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, const temporal_rs::Calendar& calendar) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::try_create(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint16_t millisecond, uint16_t microsecond, uint16_t nanosecond, temporal_rs::AnyCalendarKind calendar) {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_try_create(year,
     month,
     day,
@@ -189,7 +190,7 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDateTime>>(std::unique_ptr<temporal_rs::PlainDateTime>(temporal_rs::PlainDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::with_calendar(const temporal_rs::Calendar& calendar) const {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::with_calendar(temporal_rs::AnyCalendarKind calendar) const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_with_calendar(this->AsFFI(),
     calendar.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDateTime>>(std::unique_ptr<temporal_rs::PlainDateTime>(temporal_rs::PlainDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
@@ -20,6 +20,7 @@ namespace capi { struct PlainMonthDay; }
 class PlainMonthDay;
 struct PartialDate;
 struct TemporalError;
+class AnyCalendarKind;
 class ArithmeticOverflow;
 }
 
@@ -34,7 +35,7 @@ namespace temporal_rs {
 class PlainMonthDay {
 public:
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> create_with_overflow(uint8_t month, uint8_t day, const temporal_rs::Calendar& calendar, temporal_rs::ArithmeticOverflow overflow, std::optional<int32_t> ref_year);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> create_with_overflow(uint8_t month, uint8_t day, temporal_rs::AnyCalendarKind calendar, temporal_rs::ArithmeticOverflow overflow, std::optional<int32_t> ref_year);
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> with(temporal_rs::PartialDate partial, temporal_rs::ArithmeticOverflow overflow) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <cstdlib>
 #include "../diplomat_runtime.hpp"
+#include "AnyCalendarKind.hpp"
 #include "ArithmeticOverflow.hpp"
 #include "Calendar.hpp"
 #include "PartialDate.hpp"
@@ -24,7 +25,7 @@ namespace capi {
     extern "C" {
 
     typedef struct temporal_rs_PlainMonthDay_create_with_overflow_result {union {temporal_rs::capi::PlainMonthDay* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_create_with_overflow_result;
-    temporal_rs_PlainMonthDay_create_with_overflow_result temporal_rs_PlainMonthDay_create_with_overflow(uint8_t month, uint8_t day, const temporal_rs::capi::Calendar* calendar, temporal_rs::capi::ArithmeticOverflow overflow, diplomat::capi::OptionI32 ref_year);
+    temporal_rs_PlainMonthDay_create_with_overflow_result temporal_rs_PlainMonthDay_create_with_overflow(uint8_t month, uint8_t day, temporal_rs::capi::AnyCalendarKind calendar, temporal_rs::capi::ArithmeticOverflow overflow, diplomat::capi::OptionI32 ref_year);
 
     typedef struct temporal_rs_PlainMonthDay_with_result {union {temporal_rs::capi::PlainMonthDay* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_with_result;
     temporal_rs_PlainMonthDay_with_result temporal_rs_PlainMonthDay_with(const temporal_rs::capi::PlainMonthDay* self, temporal_rs::capi::PartialDate partial, temporal_rs::capi::ArithmeticOverflow overflow);
@@ -58,7 +59,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> temporal_rs::PlainMonthDay::create_with_overflow(uint8_t month, uint8_t day, const temporal_rs::Calendar& calendar, temporal_rs::ArithmeticOverflow overflow, std::optional<int32_t> ref_year) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> temporal_rs::PlainMonthDay::create_with_overflow(uint8_t month, uint8_t day, temporal_rs::AnyCalendarKind calendar, temporal_rs::ArithmeticOverflow overflow, std::optional<int32_t> ref_year) {
   auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_create_with_overflow(month,
     day,
     calendar.AsFFI(),

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.d.hpp
@@ -23,6 +23,7 @@ class PlainYearMonth;
 struct DifferenceSettings;
 struct PartialDate;
 struct TemporalError;
+class AnyCalendarKind;
 class ArithmeticOverflow;
 }
 
@@ -37,7 +38,7 @@ namespace temporal_rs {
 class PlainYearMonth {
 public:
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError> create_with_overflow(int32_t year, uint8_t month, std::optional<uint8_t> reference_day, const temporal_rs::Calendar& calendar, temporal_rs::ArithmeticOverflow overflow);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError> create_with_overflow(int32_t year, uint8_t month, std::optional<uint8_t> reference_day, temporal_rs::AnyCalendarKind calendar, temporal_rs::ArithmeticOverflow overflow);
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError> with(temporal_rs::PartialDate partial, std::optional<temporal_rs::ArithmeticOverflow> overflow) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.hpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <cstdlib>
 #include "../diplomat_runtime.hpp"
+#include "AnyCalendarKind.hpp"
 #include "ArithmeticOverflow.hpp"
 #include "Calendar.hpp"
 #include "DifferenceSettings.hpp"
@@ -26,7 +27,7 @@ namespace capi {
     extern "C" {
 
     typedef struct temporal_rs_PlainYearMonth_create_with_overflow_result {union {temporal_rs::capi::PlainYearMonth* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_create_with_overflow_result;
-    temporal_rs_PlainYearMonth_create_with_overflow_result temporal_rs_PlainYearMonth_create_with_overflow(int32_t year, uint8_t month, diplomat::capi::OptionU8 reference_day, const temporal_rs::capi::Calendar* calendar, temporal_rs::capi::ArithmeticOverflow overflow);
+    temporal_rs_PlainYearMonth_create_with_overflow_result temporal_rs_PlainYearMonth_create_with_overflow(int32_t year, uint8_t month, diplomat::capi::OptionU8 reference_day, temporal_rs::capi::AnyCalendarKind calendar, temporal_rs::capi::ArithmeticOverflow overflow);
 
     typedef struct temporal_rs_PlainYearMonth_with_result {union {temporal_rs::capi::PlainYearMonth* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_with_result;
     temporal_rs_PlainYearMonth_with_result temporal_rs_PlainYearMonth_with(const temporal_rs::capi::PlainYearMonth* self, temporal_rs::capi::PartialDate partial, temporal_rs::capi::ArithmeticOverflow_option overflow);
@@ -89,7 +90,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::create_with_overflow(int32_t year, uint8_t month, std::optional<uint8_t> reference_day, const temporal_rs::Calendar& calendar, temporal_rs::ArithmeticOverflow overflow) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::create_with_overflow(int32_t year, uint8_t month, std::optional<uint8_t> reference_day, temporal_rs::AnyCalendarKind calendar, temporal_rs::ArithmeticOverflow overflow) {
   auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_create_with_overflow(year,
     month,
     reference_day.has_value() ? (diplomat::capi::OptionU8{ { reference_day.value() }, true }) : (diplomat::capi::OptionU8{ {}, false }),

--- a/temporal_capi/src/calendar.rs
+++ b/temporal_capi/src/calendar.rs
@@ -187,7 +187,11 @@ pub mod ffi {
         pub fn in_leap_year(&self, date: IsoDate) -> bool {
             self.0.in_leap_year(&date.into())
         }
-
+        /// Returns the kind of this calendar
+        #[inline]
+        pub fn kind(&self) -> AnyCalendarKind {
+            self.0.kind().into()
+        }
         // TODO .fields() (need to pick a convenient way to return vectors or iterators, depending on how the API gets used)
     }
 }

--- a/temporal_capi/src/plain_date.rs
+++ b/temporal_capi/src/plain_date.rs
@@ -6,7 +6,7 @@ use crate::error::ffi::TemporalError;
 #[diplomat::abi_rename = "temporal_rs_{0}"]
 #[diplomat::attr(auto, namespace = "temporal_rs")]
 pub mod ffi {
-    use crate::calendar::ffi::Calendar;
+    use crate::calendar::ffi::{AnyCalendarKind, Calendar};
     use crate::duration::ffi::Duration;
     use crate::error::ffi::TemporalError;
     use crate::options::ffi::{ArithmeticOverflow, DifferenceSettings, DisplayCalendar};
@@ -42,34 +42,44 @@ pub mod ffi {
             year: i32,
             month: u8,
             day: u8,
-            calendar: &Calendar,
+            calendar: AnyCalendarKind,
         ) -> Result<Box<Self>, TemporalError> {
-            temporal_rs::PlainDate::new(year, month, day, calendar.0.clone())
-                .map(|x| Box::new(PlainDate(x)))
-                .map_err(Into::into)
+            temporal_rs::PlainDate::new(
+                year,
+                month,
+                day,
+                temporal_rs::Calendar::new(calendar.into()),
+            )
+            .map(|x| Box::new(PlainDate(x)))
+            .map_err(Into::into)
         }
         pub fn try_create(
             year: i32,
             month: u8,
             day: u8,
-            calendar: &Calendar,
+            calendar: AnyCalendarKind,
         ) -> Result<Box<Self>, TemporalError> {
-            temporal_rs::PlainDate::try_new(year, month, day, calendar.0.clone())
-                .map(|x| Box::new(PlainDate(x)))
-                .map_err(Into::into)
+            temporal_rs::PlainDate::try_new(
+                year,
+                month,
+                day,
+                temporal_rs::Calendar::new(calendar.into()),
+            )
+            .map(|x| Box::new(PlainDate(x)))
+            .map_err(Into::into)
         }
         pub fn create_with_overflow(
             year: i32,
             month: u8,
             day: u8,
-            calendar: &Calendar,
+            calendar: AnyCalendarKind,
             overflow: ArithmeticOverflow,
         ) -> Result<Box<Self>, TemporalError> {
             temporal_rs::PlainDate::new_with_overflow(
                 year,
                 month,
                 day,
-                calendar.0.clone(),
+                temporal_rs::Calendar::new(calendar.into()),
                 overflow.into(),
             )
             .map(|x| Box::new(PlainDate(x)))
@@ -95,9 +105,9 @@ pub mod ffi {
                 .map_err(Into::into)
         }
 
-        pub fn with_calendar(&self, calendar: &Calendar) -> Result<Box<Self>, TemporalError> {
+        pub fn with_calendar(&self, calendar: AnyCalendarKind) -> Result<Box<Self>, TemporalError> {
             self.0
-                .with_calendar(calendar.0.clone())
+                .with_calendar(temporal_rs::Calendar::new(calendar.into()))
                 .map(|x| Box::new(PlainDate(x)))
                 .map_err(Into::into)
         }

--- a/temporal_capi/src/plain_date_time.rs
+++ b/temporal_capi/src/plain_date_time.rs
@@ -4,7 +4,7 @@ use crate::error::ffi::TemporalError;
 #[diplomat::abi_rename = "temporal_rs_{0}"]
 #[diplomat::attr(auto, namespace = "temporal_rs")]
 pub mod ffi {
-    use crate::calendar::ffi::Calendar;
+    use crate::calendar::ffi::{AnyCalendarKind, Calendar};
     use crate::duration::ffi::Duration;
     use crate::error::ffi::TemporalError;
     use alloc::boxed::Box;
@@ -40,7 +40,7 @@ pub mod ffi {
             millisecond: u16,
             microsecond: u16,
             nanosecond: u16,
-            calendar: &Calendar,
+            calendar: AnyCalendarKind,
         ) -> Result<Box<Self>, TemporalError> {
             temporal_rs::PlainDateTime::new(
                 year,
@@ -52,7 +52,7 @@ pub mod ffi {
                 millisecond,
                 microsecond,
                 nanosecond,
-                calendar.0.clone(),
+                temporal_rs::Calendar::new(calendar.into()),
             )
             .map(|x| Box::new(PlainDateTime(x)))
             .map_err(Into::into)
@@ -67,7 +67,7 @@ pub mod ffi {
             millisecond: u16,
             microsecond: u16,
             nanosecond: u16,
-            calendar: &Calendar,
+            calendar: AnyCalendarKind,
         ) -> Result<Box<Self>, TemporalError> {
             temporal_rs::PlainDateTime::try_new(
                 year,
@@ -79,7 +79,7 @@ pub mod ffi {
                 millisecond,
                 microsecond,
                 nanosecond,
-                calendar.0.clone(),
+                temporal_rs::Calendar::new(calendar.into()),
             )
             .map(|x| Box::new(PlainDateTime(x)))
             .map_err(Into::into)
@@ -111,9 +111,9 @@ pub mod ffi {
                 .map_err(Into::into)
         }
 
-        pub fn with_calendar(&self, calendar: &Calendar) -> Result<Box<Self>, TemporalError> {
+        pub fn with_calendar(&self, calendar: AnyCalendarKind) -> Result<Box<Self>, TemporalError> {
             self.0
-                .with_calendar(calendar.0.clone())
+                .with_calendar(temporal_rs::Calendar::new(calendar.into()))
                 .map(|x| Box::new(PlainDateTime(x)))
                 .map_err(Into::into)
         }

--- a/temporal_capi/src/plain_month_day.rs
+++ b/temporal_capi/src/plain_month_day.rs
@@ -2,7 +2,7 @@
 #[diplomat::abi_rename = "temporal_rs_{0}"]
 #[diplomat::attr(auto, namespace = "temporal_rs")]
 pub mod ffi {
-    use crate::calendar::ffi::Calendar;
+    use crate::calendar::ffi::{AnyCalendarKind, Calendar};
     use crate::error::ffi::TemporalError;
     use alloc::boxed::Box;
 
@@ -22,14 +22,14 @@ pub mod ffi {
         pub fn create_with_overflow(
             month: u8,
             day: u8,
-            calendar: &Calendar,
+            calendar: AnyCalendarKind,
             overflow: ArithmeticOverflow,
             ref_year: Option<i32>,
         ) -> Result<Box<Self>, TemporalError> {
             temporal_rs::PlainMonthDay::new_with_overflow(
                 month,
                 day,
-                calendar.0.clone(),
+                temporal_rs::Calendar::new(calendar.into()),
                 overflow.into(),
                 ref_year,
             )

--- a/temporal_capi/src/plain_year_month.rs
+++ b/temporal_capi/src/plain_year_month.rs
@@ -2,7 +2,7 @@
 #[diplomat::abi_rename = "temporal_rs_{0}"]
 #[diplomat::attr(auto, namespace = "temporal_rs")]
 pub mod ffi {
-    use crate::calendar::ffi::Calendar;
+    use crate::calendar::ffi::{AnyCalendarKind, Calendar};
     use crate::duration::ffi::Duration;
     use crate::error::ffi::TemporalError;
     use alloc::boxed::Box;
@@ -24,14 +24,14 @@ pub mod ffi {
             year: i32,
             month: u8,
             reference_day: Option<u8>,
-            calendar: &Calendar,
+            calendar: AnyCalendarKind,
             overflow: ArithmeticOverflow,
         ) -> Result<Box<Self>, TemporalError> {
             temporal_rs::PlainYearMonth::new_with_overflow(
                 year,
                 month,
                 reference_day,
-                calendar.0.clone(),
+                temporal_rs::Calendar::new(calendar.into()),
                 overflow.into(),
             )
             .map(|x| Box::new(PlainYearMonth(x)))

--- a/temporal_capi/tests/c/simple.c
+++ b/temporal_capi/tests/c/simple.c
@@ -6,14 +6,11 @@
 #include <stdio.h>
 
 int main() {
-    Calendar *cal = temporal_rs_Calendar_create(AnyCalendarKind_Gregorian);
-
     temporal_rs_PlainDate_create_with_overflow_result result =
-        temporal_rs_PlainDate_create_with_overflow(2025, 1, 33, cal, ArithmeticOverflow_Constrain);
+        temporal_rs_PlainDate_create_with_overflow(2025, 1, 33, AnyCalendarKind_Gregorian, ArithmeticOverflow_Constrain);
 
     if (!result.is_ok) {
         fprintf(stderr, "failed to create a PlainDate\n");
-        temporal_rs_Calendar_destroy(cal);
         return 1;
     }
 
@@ -24,14 +21,12 @@ int main() {
     temporal_rs_PlainDate_to_ixdtf_string(date, DisplayCalendar_Always, &write);
     if (write.grow_failed) {
         fprintf(stderr, "format overflowed the string\n");
-        temporal_rs_Calendar_destroy(cal);
         temporal_rs_PlainDate_destroy(date);
         return 1;
     }
 
     printf("%s\n", formatted);
 
-    temporal_rs_Calendar_destroy(cal);
     temporal_rs_PlainDate_destroy(date);
 
     return 0;

--- a/temporal_capi/tests/cpp/simple.cpp
+++ b/temporal_capi/tests/cpp/simple.cpp
@@ -6,9 +6,7 @@
 using namespace temporal_rs;
 
 int main() {
-    auto c = Calendar::create(AnyCalendarKind::Gregorian);
-
-    auto date = PlainDate::create_with_overflow(2025, 1, 33, *c, ArithmeticOverflow::Constrain).ok().value();
+    auto date = PlainDate::create_with_overflow(2025, 1, 33, AnyCalendarKind::Gregorian, ArithmeticOverflow::Constrain).ok().value();
 
     auto formatted = date->to_ixdtf_string(DisplayCalendar::Always);
 


### PR DESCRIPTION
We clone these calendars anyway; the current API forces clients to retain some allocated Calendar objects for no real reason. Let's standardize around using kinds.

This breaks the CAPI, but I'm not using this stuff yet. If I decide to start using this before a release, I'll add some compat layer for the APIs I care about.