### PR TITLE
Fix duration validity check

### DIFF
--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -1215,15 +1215,16 @@ pub(crate) fn is_valid_duration(
         }
     }
     // 3. If abs(years) ≥ 2**32, return false.
-    if years.abs() >= u32::MAX as i64 {
+    // n.b. u32::MAX is 2**32 - 1
+    if years.abs() > u32::MAX as i64 {
         return false;
     };
     // 4. If abs(months) ≥ 2**32, return false.
-    if months.abs() >= u32::MAX as i64 {
+    if months.abs() > u32::MAX as i64 {
         return false;
     };
     // 5. If abs(weeks) ≥ 2**32, return false.
-    if weeks.abs() >= u32::MAX as i64 {
+    if weeks.abs() > u32::MAX as i64 {
         return false;
     };
 


### PR DESCRIPTION
This breaks Intl.DurationFormat tests