### PR TITLE
Fix `9.5.8 AddDurationToYearMonth` abstract method

### DIFF
--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -323,6 +323,21 @@ impl Duration {
             .map(|x| Unit::from(10 - x.0))
             .unwrap_or(Unit::Nanosecond)
     }
+
+    /// Equivalent of [`7.5.7 ToDateDurationRecordWithoutTime ( duration )`][spec]
+    ///
+    /// [spec]: <https://tc39.es/proposal-temporal/#sec-temporal-tointernaldurationrecordwith24hourdays>
+    ///
+    // spec(2025-06-23): https://github.com/tc39/proposal-temporal/tree/ed49b0b482981119c9b5e28b0686d877d4a9bae0
+    #[allow(clippy::wrong_self_convention)]
+    pub(crate) fn to_date_duration_record_without_time(&self) -> TemporalResult<DateDuration> {
+        // 1. Let internalDuration be ToInternalDurationRecordWith24HourDays(duration).
+        let internal_duration = NormalizedDurationRecord::from_duration_with_24_hour_days(self)?;
+
+        // 2. Let days be truncate(internalDuration.[[Time]] / nsPerDay).
+        // 3. Return ! CreateDateDurationRecord(internalDuration.[[Date]].[[Years]], internalDuration.[[Date]].[[Months]], internalDuration.[[Date]].[[Weeks]], days).
+        internal_duration.to_date_duration_record_without_time()
+    }
 }
 
 // ==== Public Duration API ====

--- a/src/builtins/core/duration/normalized.rs
+++ b/src/builtins/core/duration/normalized.rs
@@ -270,6 +270,28 @@ impl NormalizedDurationRecord {
         Self::new(date, normalized_time)
     }
 
+    /// Equivalent of [`7.5.7 ToDateDurationRecordWithoutTime ( duration )`][spec]
+    ///
+    /// [spec]: <https://tc39.es/proposal-temporal/#sec-temporal-tointernaldurationrecordwith24hourdays>
+    ///
+    // spec(2025-06-23): https://github.com/tc39/proposal-temporal/tree/ed49b0b482981119c9b5e28b0686d877d4a9bae0
+    #[allow(clippy::wrong_self_convention)]
+    pub(crate) fn to_date_duration_record_without_time(&self) -> TemporalResult<DateDuration> {
+        // 1. Let internalDuration be ToInternalDurationRecordWith24HourDays(duration).
+        let internal_duration = self;
+
+        // 2. Let days be truncate(internalDuration.[[Time]] / nsPerDay).
+        let days = internal_duration.normalized_time_duration().0 / i128::from(NS_PER_DAY);
+
+        // 3. Return ! CreateDateDurationRecord(internalDuration.[[Date]].[[Years]], internalDuration.[[Date]].[[Months]], internalDuration.[[Date]].[[Weeks]], days).
+        Ok(DateDuration::new_unchecked(
+            internal_duration.date().years,
+            internal_duration.date().months,
+            internal_duration.date().weeks,
+            days.try_into().ok().temporal_unwrap()?,
+        ))
+    }
+
     pub(crate) fn from_date_duration(date: DateDuration) -> TemporalResult<Self> {
         Self::new(date, NormalizedTimeDuration::default())
     }

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -13,14 +13,15 @@ use crate::{
     },
     parsers::{FormattableCalendar, FormattableDate, FormattableYearMonth},
     provider::NeverProvider,
+    temporal_assert,
     utils::pad_iso_year,
     Calendar, MonthCode, TemporalError, TemporalResult, TemporalUnwrap, TimeZone,
 };
 use icu_calendar::AnyCalendarKind;
 
 use super::{
-    calendar::month_to_month_code, duration::normalized::NormalizedDurationRecord, Duration,
-    PartialDate, PlainDate, PlainDateTime,
+    calendar::month_to_month_code, duration::normalized::NormalizedDurationRecord, DateDuration,
+    Duration, PartialDate, PlainDate, PlainDateTime,
 };
 use writeable::Writeable;
 
@@ -279,25 +280,89 @@ impl PlainYearMonth {
         Self { iso, calendar }
     }
 
