### PR TITLE
Use track_caller in assertion errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -86,8 +86,17 @@ impl TemporalError {
     /// Creates an assertion error
     #[inline]
     #[must_use]
+    #[cfg_attr(debug_assertions, track_caller)]
     pub(crate) const fn assert() -> Self {
-        Self::new(ErrorKind::Assert)
+        #[cfg(not(debug_assertions))]
+        {
+            Self::new(ErrorKind::Assert)
+        }
+        #[cfg(debug_assertions)]
+        Self {
+            kind: ErrorKind::Assert,
+            msg: Cow::Borrowed(core::panic::Location::caller().file()),
+        }
     }
 
     /// Create an abrupt end error.


### PR DESCRIPTION
Helps track them: Assertion errors will now get a file context, which is better than nothing.

Unfortunately I need to use `format!()` to get file/col info together, which I can't do by in const. I could if we included column info as a separate field here.