### PR TITLE
Allow adding date durations to PlainTime

### DIFF
--- a/src/builtins/core/time.rs
+++ b/src/builtins/core/time.rs
@@ -505,10 +505,6 @@ impl PlainTime {
 
     /// Add a `Duration` to the current `Time`.
     pub fn add(&self, duration: &Duration) -> TemporalResult<Self> {
-        if !duration.is_time_duration() {
-            return Err(TemporalError::range()
-                .with_message("DateDuration values cannot be added to `Time`."));
-        }
         self.add_time_duration(duration.time())
     }
 
@@ -520,10 +516,6 @@ impl PlainTime {
 
     /// Subtract a `Duration` to the current `Time`.
     pub fn subtract(&self, duration: &Duration) -> TemporalResult<Self> {
-        if !duration.is_time_duration() {
-            return Err(TemporalError::range()
-                .with_message("DateDuration values cannot be added to `Time` component."));
-        }
         self.subtract_time_duration(duration.time())
     }
 


### PR DESCRIPTION
https://tc39.es/proposal-temporal/#sec-temporal-adddurationtotime

This error is not there in the spec (there's a similar error in AddDurationToInstant, which might have been copied over)