### PR TITLE
Expose ParseTemporalCalendarString over FFI

### DIFF
--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -161,7 +161,7 @@ impl FromStr for Calendar {
 
     // 13.34 ParseTemporalCalendarString ( string )
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match parse_allowed_calendar_formats(s) {
+        match parse_allowed_calendar_formats(s.as_bytes()) {
             Some([]) => Ok(Calendar::ISO),
             Some(result) => Calendar::try_from_utf8(result),
             None => Calendar::try_from_utf8(s.as_bytes()),

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -841,6 +841,8 @@ pub(crate) fn parse_time(source: &[u8]) -> TemporalResult<TimeRecord> {
     }
 }
 
+/// Consider this API to be unstable: it is used internally by temporal_capi but
+/// will likely be replaced with a proper TemporalParser API at some point.
 #[inline]
 pub fn parse_allowed_calendar_formats(s: &[u8]) -> Option<&[u8]> {
     if let Ok(r) = parse_ixdtf(s, ParseVariant::DateTime).map(|r| r.calendar) {

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -842,14 +842,14 @@ pub(crate) fn parse_time(source: &[u8]) -> TemporalResult<TimeRecord> {
 }
 
 #[inline]
-pub(crate) fn parse_allowed_calendar_formats(s: &str) -> Option<&[u8]> {
-    if let Ok(r) = parse_ixdtf(s.as_bytes(), ParseVariant::DateTime).map(|r| r.calendar) {
+pub fn parse_allowed_calendar_formats(s: &[u8]) -> Option<&[u8]> {
+    if let Ok(r) = parse_ixdtf(s, ParseVariant::DateTime).map(|r| r.calendar) {
         return Some(r.unwrap_or(&[]));
-    } else if let Ok(r) = IxdtfParser::from_str(s).parse_time().map(|r| r.calendar) {
+    } else if let Ok(r) = IxdtfParser::from_utf8(s).parse_time().map(|r| r.calendar) {
         return Some(r.unwrap_or(&[]));
-    } else if let Ok(r) = parse_ixdtf(s.as_bytes(), ParseVariant::YearMonth).map(|r| r.calendar) {
+    } else if let Ok(r) = parse_ixdtf(s, ParseVariant::YearMonth).map(|r| r.calendar) {
         return Some(r.unwrap_or(&[]));
-    } else if let Ok(r) = parse_ixdtf(s.as_bytes(), ParseVariant::MonthDay).map(|r| r.calendar) {
+    } else if let Ok(r) = parse_ixdtf(s, ParseVariant::MonthDay).map(|r| r.calendar) {
         return Some(r.unwrap_or(&[]));
     }
     None

--- a/temporal_capi/bindings/c/AnyCalendarKind.h
+++ b/temporal_capi/bindings/c/AnyCalendarKind.h
@@ -18,6 +18,9 @@
 typedef struct temporal_rs_AnyCalendarKind_get_for_str_result {union {AnyCalendarKind ok; }; bool is_ok;} temporal_rs_AnyCalendarKind_get_for_str_result;
 temporal_rs_AnyCalendarKind_get_for_str_result temporal_rs_AnyCalendarKind_get_for_str(DiplomatStringView s);
 
+typedef struct temporal_rs_AnyCalendarKind_parse_temporal_calendar_string_result {union {AnyCalendarKind ok; }; bool is_ok;} temporal_rs_AnyCalendarKind_parse_temporal_calendar_string_result;
+temporal_rs_AnyCalendarKind_parse_temporal_calendar_string_result temporal_rs_AnyCalendarKind_parse_temporal_calendar_string(DiplomatStringView s);
+
 
 
 

--- a/temporal_capi/bindings/cpp/temporal_rs/AnyCalendarKind.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/AnyCalendarKind.d.hpp
@@ -77,6 +77,8 @@ public:
 
   inline static std::optional<temporal_rs::AnyCalendarKind> get_for_str(std::string_view s);
 
+  inline static std::optional<temporal_rs::AnyCalendarKind> parse_temporal_calendar_string(std::string_view s);
+
   inline temporal_rs::capi::AnyCalendarKind AsFFI() const;
   inline static temporal_rs::AnyCalendarKind FromFFI(temporal_rs::capi::AnyCalendarKind c_enum);
 private:

--- a/temporal_capi/bindings/cpp/temporal_rs/AnyCalendarKind.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/AnyCalendarKind.hpp
@@ -21,6 +21,9 @@ namespace capi {
     typedef struct temporal_rs_AnyCalendarKind_get_for_str_result {union {temporal_rs::capi::AnyCalendarKind ok; }; bool is_ok;} temporal_rs_AnyCalendarKind_get_for_str_result;
     temporal_rs_AnyCalendarKind_get_for_str_result temporal_rs_AnyCalendarKind_get_for_str(diplomat::capi::DiplomatStringView s);
 
+    typedef struct temporal_rs_AnyCalendarKind_parse_temporal_calendar_string_result {union {temporal_rs::capi::AnyCalendarKind ok; }; bool is_ok;} temporal_rs_AnyCalendarKind_parse_temporal_calendar_string_result;
+    temporal_rs_AnyCalendarKind_parse_temporal_calendar_string_result temporal_rs_AnyCalendarKind_parse_temporal_calendar_string(diplomat::capi::DiplomatStringView s);
+
     } // extern "C"
 } // namespace capi
 } // namespace
@@ -57,6 +60,11 @@ inline temporal_rs::AnyCalendarKind temporal_rs::AnyCalendarKind::FromFFI(tempor
 
 inline std::optional<temporal_rs::AnyCalendarKind> temporal_rs::AnyCalendarKind::get_for_str(std::string_view s) {
   auto result = temporal_rs::capi::temporal_rs_AnyCalendarKind_get_for_str({s.data(), s.size()});
+  return result.is_ok ? std::optional<temporal_rs::AnyCalendarKind>(temporal_rs::AnyCalendarKind::FromFFI(result.ok)) : std::nullopt;
+}
+
+inline std::optional<temporal_rs::AnyCalendarKind> temporal_rs::AnyCalendarKind::parse_temporal_calendar_string(std::string_view s) {
+  auto result = temporal_rs::capi::temporal_rs_AnyCalendarKind_parse_temporal_calendar_string({s.data(), s.size()});
   return result.is_ok ? std::optional<temporal_rs::AnyCalendarKind>(temporal_rs::AnyCalendarKind::FromFFI(result.ok)) : std::nullopt;
 }
 #endif // temporal_rs_AnyCalendarKind_HPP

--- a/temporal_capi/src/calendar.rs
+++ b/temporal_capi/src/calendar.rs
@@ -48,6 +48,15 @@ pub mod ffi {
                 Err(()) => None,
             }
         }
+
+        // https://tc39.es/proposal-temporal/#sec-temporal-parsetemporalcalendarstring
+        pub fn parse_temporal_calendar_string(s: &DiplomatStr) -> Option<Self> {
+            match temporal_rs::parsers::parse_allowed_calendar_formats(s) {
+                Some([]) => Some(AnyCalendarKind::Iso),
+                Some(result) => Self::get_for_str(result),
+                None => Self::get_for_str(s),
+            }
+        }
     }
 
     #[diplomat::opaque]


### PR DESCRIPTION
This is the most convenient way for this API to exist for me; since it's cheaper to not work with `Calendar`s over FFI.

It would be nice if these "calendar kind from string" APIs were available in temporal_rs without going through either `icu_locale` `Value` or going through `Calendar`.