### PR TITLE
Update README.md - mention other usages of lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ proposed for addition to the ECMAScript specification.
 
 `temporal_rs` is an implementation of Temporal in Rust that aims to be
 100% test compliant. While initially developed for [Boa][boa-repo], the
-crate has been externalized as we intended to make an engine agnostic
-and general usage implementation of Temporal and its algorithms.
+crate has been externalized and is being used in other engines such as [V8](https://v8.dev) and [Kiesel](https://codeberg.org/kiesel-js/kiesel).
 
 For more information on `temporal_rs`'s general position in the Rust
 date/time library ecoystem, see our [FAQ](./docs/FAQ.md).


### PR DESCRIPTION
There are some linking to temporal_rs when mentioning V8 using a library but there’s no mention of it here so it’s a bit confusing.

We should change the text from “we’re planning for this to be agnostic” to “ this is agnostic and it’s being used here also”