### PR TITLE
Switch compiled_data APIs to new CompiledTzdbProvider

### DIFF
--- a/src/builtins/compiled/duration/tests.rs
+++ b/src/builtins/compiled/duration/tests.rs
@@ -1,5 +1,3 @@
-use std::string::ToString;
-
 use crate::{
     options::{
         OffsetDisambiguation, RelativeTo, RoundingIncrement, RoundingMode, RoundingOptions, Unit,
@@ -506,55 +504,6 @@ fn round_relative_to_zoned_datetime() {
     // Result duration should be: (0, 0, 0, 1, 1, 0, 0, 0, 0, 0)
     assert_eq!(result.days(), 1);
     assert_eq!(result.hours(), 1);
-}
-
-#[test]
-fn test_duration_compare() {
-    // TODO(#199): fix this on Windows
-    if cfg!(not(windows)) {
-        let one = Duration::from_partial_duration(PartialDuration {
-            hours: Some(79),
-            minutes: Some(10),
-            ..Default::default()
-        })
-        .unwrap();
-        let two = Duration::from_partial_duration(PartialDuration {
-            days: Some(3),
-            hours: Some(7),
-            seconds: Some(630),
-            ..Default::default()
-        })
-        .unwrap();
-        let three = Duration::from_partial_duration(PartialDuration {
-            days: Some(3),
-            hours: Some(6),
-            minutes: Some(50),
-            ..Default::default()
-        })
-        .unwrap();
-
-        let mut arr = [&one, &two, &three];
-        arr.sort_by(|a, b| Duration::compare(a, b, None).unwrap());
-        assert_eq!(
-            arr.map(ToString::to_string),
-            [&three, &one, &two].map(ToString::to_string)
-        );
-
-        // Sorting relative to a date, taking DST changes into account:
-        let zdt = ZonedDateTime::from_str(
-            "2020-11-01T00:00-07:00[America/Los_Angeles]",
-            Default::default(),
-            OffsetDisambiguation::Reject,
-        )
-        .unwrap();
-        arr.sort_by(|a, b| {
-            Duration::compare(a, b, Some(RelativeTo::ZonedDateTime(zdt.clone()))).unwrap()
-        });
-        assert_eq!(
-            arr.map(ToString::to_string),
-            [&one, &three, &two].map(ToString::to_string)
-        )
-    }
 }
 
 #[test]

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -7,9 +7,15 @@ pub mod core;
 pub use core::*;
 
 #[cfg(feature = "compiled_data")]
+use crate::tzdb::CompiledTzdbProvider;
+#[cfg(all(test, feature = "compiled_data"))]
 use crate::tzdb::FsTzdbProvider;
 #[cfg(feature = "compiled_data")]
 use std::sync::LazyLock;
 
 #[cfg(feature = "compiled_data")]
-pub static TZ_PROVIDER: LazyLock<FsTzdbProvider> = LazyLock::new(FsTzdbProvider::default);
+pub static TZ_PROVIDER: LazyLock<CompiledTzdbProvider> =
+    LazyLock::new(CompiledTzdbProvider::default);
+
+#[cfg(all(test, feature = "compiled_data"))]
+pub(crate) static FS_TZ_PROVIDER: LazyLock<FsTzdbProvider> = LazyLock::new(FsTzdbProvider::default);


### PR DESCRIPTION
Compiled data should not hit the filesystem.

Once https://github.com/boa-dev/temporal/pull/264 is done we can remove the caching code.