### PR TITLE
Use a lock internally to FsTzdbProvider instead of externally

### DIFF
--- a/src/builtins/compiled/date.rs
+++ b/src/builtins/compiled/date.rs
@@ -9,8 +9,8 @@ impl PlainDate {
         plain_time: Option<PlainTime>
     ) -> TemporalResult<crate::ZonedDateTime> {
         let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.to_zoned_date_time_with_provider(time_zone, plain_time, &*provider)
+            
+            ;
+        self.to_zoned_date_time_with_provider(time_zone, plain_time, &*TZ_PROVIDER)
     }
 }

--- a/src/builtins/compiled/duration.rs
+++ b/src/builtins/compiled/duration.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::TZ_PROVIDER,
     options::{RelativeTo, RoundingOptions, Unit},
     primitive::FiniteF64,
-    Duration, TemporalError, TemporalResult,
+    Duration, TemporalResult,
 };
 
 use core::cmp::Ordering;
@@ -20,10 +20,7 @@ impl Duration {
         options: RoundingOptions,
         relative_to: Option<RelativeTo>,
     ) -> TemporalResult<Self> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.round_with_provider(options, relative_to, &*provider)
+        self.round_with_provider(options, relative_to, &*TZ_PROVIDER)
     }
 
     /// Returns the ordering between two [`Duration`], takes an optional
@@ -35,16 +32,10 @@ impl Duration {
         two: &Duration,
         relative_to: Option<RelativeTo>,
     ) -> TemporalResult<Ordering> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.compare_with_provider(two, relative_to, &*provider)
+        self.compare_with_provider(two, relative_to, &*TZ_PROVIDER)
     }
 
     pub fn total(&self, unit: Unit, relative_to: Option<RelativeTo>) -> TemporalResult<FiniteF64> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.total_with_provider(unit, relative_to, &*provider)
+        self.total_with_provider(unit, relative_to, &*TZ_PROVIDER)
     }
 }

--- a/src/builtins/compiled/instant.rs
+++ b/src/builtins/compiled/instant.rs
@@ -1,6 +1,5 @@
 use crate::{
-    builtins::TZ_PROVIDER, options::ToStringRoundingOptions, Instant, TemporalError,
-    TemporalResult, TimeZone,
+    builtins::TZ_PROVIDER, options::ToStringRoundingOptions, Instant, TemporalResult, TimeZone,
 };
 use alloc::string::String;
 
@@ -14,10 +13,6 @@ impl Instant {
         timezone: Option<&TimeZone>,
         options: ToStringRoundingOptions,
     ) -> TemporalResult<String> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-
-        self.to_ixdtf_string_with_provider(timezone, options, &*provider)
+        self.to_ixdtf_string_with_provider(timezone, options, &*TZ_PROVIDER)
     }
 }

--- a/src/builtins/compiled/mod.rs
+++ b/src/builtins/compiled/mod.rs
@@ -7,15 +7,11 @@ mod plain_date_time;
 mod zoneddatetime;
 
 mod options {
-    use crate::{builtins::TZ_PROVIDER, options::RelativeTo, TemporalError, TemporalResult};
+    use crate::{builtins::TZ_PROVIDER, options::RelativeTo, TemporalResult};
 
     impl RelativeTo {
         pub fn try_from_str(source: &str) -> TemporalResult<Self> {
-            let provider = TZ_PROVIDER
-                .lock()
-                .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-
-            Self::try_from_str_with_provider(source, &*provider)
+            Self::try_from_str_with_provider(source, &*TZ_PROVIDER)
         }
     }
 }

--- a/src/builtins/compiled/now.rs
+++ b/src/builtins/compiled/now.rs
@@ -2,7 +2,7 @@ use crate::builtins::{
     core::{Now, PlainDate, PlainDateTime, PlainTime},
     TZ_PROVIDER,
 };
