### PR TITLE
Move nanoseconds-validity checking to being explicit

### DIFF
--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -383,7 +383,7 @@ impl PlainDate {
         // 12. If roundingGranularityIsNoop is false, then
         if !rounding_granularity_is_noop {
             // a. Let destEpochNs be GetUTCEpochNanoseconds(other.[[ISOYear]], other.[[ISOMonth]], other.[[ISODay]], 0, 0, 0, 0, 0, 0).
-            let dest_epoch_ns = other.iso.as_nanoseconds()?;
+            let dest_epoch_ns = other.iso.as_nanoseconds();
             // b. Let dateTime be ISO Date-Time Record { [[Year]]: temporalDate.[[ISOYear]], [[Month]]: temporalDate.[[ISOMonth]], [[Day]]: temporalDate.[[ISODay]], [[Hour]]: 0, [[Minute]]: 0, [[Second]]: 0, [[Millisecond]]: 0, [[Microsecond]]: 0, [[Nanosecond]]: 0 }.
             let dt = PlainDateTime::new_unchecked(
                 IsoDateTime::new_unchecked(self.iso, IsoTime::default()),

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -303,7 +303,7 @@ impl PlainDateTime {
         }
 
         // 5. Let destEpochNs be GetUTCEpochNanoseconds(isoDateTime2).
-        let dest_epoch_ns = other.iso.as_nanoseconds()?;
+        let dest_epoch_ns = other.iso.as_nanoseconds();
         // 6. Return ? RoundRelativeDuration(diff, destEpochNs, isoDateTime1, unset, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode).
         diff.round_relative_duration(
             dest_epoch_ns.0,
@@ -331,7 +331,7 @@ impl PlainDateTime {
             return FiniteF64::try_from(diff.normalized_time_duration().0);
         }
         // 5. Let destEpochNs be GetUTCEpochNanoseconds(isoDateTime2).
-        let dest_epoch_ns = other.iso.as_nanoseconds()?;
+        let dest_epoch_ns = other.iso.as_nanoseconds();
         // 6. Return ? TotalRelativeDuration(diff, destEpochNs, isoDateTime1, unset, calendar, unit).
         diff.total_relative_duration(
             dest_epoch_ns.0,

--- a/src/builtins/core/duration/normalized.rs
+++ b/src/builtins/core/duration/normalized.rs
@@ -562,7 +562,7 @@ impl NormalizedDurationRecord {
         } else {
             // a. Let startEpochNs be GetUTCEpochNanoseconds(start.[[Year]], start.[[Month]], start.[[Day]], start.[[Hour]], start.[[Minute]], start.[[Second]], start.[[Millisecond]], start.[[Microsecond]], start.[[Nanosecond]]).
             // b. Let endEpochNs be GetUTCEpochNanoseconds(end.[[Year]], end.[[Month]], end.[[Day]], end.[[Hour]], end.[[Minute]], end.[[Second]], end.[[Millisecond]], end.[[Microsecond]], end.[[Nanosecond]]).
-            (start.as_nanoseconds()?, end.as_nanoseconds()?)
+            (start.as_nanoseconds(), end.as_nanoseconds())
         };
 
         // 9. If endEpochNs = startEpochNs, throw a RangeError exception.
@@ -900,7 +900,7 @@ impl NormalizedDurationRecord {
                     // vi. If timeZone is unset, then
                     None => {
                         // 1. Let endEpochNs be GetUTCEpochNanoseconds(endDateTime).
-                        end_date_time.as_nanoseconds()?
+                        end_date_time.as_nanoseconds()
                     }
                     // vii. Else,
                     Some((time_zone, time_zone_provider)) => {

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -163,10 +163,13 @@ impl Instant {
     ///
     /// Temporal-Proposal equivalent: `AddInstant`.
     pub(crate) fn add_to_instant(&self, duration: &TimeDuration) -> TemporalResult<Self> {
+        // 1. Let result be AddTimeDurationToEpochNanoseconds(timeDuration, epochNanoseconds).
         let norm = NormalizedTimeDuration::from_time_duration(duration);
         let result = self.epoch_nanoseconds().0 + norm.0;
         let ns = EpochNanoseconds::from(result);
+        // 2. If IsValidEpochNanoseconds(result) is false, throw a RangeError exception.
         ns.check_validity()?;
+        // 3. Return result.
         Ok(Self::from(ns))
     }
 
@@ -321,6 +324,8 @@ impl Instant {
         );
 
         let nanoseconds = balanced.as_nanoseconds();
+
+        nanoseconds.check_validity()?;
 
         Ok(Self(nanoseconds))
     }

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -165,7 +165,9 @@ impl Instant {
     pub(crate) fn add_to_instant(&self, duration: &TimeDuration) -> TemporalResult<Self> {
         let norm = NormalizedTimeDuration::from_time_duration(duration);
         let result = self.epoch_nanoseconds().0 + norm.0;
-        Ok(Self::from(EpochNanoseconds::try_from(result)?))
+        let ns = EpochNanoseconds::from(result);
+        ns.check_validity()?;
+        Ok(Self::from(ns))
     }
 
     /// `temporal_rs` equivalent of `DifferenceInstant`
@@ -265,7 +267,9 @@ impl Instant {
     /// Create a new validated `Instant`.
     #[inline]
     pub fn try_new(nanoseconds: i128) -> TemporalResult<Self> {
-        Ok(Self::from(EpochNanoseconds::try_from(nanoseconds)?))
+        let ns = EpochNanoseconds::from(nanoseconds);
+        ns.check_validity()?;
+        Ok(Self::from(ns))
     }
 
     /// Creates a new `Instant` from the provided Epoch millisecond value.
@@ -316,7 +320,7 @@ impl Instant {
             i128::from(nanosecond) - i128::from(ns_offset),
         );
 
-        let nanoseconds = balanced.as_nanoseconds()?;
+        let nanoseconds = balanced.as_nanoseconds();
 
         Ok(Self(nanoseconds))
     }

--- a/src/builtins/core/now.rs
+++ b/src/builtins/core/now.rs
@@ -140,13 +140,13 @@ mod tests {
         let provider = FsTzdbProvider::default();
 
         // 2025-03-11T10:47-06:00
-        const TIME_BASE: u128 = 1_741_751_188_077_363_694;
+        const TIME_BASE: i128 = 1_741_751_188_077_363_694;
 
         let cdt = TimeZone::try_from_identifier_str_with_provider("-05:00", &provider).unwrap();
         let uschi =
             TimeZone::try_from_identifier_str_with_provider("America/Chicago", &provider).unwrap();
 
-        let base = EpochNanoseconds::try_from(TIME_BASE).unwrap();
+        let base = EpochNanoseconds::from(TIME_BASE);
         let now = NowBuilder::default()
             .with_system_nanoseconds(base)
             .with_system_zone(cdt.clone())
@@ -175,7 +175,7 @@ mod tests {
         assert_eq!(cdt_datetime, uschi_datetime);
 
         let plus_5_secs = TIME_BASE + (5 * 1_000_000_000);
-        let plus_5_epoch = EpochNanoseconds::try_from(plus_5_secs).unwrap();
+        let plus_5_epoch = EpochNanoseconds::from(plus_5_secs);
         let plus_5_now = NowBuilder::default()
             .with_system_nanoseconds(plus_5_epoch)
             .with_system_zone(cdt)

--- a/src/builtins/core/timezone.rs
+++ b/src/builtins/core/timezone.rs
@@ -311,7 +311,7 @@ impl TimeZone {
                 // b. Perform ? CheckISODaysRange(balanced.[[ISODate]]).
                 balanced.date.is_valid_day_range()?;
                 // c. Let epochNanoseconds be GetUTCEpochNanoseconds(balanced).
-                let epoch_ns = balanced.as_nanoseconds()?;
+                let epoch_ns = balanced.as_nanoseconds();
                 // d. Let possibleEpochNanoseconds be « epochNanoseconds ».
                 vec![epoch_ns]
             }
@@ -327,6 +327,9 @@ impl TimeZone {
         };
         // 4. For each value epochNanoseconds in possibleEpochNanoseconds, do
         // a . If IsValidEpochNanoseconds(epochNanoseconds) is false, throw a RangeError exception.
+        for ns in possible_nanoseconds {
+            ns.check_validity()?;
+        }
         // 5. Return possibleEpochNanoseconds.
         Ok(possible_nanoseconds)
     }
@@ -523,7 +526,9 @@ impl TimeZone {
         // let provider.
         // 6. Assert: possibleEpochNsAfter's length = 1.
         // 7. Return possibleEpochNsAfter[0].
-        EpochNanoseconds::try_from(i128::from(transition_epoch) * 1_000_000_000)
+        Ok(EpochNanoseconds::from(
+            i128::from(transition_epoch) * 1_000_000_000,
+        ))
     }
 }
 

--- a/src/builtins/core/timezone.rs
+++ b/src/builtins/core/timezone.rs
@@ -230,7 +230,12 @@ impl TimeZone {
         instant: &Instant,
         provider: &impl TimeZoneProvider,
     ) -> TemporalResult<IsoDateTime> {
+        // 1. Let offsetNanoseconds be GetOffsetNanosecondsFor(timeZone, epochNs).
         let nanos = self.get_offset_nanos_for(instant.as_i128(), provider)?;
+        // 2. Let result be GetISOPartsFromEpoch(ℝ(epochNs)).
+        // 3. Return BalanceISODateTime(result.[[ISODate]].[[Year]], result.[[ISODate]].[[Month]], result.[[ISODate]].[[Day]],
+        // result.[[Time]].[[Hour]], result.[[Time]].[[Minute]], result.[[Time]].[[Second]], result.[[Time]].[[Millisecond]],
+        // result.[[Time]].[[Microsecond]], result.[[Time]].[[Nanosecond]] + offsetNanoseconds).
         IsoDateTime::from_epoch_nanos(instant.epoch_nanoseconds(), nanos.to_i64().unwrap_or(0))
     }
 
@@ -327,7 +332,7 @@ impl TimeZone {
         };
         // 4. For each value epochNanoseconds in possibleEpochNanoseconds, do
         // a . If IsValidEpochNanoseconds(epochNanoseconds) is false, throw a RangeError exception.
-        for ns in possible_nanoseconds {
+        for ns in &possible_nanoseconds {
             ns.check_validity()?;
         }
         // 5. Return possibleEpochNanoseconds.

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -428,7 +428,7 @@ impl PlainYearMonth {
             // b. Let isoDateTimeOther be CombineISODateAndTimeRecord(otherDate, MidnightTimeRecord()).
             let target_iso_date_time = IsoDateTime::new_unchecked(other.iso, IsoTime::default());
             // c. Let destEpochNs be GetUTCEpochNanoseconds(isoDateTimeOther).
-            let dest_epoch_ns = target_iso_date_time.as_nanoseconds()?;
+            let dest_epoch_ns = target_iso_date_time.as_nanoseconds();
             // d. Set duration to ? RoundRelativeDuration(duration, destEpochNs, isoDateTime, unset, calendar, resolved.[[LargestUnit]], resolved.[[RoundingIncrement]], resolved.[[SmallestUnit]], resolved.[[RoundingMode]]).
             duration = duration.round_relative_duration(
                 dest_epoch_ns.as_i128(),

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -1468,9 +1468,11 @@ pub(crate) fn interpret_isodatetime_offset(
             iso.date.is_valid_day_range()?;
 
             // c. Let epochNanoseconds be GetUTCEpochNanoseconds(balanced).
+            let ns = iso.as_nanoseconds();
             // d. If IsValidEpochNanoseconds(epochNanoseconds) is false, throw a RangeError exception.
+            ns.check_validity()?;
             // e. Return epochNanoseconds.
-            iso.as_nanoseconds()
+            Ok(ns)
         }
         // 5. Assert: offsetBehaviour is option.
         // 6. Assert: offsetOption is prefer or reject.
@@ -1479,7 +1481,7 @@ pub(crate) fn interpret_isodatetime_offset(
             date.is_valid_day_range()?;
             let iso = IsoDateTime::new_unchecked(date, time);
             // 8. Let utcEpochNanoseconds be GetUTCEpochNanoseconds(isoDateTime).
-            let utc_epochs = iso.as_nanoseconds()?;
+            let utc_epochs = iso.as_nanoseconds();
             // 9. Let possibleEpochNs be ? GetPossibleEpochNanoseconds(timeZone, isoDateTime).
             let possible_nanos = timezone.get_possible_epoch_ns_for(iso, provider)?;
             // 10. For each element candidate of possibleEpochNs, do

--- a/src/epoch_nanoseconds.rs
+++ b/src/epoch_nanoseconds.rs
@@ -1,37 +1,11 @@
-use num_traits::FromPrimitive;
-
-use crate::{error::ErrorMessage, TemporalError, NS_MAX_INSTANT};
+use crate::{error::ErrorMessage, TemporalError};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EpochNanoseconds(pub(crate) i128);
 
-impl TryFrom<i128> for EpochNanoseconds {
-    type Error = TemporalError;
-    fn try_from(value: i128) -> Result<Self, Self::Error> {
-        if !is_valid_epoch_nanos(&value) {
-            return Err(TemporalError::range().with_enum(ErrorMessage::InstantOutOfRange));
-        }
-        Ok(Self(value))
-    }
-}
-
-impl TryFrom<u128> for EpochNanoseconds {
-    type Error = TemporalError;
-    fn try_from(value: u128) -> Result<Self, Self::Error> {
-        if (NS_MAX_INSTANT as u128) < value {
-            return Err(TemporalError::range().with_enum(ErrorMessage::InstantOutOfRange));
-        }
-        Ok(Self(value as i128))
-    }
-}
-
-impl TryFrom<f64> for EpochNanoseconds {
-    type Error = TemporalError;
-    fn try_from(value: f64) -> Result<Self, Self::Error> {
-        let Some(value) = i128::from_f64(value) else {
-            return Err(TemporalError::range().with_enum(ErrorMessage::InstantOutOfRange));
-        };
-        Self::try_from(value)
+impl From<i128> for EpochNanoseconds {
+    fn from(value: i128) -> Self {
+        Self(value)
     }
 }
 
@@ -39,6 +13,13 @@ impl TryFrom<f64> for EpochNanoseconds {
 impl EpochNanoseconds {
     pub fn as_i128(&self) -> i128 {
         self.0
+    }
+
+    pub fn check_validity(&self) -> Result<(), TemporalError> {
+        if !is_valid_epoch_nanos(&self.0) {
+            return Err(TemporalError::range().with_enum(ErrorMessage::InstantOutOfRange));
+        }
+        Ok(())
     }
 }
 

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -145,7 +145,7 @@ impl IsoDateTime {
     }
 
     /// Returns this `IsoDateTime` in nanoseconds
-    pub fn as_nanoseconds(&self) -> TemporalResult<EpochNanoseconds> {
+    pub fn as_nanoseconds(&self) -> EpochNanoseconds {
         utc_epoch_nanos(self.date, &self.time)
     }
 
@@ -371,7 +371,7 @@ impl IsoDate {
 
     /// Returns this `IsoDate` in nanoseconds.
     #[inline]
-    pub(crate) fn as_nanoseconds(&self) -> TemporalResult<EpochNanoseconds> {
+    pub(crate) fn as_nanoseconds(&self) -> EpochNanoseconds {
         utc_epoch_nanos(*self, &IsoTime::default())
     }
 
@@ -930,9 +930,9 @@ fn iso_dt_within_valid_limits(date: IsoDate, time: &IsoTime) -> bool {
 
 #[inline]
 /// Utility function to convert a `IsoDate` and `IsoTime` values into epoch nanoseconds
-fn utc_epoch_nanos(date: IsoDate, time: &IsoTime) -> TemporalResult<EpochNanoseconds> {
+fn utc_epoch_nanos(date: IsoDate, time: &IsoTime) -> EpochNanoseconds {
     let epoch_nanos = to_unchecked_epoch_nanoseconds(date, time);
-    EpochNanoseconds::try_from(epoch_nanos)
+    EpochNanoseconds::from(epoch_nanos)
 }
 
 #[inline]

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -64,5 +64,5 @@ pub(crate) fn get_system_nanoseconds() -> TemporalResult<EpochNanoseconds> {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|e| TemporalError::general(e.to_string()))
-        .map(|d| EpochNanoseconds::try_from(d.as_nanos()))?
+        .map(|d| EpochNanoseconds::from(d.as_nanos() as i128))
 }

--- a/src/tzdb.rs
+++ b/src/tzdb.rs
@@ -651,22 +651,21 @@ impl TimeZoneProvider for CompiledTzdbProvider {
         identifier: &str,
         iso_datetime: IsoDateTime,
     ) -> TemporalResult<Vec<EpochNanoseconds>> {
-        let epoch_nanos = iso_datetime.as_nanoseconds()?;
+        let epoch_nanos = iso_datetime.as_nanoseconds();
         let seconds = (epoch_nanos.0 / 1_000_000_000) as i64;
         let tzif = self.get(identifier)?;
         let local_time_record_result = tzif.v2_estimate_tz_pair(&Seconds(seconds))?;
         let result = match local_time_record_result {
             LocalTimeRecordResult::Empty => Vec::default(),
             LocalTimeRecordResult::Single(r) => {
-                let epoch_ns =
-                    EpochNanoseconds::try_from(epoch_nanos.0 - seconds_to_nanoseconds(r.0))?;
+                let epoch_ns = EpochNanoseconds::from(epoch_nanos.0 - seconds_to_nanoseconds(r.0));
                 vec![epoch_ns]
             }
             LocalTimeRecordResult::Ambiguous { std, dst } => {
                 let std_epoch_ns =
-                    EpochNanoseconds::try_from(epoch_nanos.0 - seconds_to_nanoseconds(std.0))?;
+                    EpochNanoseconds::from(epoch_nanos.0 - seconds_to_nanoseconds(std.0));
                 let dst_epoch_ns =
-                    EpochNanoseconds::try_from(epoch_nanos.0 - seconds_to_nanoseconds(dst.0))?;
+                    EpochNanoseconds::from(epoch_nanos.0 - seconds_to_nanoseconds(dst.0));
                 vec![std_epoch_ns, dst_epoch_ns]
             }
         };
@@ -741,22 +740,21 @@ impl TimeZoneProvider for FsTzdbProvider {
         identifier: &str,
         iso_datetime: IsoDateTime,
     ) -> TemporalResult<Vec<EpochNanoseconds>> {
-        let epoch_nanos = iso_datetime.as_nanoseconds()?;
+        let epoch_nanos = iso_datetime.as_nanoseconds();
         let seconds = (epoch_nanos.0 / 1_000_000_000) as i64;
         let tzif = self.get(identifier)?;
         let local_time_record_result = tzif.v2_estimate_tz_pair(&Seconds(seconds))?;
         let result = match local_time_record_result {
             LocalTimeRecordResult::Empty => Vec::default(),
             LocalTimeRecordResult::Single(r) => {
-                let epoch_ns =
-                    EpochNanoseconds::try_from(epoch_nanos.0 - seconds_to_nanoseconds(r.0))?;
+                let epoch_ns = EpochNanoseconds::from(epoch_nanos.0 - seconds_to_nanoseconds(r.0));
                 vec![epoch_ns]
             }
             LocalTimeRecordResult::Ambiguous { std, dst } => {
                 let std_epoch_ns =
-                    EpochNanoseconds::try_from(epoch_nanos.0 - seconds_to_nanoseconds(std.0))?;
+                    EpochNanoseconds::from(epoch_nanos.0 - seconds_to_nanoseconds(std.0));
                 let dst_epoch_ns =
-                    EpochNanoseconds::try_from(epoch_nanos.0 - seconds_to_nanoseconds(dst.0))?;
+                    EpochNanoseconds::from(epoch_nanos.0 - seconds_to_nanoseconds(dst.0));
                 vec![std_epoch_ns, dst_epoch_ns]
             }
         };
@@ -935,7 +933,7 @@ mod tests {
             nanosecond: 0,
         };
         let edge_case = IsoDateTime::new(date, time).unwrap();
-        let edge_case_seconds = (edge_case.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
+        let edge_case_seconds = (edge_case.as_nanoseconds().0 / 1_000_000_000) as i64;
 
         #[cfg(not(target_os = "windows"))]
         let new_york = Tzif::read_tzif("America/New_York");
@@ -971,7 +969,7 @@ mod tests {
             nanosecond: 0,
         };
         let today = IsoDateTime::new(date, time).unwrap();
-        let seconds = (today.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
+        let seconds = (today.as_nanoseconds().0 / 1_000_000_000) as i64;
 
         #[cfg(not(target_os = "windows"))]
         let sydney = Tzif::read_tzif("Australia/Sydney");
@@ -1004,7 +1002,7 @@ mod tests {
             nanosecond: 0,
         };
         let edge_case = IsoDateTime::new(date, time).unwrap();
-        let edge_case_seconds = (edge_case.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
+        let edge_case_seconds = (edge_case.as_nanoseconds().0 / 1_000_000_000) as i64;
 
         #[cfg(not(target_os = "windows"))]
         let new_york = Tzif::read_tzif("America/New_York");
@@ -1047,7 +1045,7 @@ mod tests {
             nanosecond: 0,
         };
         let today = IsoDateTime::new(date, time).unwrap();
-        let seconds = (today.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
+        let seconds = (today.as_nanoseconds().0 / 1_000_000_000) as i64;
 
         #[cfg(not(target_os = "windows"))]
         let sydney = Tzif::read_tzif("Australia/Sydney");
@@ -1092,7 +1090,7 @@ mod tests {
             nanosecond: 0,
         };
         let edge_case = IsoDateTime::new(date, time).unwrap();
-        let edge_case_seconds = (edge_case.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
+        let edge_case_seconds = (edge_case.as_nanoseconds().0 / 1_000_000_000) as i64;
 
         let locals = new_york
             .v2_estimate_tz_pair(&Seconds(edge_case_seconds))
@@ -1129,7 +1127,7 @@ mod tests {
             nanosecond: 0,
         };
         let today = IsoDateTime::new(date, time).unwrap();
-        let seconds = (today.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
+        let seconds = (today.as_nanoseconds().0 / 1_000_000_000) as i64;
 
         let locals = sydney.v2_estimate_tz_pair(&Seconds(seconds)).unwrap();
 
@@ -1163,7 +1161,7 @@ mod tests {
             nanosecond: 0,
         };
         let edge_case = IsoDateTime::new(date, time).unwrap();
-        let edge_case_seconds = (edge_case.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
+        let edge_case_seconds = (edge_case.as_nanoseconds().0 / 1_000_000_000) as i64;
 
         #[cfg(not(target_os = "windows"))]
         let new_york = Tzif::read_tzif("America/New_York");
@@ -1205,7 +1203,7 @@ mod tests {
             nanosecond: 0,
         };
         let today = IsoDateTime::new(date, time).unwrap();
-        let seconds = (today.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
+        let seconds = (today.as_nanoseconds().0 / 1_000_000_000) as i64;
 
         #[cfg(not(target_os = "windows"))]
         let sydney = Tzif::read_tzif("Australia/Sydney");
@@ -1243,7 +1241,7 @@ mod tests {
             nanosecond: 0,
         };
         let start_dt = IsoDateTime::new(start_date, start_time).unwrap();
-        let start_dt_secs = (start_dt.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
+        let start_dt_secs = (start_dt.as_nanoseconds().0 / 1_000_000_000) as i64;
 
         let start_seconds = &Seconds(start_dt_secs);
 
@@ -1267,7 +1265,7 @@ mod tests {
             nanosecond: 0,
         };
         let end_dt = IsoDateTime::new(end_date, end_time).unwrap();
-        let end_dt_secs = (end_dt.as_nanoseconds().unwrap().0 / 1_000_000_000) as i64;
+        let end_dt_secs = (end_dt.as_nanoseconds().0 / 1_000_000_000) as i64;
 
         let end_seconds = &Seconds(end_dt_secs);
 

--- a/temporal_capi/src/instant.rs
+++ b/temporal_capi/src/instant.rs
@@ -35,7 +35,9 @@ pub mod ffi {
     impl I128Nanoseconds {
         pub fn is_valid(self) -> bool {
             let ns = i128::from(self);
-            temporal_rs::unix_time::EpochNanoseconds::try_from(ns).is_ok()
+            temporal_rs::unix_time::EpochNanoseconds::from(ns)
+                .check_validity()
+                .is_ok()
         }
     }
 


### PR DESCRIPTION
The spec often deals in ns values without checking for validity; e.g. in Duration.total.