### PR TITLE
Add Writeable getters for some types, use in FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "icu_locale",
  "num-traits",
  "temporal_rs",
+ "writeable",
 ]
 
 [[package]]

--- a/src/builtins/compiled/instant.rs
+++ b/src/builtins/compiled/instant.rs
@@ -15,4 +15,16 @@ impl Instant {
     ) -> TemporalResult<String> {
         self.to_ixdtf_string_with_provider(timezone, options, &*TZ_PROVIDER)
     }
+
+    /// Returns the RFC9557 (IXDTF) string for this `Instant` with the
+    /// provided options as a Writeable
+    ///
+    /// Enable with the `compiled_data` feature flag.
+    pub fn to_ixdtf_writeable(
+        &self,
+        timezone: Option<&TimeZone>,
+        options: ToStringRoundingOptions,
+    ) -> TemporalResult<impl writeable::Writeable + '_> {
+        self.to_ixdtf_writeable_with_provider(timezone, options, &*TZ_PROVIDER)
+    }
 }

--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -17,6 +17,7 @@ use crate::{
 use alloc::{format, string::String};
 use core::{cmp::Ordering, str::FromStr};
 use icu_calendar::AnyCalendarKind;
+use writeable::Writeable;
 
 use super::{
     calendar::month_to_month_code,
@@ -679,6 +680,13 @@ impl PlainDate {
 
     #[inline]
     pub fn to_ixdtf_string(&self, display_calendar: DisplayCalendar) -> String {
+        self.to_ixdtf_writeable(display_calendar)
+            .write_to_string()
+            .into()
+    }
+
+    #[inline]
+    pub fn to_ixdtf_writeable(&self, display_calendar: DisplayCalendar) -> impl Writeable + '_ {
         IxdtfStringBuilder::default()
             .with_date(self.iso)
             .with_calendar(self.calendar.identifier(), display_calendar)

--- a/src/builtins/core/month_day.rs
+++ b/src/builtins/core/month_day.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 
 use super::{PartialDate, PlainDate};
+use writeable::Writeable;
 
 /// The native Rust implementation of `Temporal.PlainMonthDay`
 #[non_exhaustive]
@@ -164,6 +165,12 @@ impl PlainMonthDay {
     }
 
     pub fn to_ixdtf_string(&self, display_calendar: DisplayCalendar) -> String {
+        self.to_ixdtf_writeable(display_calendar)
+            .write_to_string()
+            .into()
+    }
+
+    pub fn to_ixdtf_writeable(&self, display_calendar: DisplayCalendar) -> impl Writeable + '_ {
         let ixdtf = FormattableMonthDay {
             date: FormattableDate(self.iso_year(), self.iso_month(), self.iso.day),
             calendar: FormattableCalendar {
@@ -171,7 +178,7 @@ impl PlainMonthDay {
                 calendar: self.calendar().identifier(),
             },
         };
-        ixdtf.to_string()
+        ixdtf
     }
 }
 

--- a/src/builtins/core/time.rs
+++ b/src/builtins/core/time.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use alloc::string::String;
 use core::str::FromStr;
+use writeable::Writeable;
 
 use super::{duration::normalized::NormalizedTimeDuration, PlainDateTime};
 
@@ -474,14 +475,21 @@ impl PlainTime {
     }
 
     pub fn to_ixdtf_string(&self, options: ToStringRoundingOptions) -> TemporalResult<String> {
+        self.to_ixdtf_writeable(options)
+            .map(|x| x.write_to_string().into())
+    }
+
+    #[inline]
+    pub fn to_ixdtf_writeable(
+        &self,
+        options: ToStringRoundingOptions,
+    ) -> TemporalResult<impl Writeable + '_> {
         let resolved = options.resolve()?;
         let (_, result) = self
             .iso
             .round(ResolvedRoundingOptions::from_to_string_options(&resolved))?;
-        let ixdtf_string = IxdtfStringBuilder::default()
-            .with_time(result, resolved.precision)
-            .build();
-        Ok(ixdtf_string)
+        let builder = IxdtfStringBuilder::default().with_time(result, resolved.precision);
+        Ok(builder)
     }
 }
 

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -20,6 +20,7 @@ use crate::{
 use super::{
     duration::normalized::NormalizedDurationRecord, Duration, PartialDate, PlainDate, PlainDateTime,
 };
+use writeable::Writeable;
 
 /// The native Rust implementation of `Temporal.YearMonth`.
 #[non_exhaustive]
@@ -430,6 +431,14 @@ impl PlainYearMonth {
     /// Returns a RFC9557 IXDTF string for the current `PlainYearMonth`
     #[inline]
     pub fn to_ixdtf_string(&self, display_calendar: DisplayCalendar) -> String {
+        self.to_ixdtf_writeable(display_calendar)
+            .write_to_string()
+            .into()
+    }
+
+    /// Returns a RFC9557 IXDTF string for the current `PlainYearMonth` as a Writeable
+    #[inline]
+    pub fn to_ixdtf_writeable(&self, display_calendar: DisplayCalendar) -> impl Writeable + '_ {
         let ixdtf = FormattableYearMonth {
             date: FormattableDate(self.iso_year(), self.iso_month(), self.iso.day),
             calendar: FormattableCalendar {
@@ -437,7 +446,7 @@ impl PlainYearMonth {
                 calendar: self.calendar().identifier(),
             },
         };
-        ixdtf.to_string()
+        ixdtf
     }
 }
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -91,6 +91,16 @@ impl<'a> IxdtfStringBuilder<'a> {
     }
 }
 