-use crate::{TemporalError, TemporalResult, TimeZone};
+use crate::{TemporalResult, TimeZone};
 
 impl Now {
     /// Returns the current system time as a [`PlainDateTime`] with an optional
@@ -10,10 +10,7 @@ impl Now {
     ///
     /// Enable with the `compiled_data` and `sys` feature flags.
     pub fn plain_date_time_iso(self, time_zone: Option<TimeZone>) -> TemporalResult<PlainDateTime> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.plain_date_time_iso_with_provider(time_zone, &*provider)
+        self.plain_date_time_iso_with_provider(time_zone, &*TZ_PROVIDER)
     }
 
     /// Returns the current system time as a [`PlainDate`] with an optional
@@ -21,10 +18,7 @@ impl Now {
     ///
     /// Enable with the `compiled_data` and `sys` feature flags.
     pub fn plain_date_iso(self, time_zone: Option<TimeZone>) -> TemporalResult<PlainDate> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.plain_date_iso_with_provider(time_zone, &*provider)
+        self.plain_date_iso_with_provider(time_zone, &*TZ_PROVIDER)
     }
 
     /// Returns the current system time as a [`PlainTime`] with an optional
@@ -32,9 +26,6 @@ impl Now {
     ///
     /// Enable with the `compiled_data` and `sys` feature flags.
     pub fn plain_time_iso(self, time_zone: Option<TimeZone>) -> TemporalResult<PlainTime> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.plain_time_with_provider(time_zone, &*provider)
+        self.plain_time_with_provider(time_zone, &*TZ_PROVIDER)
     }
 }

--- a/src/builtins/compiled/plain_date_time.rs
+++ b/src/builtins/compiled/plain_date_time.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::core::{PlainDateTime, ZonedDateTime},
     builtins::TZ_PROVIDER,
     options::Disambiguation,
-    TemporalError, TemporalResult, TimeZone,
+    TemporalResult, TimeZone,
 };
 
 impl PlainDateTime {
@@ -14,10 +14,6 @@ impl PlainDateTime {
         time_zone: &TimeZone,
         disambiguation: Disambiguation,
     ) -> TemporalResult<ZonedDateTime> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-
-        self.to_zoned_date_time_with_provider(time_zone, disambiguation, &*provider)
+        self.to_zoned_date_time_with_provider(time_zone, disambiguation, &*TZ_PROVIDER)
     }
 }

--- a/src/builtins/compiled/zoneddatetime.rs
+++ b/src/builtins/compiled/zoneddatetime.rs
@@ -6,7 +6,7 @@ use crate::{
         ArithmeticOverflow, DifferenceSettings, Disambiguation, DisplayCalendar, DisplayOffset,
         DisplayTimeZone, OffsetDisambiguation, RoundingOptions, ToStringRoundingOptions,
     },
-    Duration, MonthCode, PlainDate, PlainDateTime, PlainTime, TemporalError, TemporalResult,
+    Duration, MonthCode, PlainDate, PlainDateTime, PlainTime, TemporalResult,
 };
 use alloc::string::String;
 use tinystr::TinyAsciiStr;
@@ -40,107 +40,70 @@ impl ZonedDateTime {
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn year(&self) -> TemporalResult<i32> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.year_with_provider(&*provider)
+        self.year_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the `ZonedDateTime`'s calendar month.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn month(&self) -> TemporalResult<u8> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.month_with_provider(&*provider)
+        self.month_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the `ZonedDateTime`'s calendar month code.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn month_code(&self) -> TemporalResult<MonthCode> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.month_code_with_provider(&*provider)
+        self.month_code_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the `ZonedDateTime`'s calendar day.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn day(&self) -> TemporalResult<u8> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.day_with_provider(&*provider)
+        self.day_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the `ZonedDateTime`'s hour.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn hour(&self) -> TemporalResult<u8> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.hour_with_provider(&*provider)
+        self.hour_with_provider(&*TZ_PROVIDER)
     }
 
     /// Enable with the `compiled_data` feature flag.
     pub fn minute(&self) -> TemporalResult<u8> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.minute_with_provider(&*provider)
