### PR TITLE
Stop depending on `is_dst` for calculations

### DIFF
--- a/src/builtins/core/timezone.rs
+++ b/src/builtins/core/timezone.rs
@@ -11,7 +11,7 @@ use crate::builtins::core::duration::DateDuration;
 use crate::parsers::{
     parse_allowed_timezone_formats, parse_identifier, FormattableOffset, FormattableTime, Precision,
 };
-use crate::provider::{TimeZoneOffset, TimeZoneProvider};
+use crate::provider::{TimeZoneProvider, TimeZoneTransitionInfo};
 use crate::{
     builtins::core::{duration::normalized::NormalizedTimeDuration, Instant},
     iso::{IsoDate, IsoDateTime, IsoTime},
@@ -177,7 +177,7 @@ impl TimeZone {
             // 3. Return GetNamedTimeZoneOffsetNanoseconds(parseResult.[[Name]], epochNs).
             Self::IanaIdentifier(identifier) => provider
                 .get_named_tz_offset_nanoseconds(identifier, utc_epoch)
-                .map(|offset| i128::from(offset.offset) * 1_000_000_000),
+                .map(|transition| i128::from(transition.offset.0) * 1_000_000_000),
         }
     }
 
@@ -428,7 +428,7 @@ impl TimeZone {
                 .with_message("Could not determine the start of day for the provided date."));
         };
 
-        let TimeZoneOffset {
+        let TimeZoneTransitionInfo {
             transition_epoch: Some(transition_epoch),
             ..
         } = provider.get_named_tz_offset_nanoseconds(identifier, after_epoch.0)?

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -91,7 +91,7 @@ impl<'a> IxdtfStringBuilder<'a> {
     }
 }
 
-impl<'a> Writeable for IxdtfStringBuilder<'a> {
+impl Writeable for IxdtfStringBuilder<'_> {
     fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
         self.inner.write_to(sink)
     }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -5,13 +5,17 @@ use core::str::FromStr;
 use crate::{iso::IsoDateTime, unix_time::EpochNanoseconds, TemporalResult};
 use alloc::vec::Vec;
 
-/// `TimeZoneOffset` represents the number of seconds to be added to UT in order to determine local time.
+/// `UtcOffsetSeconds` represents the amount of seconds we need to add to the UTC to reach the local time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct TimeZoneOffset {
+pub struct UtcOffsetSeconds(pub i64);
+
+/// `TimeZoneTransitionInfo` represents information about a timezone transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TimeZoneTransitionInfo {
     /// The transition time epoch at which the offset needs to be applied.
     pub transition_epoch: Option<i64>,
     /// The time zone offset in seconds.
-    pub offset: i64,
+    pub offset: UtcOffsetSeconds,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -67,7 +71,7 @@ pub trait TimeZoneProvider {
         &self,
         identifier: &str,
         epoch_nanoseconds: i128,
-    ) -> TemporalResult<TimeZoneOffset>;
+    ) -> TemporalResult<TimeZoneTransitionInfo>;
 
     // TODO: implement and stabalize
     fn get_named_tz_transition(
@@ -93,7 +97,7 @@ impl TimeZoneProvider for NeverProvider {
         unimplemented!()
     }
 
-    fn get_named_tz_offset_nanoseconds(&self, _: &str, _: i128) -> TemporalResult<TimeZoneOffset> {
+    fn get_named_tz_offset_nanoseconds(&self, _: &str, _: i128) -> TemporalResult<TimeZoneTransitionInfo> {
         unimplemented!()
     }
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -97,7 +97,11 @@ impl TimeZoneProvider for NeverProvider {
         unimplemented!()
     }
 
-    fn get_named_tz_offset_nanoseconds(&self, _: &str, _: i128) -> TemporalResult<TimeZoneTransitionInfo> {
+    fn get_named_tz_offset_nanoseconds(
+        &self,
+        _: &str,
+        _: i128,
+    ) -> TemporalResult<TimeZoneTransitionInfo> {
         unimplemented!()
     }
 

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -87,7 +87,10 @@ pub enum LocalTimeRecordResult {
     Single(UtcOffsetSeconds),
     // Note(nekevss): it may be best to switch this to initial, need to double check
     // disambiguation ops with inverse DST-STD relationship
-    Ambiguous { std: UtcOffsetSeconds, dst: UtcOffsetSeconds },
+    Ambiguous {
+        std: UtcOffsetSeconds,
+        dst: UtcOffsetSeconds,
+    },
 }
 
 impl From<UtcOffsetSeconds> for LocalTimeRecordResult {


### PR DESCRIPTION
Makes it so that our timezone calculations don't depend on the `is_dst` field to calculate if a datetime is within a forward transition.

I think this is a breaking change, but because the timezone providers are unstable, it should be fine.