+impl<'a> Writeable for IxdtfStringBuilder<'a> {
+    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
+        self.inner.write_to(sink)
+    }
+
+    fn writeable_length_hint(&self) -> LengthHint {
+        self.inner.writeable_length_hint()
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Precision {
     #[default]

--- a/temporal_capi/Cargo.toml
+++ b/temporal_capi/Cargo.toml
@@ -24,6 +24,7 @@ num-traits.workspace = true
 temporal_rs = { workspace = true, default-features = false }
 icu_calendar = { version = "2.0.2", default-features = false }
 icu_locale = { version = "2.0.0" }
+writeable = "0.6.1"
 
 [features]
 compiled_data = ["temporal_rs/compiled_data"]

--- a/temporal_capi/src/instant.rs
+++ b/temporal_capi/src/instant.rs
@@ -140,10 +140,13 @@ pub mod ffi {
             options: ToStringRoundingOptions,
             write: &mut DiplomatWrite,
         ) -> Result<(), TemporalError> {
-            use core::fmt::Write;
-            let string = self.0.to_ixdtf_string(zone.map(|x| &x.0), options.into())?;
-            // throw away the error, this should always succeed
-            let _ = write.write_str(&string);
+            use writeable::Writeable;
+            let writeable = self
+                .0
+                .to_ixdtf_writeable(zone.map(|x| &x.0), options.into())?;
+            // This can only fail in cases where the DiplomatWriteable is capped, we
+            // don't care about that.
+            let _ = writeable.write_to(write);
 
             Ok(())
         }

--- a/temporal_capi/src/plain_date.rs
+++ b/temporal_capi/src/plain_date.rs
@@ -23,6 +23,7 @@ pub mod ffi {
     use core::fmt::Write;
     use diplomat_runtime::{DiplomatOption, DiplomatStrSlice, DiplomatWrite};
     use diplomat_runtime::{DiplomatStr, DiplomatStr16};
+    use writeable::Writeable;
 
     use core::str::FromStr;
 
@@ -293,10 +294,10 @@ pub mod ffi {
             display_calendar: DisplayCalendar,
             write: &mut DiplomatWrite,
         ) {
-            // TODO this double-allocates, an API returning a Writeable or impl Write would be better
-            let string = self.0.to_ixdtf_string(display_calendar.into());
-            // throw away the error, this should always succeed
-            let _ = write.write_str(&string);
+            let writeable = self.0.to_ixdtf_writeable(display_calendar.into());
+            // This can only fail in cases where the DiplomatWriteable is capped, we
+            // don't care about that.
+            let _ = writeable.write_to(write);
         }
     }
 }

--- a/temporal_capi/src/plain_date_time.rs
+++ b/temporal_capi/src/plain_date_time.rs
@@ -27,6 +27,7 @@ pub mod ffi {
     use core::str::FromStr;
     use diplomat_runtime::DiplomatWrite;
     use diplomat_runtime::{DiplomatStr, DiplomatStr16};
+    use writeable::Writeable;
 
     #[diplomat::opaque]
     pub struct PlainDateTime(pub(crate) temporal_rs::PlainDateTime);
@@ -338,12 +339,13 @@ pub mod ffi {
             display_calendar: DisplayCalendar,
             write: &mut DiplomatWrite,
         ) -> Result<(), TemporalError> {
-            // TODO this double-allocates, an API returning a Writeable or impl Write would be better
-            let string = self
+            let writeable = self
                 .0
-                .to_ixdtf_string(options.into(), display_calendar.into())?;
-            // throw away the error, this should always succeed
-            let _ = write.write_str(&string);
+                .to_ixdtf_writeable(options.into(), display_calendar.into())?;
+
+            // This can only fail in cases where the DiplomatWriteable is capped, we
+            // don't care about that.
+            let _ = writeable.write_to(write);
             Ok(())
         }
     }

--- a/temporal_capi/src/plain_month_day.rs
+++ b/temporal_capi/src/plain_month_day.rs
@@ -14,6 +14,7 @@ pub mod ffi {
     use core::str::FromStr;
     use diplomat_runtime::DiplomatWrite;
     use diplomat_runtime::{DiplomatStr, DiplomatStr16};
+    use writeable::Writeable;
 
     #[diplomat::opaque]
     pub struct PlainMonthDay(pub(crate) temporal_rs::PlainMonthDay);
@@ -104,10 +105,10 @@ pub mod ffi {
             display_calendar: DisplayCalendar,
             write: &mut DiplomatWrite,
         ) {
-            // TODO this double-allocates, an API returning a Writeable or impl Write would be better
-            let string = self.0.to_ixdtf_string(display_calendar.into());
-            // throw away the error, this should always succeed
-            let _ = write.write_str(&string);
+            let writeable = self.0.to_ixdtf_writeable(display_calendar.into());
+            // This can only fail in cases where the DiplomatWriteable is capped, we
+            // don't care about that.
+            let _ = writeable.write_to(write);
         }
     }
 }

