### PR TITLE
Remove UTC designator check from time zone parsing

### DIFF
--- a/src/builtins/compiled/zoneddatetime.rs
+++ b/src/builtins/compiled/zoneddatetime.rs
@@ -378,7 +378,7 @@ mod tests {
         let zdt = ZonedDateTime::try_new(
             nov_30_2023_utc,
             Calendar::from_str("iso8601").unwrap(),
-            TimeZone::try_from_str("Z").unwrap(),
+            TimeZone::try_from_str("UTC").unwrap(),
         )
         .unwrap();
 

--- a/src/builtins/core/timezone.rs
+++ b/src/builtins/core/timezone.rs
@@ -111,9 +111,6 @@ impl TimeZone {
 
     /// Parses a `TimeZone` from a provided `&str`.
     pub fn try_from_identifier_str(identifier: &str) -> TemporalResult<Self> {
-        if identifier == "Z" {
-            return Ok(TimeZone::UtcOffset(UtcOffset(0)));
-        }
         parse_identifier(identifier).map(|tz| match tz {
             TimeZoneRecord::Name(items) => Ok(TimeZone::IanaIdentifier(
                 from_utf8(items)
@@ -129,11 +126,13 @@ impl TimeZone {
         })?
     }
 
+    /// Parse a `TimeZone` from a `&str`
+    ///
+    /// This is the equivalent to [`ParseTemporalTimeZoneString`](https://tc39.es/proposal-temporal/#sec-temporal-parsetemporaltimezonestring)
     pub fn try_from_str(src: &str) -> TemporalResult<Self> {
         if let Ok(timezone) = Self::try_from_identifier_str(src) {
             return Ok(timezone);
         }
-
         parse_allowed_timezone_formats(src)
             .ok_or_else(|| TemporalError::range().with_message("Not a valid time zone string"))
     }

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -1511,7 +1511,7 @@ mod tests {
         let zdt = ZonedDateTime::try_new(
             nov_30_2023_utc,
             Calendar::from_str("iso8601").unwrap(),
-            TimeZone::try_from_str("Z").unwrap(),
+            TimeZone::try_from_str("UTC").unwrap(),
         )
         .unwrap();
 


### PR DESCRIPTION
This PR addresses #391. 

It removes any handling of `Z` from the code path. This seems to be holdover from the very early days of the time zone implementation and was not correct.