### PR TITLE
Implement PlainMonthDay::with functionality

### DIFF
--- a/temporal_capi/bindings/c/PlainMonthDay.h
+++ b/temporal_capi/bindings/c/PlainMonthDay.h
@@ -25,7 +25,7 @@ typedef struct temporal_rs_PlainMonthDay_try_new_with_overflow_result {union {Pl
 temporal_rs_PlainMonthDay_try_new_with_overflow_result temporal_rs_PlainMonthDay_try_new_with_overflow(uint8_t month, uint8_t day, AnyCalendarKind calendar, ArithmeticOverflow overflow, OptionI32 ref_year);
 
 typedef struct temporal_rs_PlainMonthDay_with_result {union {PlainMonthDay* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_with_result;
-temporal_rs_PlainMonthDay_with_result temporal_rs_PlainMonthDay_with(const PlainMonthDay* self, PartialDate partial, ArithmeticOverflow overflow);
+temporal_rs_PlainMonthDay_with_result temporal_rs_PlainMonthDay_with(const PlainMonthDay* self, PartialDate partial, ArithmeticOverflow_option overflow);
 
 bool temporal_rs_PlainMonthDay_equals(const PlainMonthDay* self, const PlainMonthDay* other);
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
@@ -37,7 +37,7 @@ public:
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> try_new_with_overflow(uint8_t month, uint8_t day, temporal_rs::AnyCalendarKind calendar, temporal_rs::ArithmeticOverflow overflow, std::optional<int32_t> ref_year);
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> with(temporal_rs::PartialDate partial, temporal_rs::ArithmeticOverflow overflow) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> with(temporal_rs::PartialDate partial, std::optional<temporal_rs::ArithmeticOverflow> overflow) const;
 
   inline bool equals(const temporal_rs::PlainMonthDay& other) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
@@ -28,7 +28,7 @@ namespace capi {
     temporal_rs_PlainMonthDay_try_new_with_overflow_result temporal_rs_PlainMonthDay_try_new_with_overflow(uint8_t month, uint8_t day, temporal_rs::capi::AnyCalendarKind calendar, temporal_rs::capi::ArithmeticOverflow overflow, diplomat::capi::OptionI32 ref_year);
 
     typedef struct temporal_rs_PlainMonthDay_with_result {union {temporal_rs::capi::PlainMonthDay* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_with_result;
-    temporal_rs_PlainMonthDay_with_result temporal_rs_PlainMonthDay_with(const temporal_rs::capi::PlainMonthDay* self, temporal_rs::capi::PartialDate partial, temporal_rs::capi::ArithmeticOverflow overflow);
+    temporal_rs_PlainMonthDay_with_result temporal_rs_PlainMonthDay_with(const temporal_rs::capi::PlainMonthDay* self, temporal_rs::capi::PartialDate partial, temporal_rs::capi::ArithmeticOverflow_option overflow);
 
     bool temporal_rs_PlainMonthDay_equals(const temporal_rs::capi::PlainMonthDay* self, const temporal_rs::capi::PlainMonthDay* other);
 
@@ -68,10 +68,10 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainMonthDay>>(std::unique_ptr<temporal_rs::PlainMonthDay>(temporal_rs::PlainMonthDay::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> temporal_rs::PlainMonthDay::with(temporal_rs::PartialDate partial, temporal_rs::ArithmeticOverflow overflow) const {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> temporal_rs::PlainMonthDay::with(temporal_rs::PartialDate partial, std::optional<temporal_rs::ArithmeticOverflow> overflow) const {
   auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_with(this->AsFFI(),
     partial.AsFFI(),
-    overflow.AsFFI());
+    overflow.has_value() ? (temporal_rs::capi::ArithmeticOverflow_option{ { overflow.value().AsFFI() }, true }) : (temporal_rs::capi::ArithmeticOverflow_option{ {}, false }));
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainMonthDay>>(std::unique_ptr<temporal_rs::PlainMonthDay>(temporal_rs::PlainMonthDay::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 

--- a/temporal_capi/src/plain_month_day.rs
+++ b/temporal_capi/src/plain_month_day.rs
@@ -40,10 +40,10 @@ pub mod ffi {
         pub fn with(
             &self,
             partial: PartialDate,
-            overflow: ArithmeticOverflow,
+            overflow: Option<ArithmeticOverflow>,
         ) -> Result<Box<PlainMonthDay>, TemporalError> {
             self.0
-                .with(partial.try_into()?, overflow.into())
+                .with(partial.try_into()?, overflow.map(Into::into))
                 .map(|x| Box::new(PlainMonthDay(x)))
                 .map_err(Into::into)
         }


### PR DESCRIPTION
This implements `PlainMonthDay::with` method.

Closes #283

Special handling had to be added to the `Era` and `EraYear` resolution in order to properly support base line functionality.

CC: @Manishearth for the `temporal_capi` updates