+        self.minute_with_provider(&*TZ_PROVIDER)
     }
 
     /// Enable with the `compiled_data` feature flag.
     pub fn second(&self) -> TemporalResult<u8> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.second_with_provider(&*provider)
+        self.second_with_provider(&*TZ_PROVIDER)
     }
 
     /// Enable with the `compiled_data` feature flag.
     pub fn millisecond(&self) -> TemporalResult<u16> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.millisecond_with_provider(&*provider)
+        self.millisecond_with_provider(&*TZ_PROVIDER)
     }
 
     /// Enable with the `compiled_data` feature flag.
     pub fn microsecond(&self) -> TemporalResult<u16> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.millisecond_with_provider(&*provider)
+        self.millisecond_with_provider(&*TZ_PROVIDER)
     }
 
     /// Enable with the `compiled_data` feature flag.
     pub fn nanosecond(&self) -> TemporalResult<u16> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-
-        self.millisecond_with_provider(&*provider)
+        self.millisecond_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the current offset as a formatted offset string.
     pub fn offset(&self) -> TemporalResult<String> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.offset_with_provider(&*provider)
+        self.offset_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the current offset in nanoseconds
     pub fn offset_nanoseconds(&self) -> TemporalResult<i64> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.offset_nanoseconds_with_provider(&*provider)
+        self.offset_nanoseconds_with_provider(&*TZ_PROVIDER)
     }
 }
 
@@ -159,10 +122,7 @@ impl ZonedDateTime {
     ///
     /// Please note that era support is still experimental. Use with caution.
     pub fn era(&self) -> TemporalResult<Option<TinyAsciiStr<16>>> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.era_with_provider(&*provider)
+        self.era_with_provider(&*TZ_PROVIDER)
     }
 
     /// Return the era year for the current `ZonedDateTime`.
@@ -173,100 +133,70 @@ impl ZonedDateTime {
     ///
     /// Please note that era year support is still experimental. Use with caution.
     pub fn era_year(&self) -> TemporalResult<Option<i32>> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.era_year_with_provider(&*provider)
+        self.era_year_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the calendar day of week value.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn day_of_week(&self) -> TemporalResult<u16> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.day_of_week_with_provider(&*provider)
+        self.day_of_week_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the calendar day of year value.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn day_of_year(&self) -> TemporalResult<u16> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.day_of_year_with_provider(&*provider)
+        self.day_of_year_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the calendar week of year value.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn week_of_year(&self) -> TemporalResult<Option<u8>> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.week_of_year_with_provider(&*provider)
+        self.week_of_year_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the calendar year of week value.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn year_of_week(&self) -> TemporalResult<Option<i32>> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.year_of_week_with_provider(&*provider)
+        self.year_of_week_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the calendar days in week value.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn days_in_week(&self) -> TemporalResult<u16> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.days_in_week_with_provider(&*provider)
+        self.days_in_week_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the calendar days in month value.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn days_in_month(&self) -> TemporalResult<u16> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.days_in_month_with_provider(&*provider)
+        self.days_in_month_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the calendar days in year value.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn days_in_year(&self) -> TemporalResult<u16> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.days_in_year_with_provider(&*provider)
+        self.days_in_year_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns the calendar months in year value.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn months_in_year(&self) -> TemporalResult<u16> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.months_in_year_with_provider(&*provider)
+        self.months_in_year_with_provider(&*TZ_PROVIDER)
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn in_leap_year(&self) -> TemporalResult<bool> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.in_leap_year_with_provider(&*provider)
+        self.in_leap_year_with_provider(&*TZ_PROVIDER)
     }
 
     // TODO: Update direction to correct option
@@ -274,20 +204,14 @@ impl ZonedDateTime {
         &self,
         direction: TransitionDirection,
     ) -> TemporalResult<Option<Self>> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.get_time_zone_transition_with_provider(direction, &*provider)