+    /// [`9.5.8 AddDurationToYearMonth(operation, yearMonth, temporalDurationLike, options)`][spec]
+    ///
     /// Internal addition method for adding `Duration` to a `PlainYearMonth`
-    pub(crate) fn add_or_subtract_duration(
+    ///
+    /// [spec]: <https://tc39.es/proposal-temporal/#sec-temporal-adddurationtoyearmonth>
+    ///
+    // spec(2025-06-23): https://github.com/tc39/proposal-temporal/tree/ed49b0b482981119c9b5e28b0686d877d4a9bae0
+    pub(crate) fn add_duration(
         &self,
         duration: &Duration,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<Self> {
-        // Potential TODO: update to current Temporal specification
-        let partial = PartialYearMonth::try_from_year_month(self)?;
+        // NOTE: The following are engine specific:
+        //    SKIP: 1. Let duration be ? ToTemporalDuration(temporalDurationLike).
 
-        let mut intermediate_date = self
-            .calendar()
-            .date_from_partial(&PartialDate::from(&partial), overflow)?;
+        // NOTE: The following operation has been moved to the caller.
+        //    MOVE: 2. If operation is subtract, set duration to CreateNegatedTemporalDuration(duration).
 
-        intermediate_date = intermediate_date.add_date(duration, Some(overflow))?;
+        // NOTE: The following are engine specific:
+        //    SKIP: 3. Let resolvedOptions be ? GetOptionsObject(options).
+        //    SKIP: 4. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
 
-        let result_fields = PartialDate::default().with_fallback_date(&intermediate_date)?;
+        // 5. Let sign be DurationSign(duration).
+        let sign = duration.sign();
 
-        self.calendar()
-            .year_month_from_partial(&PartialYearMonth::from(&result_fields), overflow)
+        // 6. Let calendar be yearMonth.[[Calendar]].
+        let calendar = self.calendar();
+
+        // 7. Let fields be ISODateToFields(calendar, yearMonth.[[ISODate]], year-month).
+        let fields = PartialDate::from(&PartialYearMonth::try_from_year_month(self)?);
+
+        // 8. Set fields.[[Day]] to 1.
+        let fields = fields.with_day(Some(1));
+
+        // 9. Let intermediateDate be ? CalendarDateFromFields(calendar, fields, constrain).
+        let intermediate_date = calendar.date_from_partial(&fields, overflow)?;
+
+        // 10. If sign < 0, then
+        let date = if sign.as_sign_multiplier() < 0 {
+            // a. Let oneMonthDuration be ! CreateDateDurationRecord(0, 1, 0, 0).
+            let one_month_duration = DateDuration::new_unchecked(0, 1, 0, 0);
+
+            // b. Let nextMonth be ? CalendarDateAdd(calendar, intermediateDate, oneMonthDuration, constrain).
+            let next_month = calendar.date_add(
+                &intermediate_date.iso,
+                &Duration::from(one_month_duration),
+                ArithmeticOverflow::Constrain,
+            )?;
+
+            // c. Let date be BalanceISODate(nextMonth.[[Year]], nextMonth.[[Month]], nextMonth.[[Day]] - 1).
+            let date = IsoDate::balance(
+                next_month.year(),
+                i32::from(next_month.month()),
+                i32::from(next_month.day())
+                    .checked_sub(1)
+                    .temporal_unwrap()?,
+            );
+
+            // d. Assert: ISODateWithinLimits(date) is true.
+            temporal_assert!(date.is_valid());
+
+            date
+        } else {
+            // 11. Else,
+            //    a. Let date be intermediateDate.
+            intermediate_date.iso
+        };
+
+        // 12. Let durationToAdd be ToDateDurationRecordWithoutTime(duration).
+        let duration_to_add = duration.to_date_duration_record_without_time()?;
+
+        // 13. Let addedDate be ? CalendarDateAdd(calendar, date, durationToAdd, overflow).
+        let added_date = calendar.date_add(&date, &Duration::from(duration_to_add), overflow)?;
+
+        // 14. Let addedDateFields be ISODateToFields(calendar, addedDate, year-month).
+        let added_date_fields =
+            PartialYearMonth::from(&PartialDate::default().with_fallback_date(&added_date)?);
+
+        // 15. Let isoDate be ? CalendarYearMonthFromFields(calendar, addedDateFields, overflow).
+        let iso_date = calendar.year_month_from_partial(&added_date_fields, overflow)?;
+
+        // 16. Return ! CreateTemporalYearMonth(isoDate, calendar).
+        Ok(iso_date)
     }
 
     /// The internal difference operation of `PlainYearMonth`.
@@ -622,7 +687,7 @@ impl PlainYearMonth {
     /// Adds a [`Duration`] from the current `PlainYearMonth`.
     #[inline]
     pub fn add(&self, duration: &Duration, overflow: ArithmeticOverflow) -> TemporalResult<Self> {
-        self.add_or_subtract_duration(duration, overflow)
+        self.add_duration(duration, overflow)
     }
 
     /// Subtracts a [`Duration`] from the current `PlainYearMonth`.
@@ -632,7 +697,7 @@ impl PlainYearMonth {
         duration: &Duration,
         overflow: ArithmeticOverflow,
     ) -> TemporalResult<Self> {
-        self.add_or_subtract_duration(&duration.negated(), overflow)
+        self.add_duration(&duration.negated(), overflow)
     }
 
     /// Returns a `Duration` representing the period of time from this `PlainYearMonth` until the other `PlainYearMonth`.


### PR DESCRIPTION
This PR fixes the regression introduced in `v0.0.10` (see boa-dev/boa#4318) by aligning the `9.5.8 AddDurationToYearMonth` abstract method to the latest specification (tc39/proposal-temporal@ed49b0b482981119c9b5e28b0686d877d4a9bae0).

This additionally fixes some tests that were unrelated to the regressions :partying_face: :

### Test262 conformance changes

| Test result | main count | PR count | difference |
| :---------: | :----------: | :------: | :--------: |
| Total | 50,595 | 50,595 | 0 |
| Passed | 47,259 | 47,291 | **+32** |
| Ignored | 1,964 | 1,964 | 0 |
| Failed | 1,372 | 1,340 | **-32** |
| Panics | 0 | 0 | 0 |
| Conformance | 93.41% | 93.47% | **+0.06%** |

<details><summary><b>Fixed tests (32):</b></summary>

```
test/built-ins/Temporal/PlainYearMonth/prototype/subtract/month-length.js (previously Failed)
test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-lower-units.js (previously Failed)
test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-duration-max.js (previously Failed)
test/built-ins/Temporal/PlainYearMonth/prototype/subtract/argument-string-negative-fractional-units.js (previously Failed)
test/built-ins/Temporal/PlainYearMonth/prototype/subtract/subtract-from-last-representable-month.js (previously Failed)
test/built-ins/Temporal/PlainYearMonth/prototype/subtract/end-of-month-out-of-range.js (previously Failed)
test/built-ins/Temporal/PlainYearMonth/prototype/add/month-length.js (previously Failed)
test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-lower-units.js (previously Failed)
test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-duration-max.js (previously Failed)
test/built-ins/Temporal/PlainYearMonth/prototype/add/argument-string-negative-fractional-units.js (previously Failed)
test/built-ins/Temporal/PlainYearMonth/prototype/add/subtract-from-last-representable-month.js (previously Failed)
test/built-ins/Temporal/PlainYearMonth/prototype/add/end-of-month-out-of-range.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/calendar-always.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-date-with-utc-offset.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/prototype/equals/leap-second.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-time-zone-annotation.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-calendar-annotation.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-unknown-annotation.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-time-separators.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/prototype/valueOf/basic.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/prototype/with/monthdaylike-invalid.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/from/fields-string.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/from/argument-string-date-with-utc-offset.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/from/leap-second.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/from/argument-string-time-zone-annotation.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/from/argument-string-calendar-annotation.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/from/argument-string-unknown-annotation.js (previously Failed)
test/built-ins/Temporal/PlainMonthDay/from/argument-string-time-separators.js (previously Failed)
test/built-ins/Temporal/PlainDate/prototype/with/plaindatelike-invalid.js (previously Failed)
test/built-ins/Temporal/PlainTime/prototype/with/plaintimelike-invalid.js (previously Failed)
test/staging/Temporal/Regex/old/plainmonthday.js (previously Failed)
```
</details>