--- a/temporal_capi/src/plain_time.rs
+++ b/temporal_capi/src/plain_time.rs
@@ -10,10 +10,10 @@ pub mod ffi {
         ArithmeticOverflow, DifferenceSettings, RoundingMode, ToStringRoundingOptions, Unit,
     };
     use alloc::string::String;
-    use core::fmt::Write;
     use core::str::FromStr;
     use diplomat_runtime::{DiplomatOption, DiplomatWrite};
     use diplomat_runtime::{DiplomatStr, DiplomatStr16};
+    use writeable::Writeable;
 
     #[diplomat::opaque]
     pub struct PlainTime(pub(crate) temporal_rs::PlainTime);
@@ -205,10 +205,10 @@ pub mod ffi {
             options: ToStringRoundingOptions,
             write: &mut DiplomatWrite,
         ) -> Result<(), TemporalError> {
-            // TODO this double-allocates, an API returning a Writeable or impl Write would be better
-            let string = self.0.to_ixdtf_string(options.into())?;
-            // throw away the error, the write itself should always succeed
-            let _ = write.write_str(&string);
+            let writeable = self.0.to_ixdtf_writeable(options.into())?;
+            // This can only fail in cases where the DiplomatWriteable is capped, we
+            // don't care about that.
+            let _ = writeable.write_to(write);
 
             Ok(())
         }

--- a/temporal_capi/src/plain_year_month.rs
+++ b/temporal_capi/src/plain_year_month.rs
@@ -13,6 +13,7 @@ pub mod ffi {
     use core::fmt::Write;
     use diplomat_runtime::DiplomatWrite;
     use diplomat_runtime::{DiplomatStr, DiplomatStr16};
+    use writeable::Writeable;
 
     use core::str::FromStr;
 
@@ -178,10 +179,10 @@ pub mod ffi {
             display_calendar: DisplayCalendar,
             write: &mut DiplomatWrite,
         ) {
-            // TODO this double-allocates, an API returning a Writeable or impl Write would be better
-            let string = self.0.to_ixdtf_string(display_calendar.into());
-            // throw away the error, this should always succeed
-            let _ = write.write_str(&string);
+            let writeable = self.0.to_ixdtf_writeable(display_calendar.into());
+            // This can only fail in cases where the DiplomatWriteable is capped, we
+            // don't care about that.
+            let _ = writeable.write_to(write);
         }
     }
 }


### PR DESCRIPTION
I didn't do all of the APIs, just some of them.

I wasn't sure if I should make IxdtfStringBuilder writeable, or give it a `.writeable()` method that returns an `impl Writeable` (the inner type). Open to opinions.