+        self.get_time_zone_transition_with_provider(direction, &*TZ_PROVIDER)
     }
 
     /// Returns the hours in the day.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn hours_in_day(&self) -> TemporalResult<u8> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.hours_in_day_with_provider(&*provider)
+        self.hours_in_day_with_provider(&*TZ_PROVIDER)
     }
 }
 
@@ -302,10 +226,7 @@ impl ZonedDateTime {
     ///
     /// combined with the provided `TimeZone`.
     pub fn with_plain_time(&self, time: PlainTime) -> TemporalResult<Self> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.with_plain_time_and_provider(time, &*provider)
+        self.with_plain_time_and_provider(time, &*TZ_PROVIDER)
     }
 
     /// Adds a [`Duration`] to the current `ZonedDateTime`.
@@ -316,10 +237,7 @@ impl ZonedDateTime {
         duration: &Duration,
         overflow: Option<ArithmeticOverflow>,
     ) -> TemporalResult<Self> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.add_with_provider(duration, overflow, &*provider)
+        self.add_with_provider(duration, overflow, &*TZ_PROVIDER)
     }
 
     /// Subtracts a [`Duration`] to the current `ZonedDateTime`.
@@ -330,80 +248,56 @@ impl ZonedDateTime {
         duration: &Duration,
         overflow: Option<ArithmeticOverflow>,
     ) -> TemporalResult<Self> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.subtract_with_provider(duration, overflow, &*provider)
+        self.subtract_with_provider(duration, overflow, &*TZ_PROVIDER)
     }
 
     /// Returns a [`Duration`] representing the period of time from this `ZonedDateTime` since the other `ZonedDateTime`.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn since(&self, other: &Self, options: DifferenceSettings) -> TemporalResult<Duration> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.since_with_provider(other, options, &*provider)
+        self.since_with_provider(other, options, &*TZ_PROVIDER)
     }
 
     /// Returns a [`Duration`] representing the period of time from this `ZonedDateTime` since the other `ZonedDateTime`.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn until(&self, other: &Self, options: DifferenceSettings) -> TemporalResult<Duration> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.until_with_provider(other, options, &*provider)
+        self.until_with_provider(other, options, &*TZ_PROVIDER)
     }
 
     /// Returns the start of day for the current `ZonedDateTime`.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn start_of_day(&self) -> TemporalResult<Self> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.start_of_day_with_provider(&*provider)
+        self.start_of_day_with_provider(&*TZ_PROVIDER)
     }
 
     /// Creates a new [`PlainDate`] from this `ZonedDateTime`.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn to_plain_date(&self) -> TemporalResult<PlainDate> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.to_plain_date_with_provider(&*provider)
+        self.to_plain_date_with_provider(&*TZ_PROVIDER)
     }
 
     /// Creates a new [`PlainTime`] from this `ZonedDateTime`.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn to_plain_time(&self) -> TemporalResult<PlainTime> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.to_plain_time_with_provider(&*provider)
+        self.to_plain_time_with_provider(&*TZ_PROVIDER)
     }
 
     /// Creates a new [`PlainDateTime`] from this `ZonedDateTime`.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn to_plain_datetime(&self) -> TemporalResult<PlainDateTime> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.to_plain_datetime_with_provider(&*provider)
+        self.to_plain_datetime_with_provider(&*TZ_PROVIDER)
     }
 
     /// Rounds this [`ZonedDateTime`] to the nearest value according to the given rounding options.
     ///
     /// Enable with the `compiled_data` feature flag.
     pub fn round(&self, options: RoundingOptions) -> TemporalResult<Self> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        self.round_with_provider(options, &*provider)
+        self.round_with_provider(options, &*TZ_PROVIDER)
     }
 
     /// Returns a RFC9557 (IXDTF) string with the provided options.
