### PR TITLE
Add TimeZone::utc() to FFI

### DIFF
--- a/temporal_capi/bindings/c/TimeZone.h
+++ b/temporal_capi/bindings/c/TimeZone.h
@@ -27,6 +27,8 @@ temporal_rs_TimeZone_try_from_str_result temporal_rs_TimeZone_try_from_str(Diplo
 
 void temporal_rs_TimeZone_identifier(const TimeZone* self, DiplomatWrite* write);
 
+TimeZone* temporal_rs_TimeZone_utc(void);
+
 TimeZone* temporal_rs_TimeZone_clone(const TimeZone* self);
 
 bool temporal_rs_TimeZone_is_valid(const TimeZone* self);

--- a/temporal_capi/bindings/cpp/temporal_rs/TimeZone.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/TimeZone.d.hpp
@@ -38,6 +38,8 @@ public:
   template<typename W>
   inline void identifier_write(W& writeable_output) const;
 
+  inline static std::unique_ptr<temporal_rs::TimeZone> utc();
+
   inline std::unique_ptr<temporal_rs::TimeZone> clone() const;
 
   inline bool is_valid() const;

--- a/temporal_capi/bindings/cpp/temporal_rs/TimeZone.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/TimeZone.hpp
@@ -30,6 +30,8 @@ namespace capi {
 
     void temporal_rs_TimeZone_identifier(const temporal_rs::capi::TimeZone* self, diplomat::capi::DiplomatWrite* write);
 
+    temporal_rs::capi::TimeZone* temporal_rs_TimeZone_utc(void);
+
     temporal_rs::capi::TimeZone* temporal_rs_TimeZone_clone(const temporal_rs::capi::TimeZone* self);
 
     bool temporal_rs_TimeZone_is_valid(const temporal_rs::capi::TimeZone* self);
@@ -67,6 +69,11 @@ inline void temporal_rs::TimeZone::identifier_write(W& writeable) const {
   diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
   temporal_rs::capi::temporal_rs_TimeZone_identifier(this->AsFFI(),
     &write);
+}
+
+inline std::unique_ptr<temporal_rs::TimeZone> temporal_rs::TimeZone::utc() {
+  auto result = temporal_rs::capi::temporal_rs_TimeZone_utc();
+  return std::unique_ptr<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result));
 }
 
 inline std::unique_ptr<temporal_rs::TimeZone> temporal_rs::TimeZone::clone() const {

--- a/temporal_capi/src/time_zone.rs
+++ b/temporal_capi/src/time_zone.rs
@@ -44,6 +44,10 @@ pub mod ffi {
             let _ = write.write_str(&s);
         }
 
+        pub fn utc() -> Box<Self> {
+            Box::new(Self(temporal_rs::TimeZone::IanaIdentifier("UTC".into())))
+        }
+
         #[allow(clippy::should_implement_trait)]
         pub fn clone(&self) -> Box<TimeZone> {
             Box::new(TimeZone(self.0.clone()))


### PR DESCRIPTION
Cloning is generally useful, and `utc()` allows for infallible construction (currently there is no way to infallibly construct a timezone)