@@ -416,15 +310,12 @@ impl ZonedDateTime {
         display_calendar: DisplayCalendar,
         options: ToStringRoundingOptions,
     ) -> TemporalResult<String> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
         self.to_ixdtf_string_with_provider(
             display_offset,
             display_timezone,
             display_calendar,
             options,
-            &*provider,
+            &*TZ_PROVIDER,
         )
     }
 
@@ -436,10 +327,7 @@ impl ZonedDateTime {
         disambiguation: Disambiguation,
         offset_option: OffsetDisambiguation,
     ) -> TemporalResult<Self> {
-        let provider = TZ_PROVIDER
-            .lock()
-            .map_err(|_| TemporalError::general("Unable to acquire lock"))?;
-        ZonedDateTime::from_str_with_provider(source, disambiguation, offset_option, &*provider)
+        ZonedDateTime::from_str_with_provider(source, disambiguation, offset_option, &*TZ_PROVIDER)
     }
 }
 

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -9,8 +9,7 @@ pub use core::*;
 #[cfg(feature = "compiled_data")]
 use crate::tzdb::FsTzdbProvider;
 #[cfg(feature = "compiled_data")]
-use std::sync::{LazyLock, Mutex};
+use std::sync::LazyLock;
 
 #[cfg(feature = "compiled_data")]
-pub static TZ_PROVIDER: LazyLock<Mutex<FsTzdbProvider>> =
-    LazyLock::new(|| Mutex::new(FsTzdbProvider::default()));
+pub static TZ_PROVIDER: LazyLock<FsTzdbProvider> = LazyLock::new(FsTzdbProvider::default);

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -620,7 +620,7 @@ impl FsTzdbProvider {
         if let Some(tzif) = self
             .cache
             .read()
-            .map_err(|_| TemporalError::range().with_message("poisoned RWLock"))?
+            .map_err(|_| TemporalError::general("poisoned RWLock"))?
             .get(identifier)
         {
             return Ok(tzif.clone());
@@ -641,7 +641,7 @@ impl FsTzdbProvider {
         Ok(self
             .cache
             .write()
-            .map_err(|_| TemporalError::range().with_message("poisoned RWLock"))?
+            .map_err(|_| TemporalError::general("poisoned RWLock"))?
             .entry(identifier.into())
             .or_insert(tzif)
             .clone())

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -34,7 +34,7 @@ use std::path::PathBuf;
 use alloc::collections::BTreeMap;
 use alloc::string::{String, ToString};
 use alloc::{vec, vec::Vec};
-use core::cell::RefCell;
+use std::sync::RwLock;
 
 use combine::Parser;
 
@@ -612,12 +612,17 @@ fn offset_range(offset_one: i64, offset_two: i64) -> core::ops::Range<i64> {
 
 #[derive(Debug, Default)]
 pub struct FsTzdbProvider {
-    cache: RefCell<BTreeMap<String, Tzif>>,
+    cache: RwLock<BTreeMap<String, Tzif>>,
 }
 
 impl FsTzdbProvider {
     pub fn get(&self, identifier: &str) -> TemporalResult<Tzif> {
-        if let Some(tzif) = self.cache.borrow().get(identifier) {
+        if let Some(tzif) = self
+            .cache
+            .read()
+            .map_err(|_| TemporalError::range().with_message("poisoned RWLock"))?
+            .get(identifier)
+        {
             return Ok(tzif.clone());
         }
         #[cfg(target_family = "unix")]
@@ -635,7 +640,8 @@ impl FsTzdbProvider {
 
         Ok(self
             .cache
-            .borrow_mut()
+            .write()
+            .map_err(|_| TemporalError::range().with_message("poisoned RWLock"))?
             .entry(identifier.into())
             .or_insert(tzif)
             .clone())


### PR DESCRIPTION
It already uses interior mutability, we don't gain much by having the lock be external in `TZ_PROVIDER`.

By having it be internal, the critical section of tzdb stuff is limited to the caching logic, rather than anything larger.