### PR TITLE
Add .clone() to FFI, YearMonth::reference_day

### DIFF
--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -588,6 +588,13 @@ impl PlainYearMonth {
         self.iso.month
     }
 
+    /// Returns the internal ISO day for this `YearMonth`.
+    #[inline]
+    #[must_use]
+    pub fn iso_reference_day(&self) -> u8 {
+        self.iso.day
+    }
+
     /// Returns the calendar era of the current `PlainYearMonth`
     pub fn era(&self) -> Option<TinyAsciiStr<16>> {
         self.calendar().era(&self.iso)
@@ -606,6 +613,11 @@ impl PlainYearMonth {
     /// Returns the calendar month of the current `PlainYearMonth`
     pub fn month(&self) -> u8 {
         self.calendar().month(&self.iso)
+    }
+
+    /// Returns the calendar reference day of the current `PlainYearMonth`
+    pub fn reference_day(&self) -> u8 {
+        self.calendar().day(&self.iso)
     }
 
     /// Returns the calendar month code of the current `PlainYearMonth`

--- a/temporal_capi/bindings/c/Duration.h
+++ b/temporal_capi/bindings/c/Duration.h
@@ -94,6 +94,8 @@ temporal_rs_Duration_compare_result temporal_rs_Duration_compare(const Duration*
 typedef struct temporal_rs_Duration_total_result {union {double ok; TemporalError err;}; bool is_ok;} temporal_rs_Duration_total_result;
 temporal_rs_Duration_total_result temporal_rs_Duration_total(const Duration* self, Unit unit, RelativeTo relative_to);
 
+Duration* temporal_rs_Duration_clone(const Duration* self);
+
 void temporal_rs_Duration_destroy(Duration* self);
 
 

--- a/temporal_capi/bindings/c/Instant.h
+++ b/temporal_capi/bindings/c/Instant.h
@@ -70,6 +70,8 @@ temporal_rs_Instant_to_ixdtf_string_with_compiled_data_result temporal_rs_Instan
 
 ZonedDateTime* temporal_rs_Instant_to_zoned_date_time_iso(const Instant* self, const TimeZone* zone);
 
+Instant* temporal_rs_Instant_clone(const Instant* self);
+
 void temporal_rs_Instant_destroy(Instant* self);
 
 

--- a/temporal_capi/bindings/c/PlainDate.h
+++ b/temporal_capi/bindings/c/PlainDate.h
@@ -131,6 +131,8 @@ temporal_rs_PlainDate_to_zoned_date_time_result temporal_rs_PlainDate_to_zoned_d
 
 void temporal_rs_PlainDate_to_ixdtf_string(const PlainDate* self, DisplayCalendar display_calendar, DiplomatWrite* write);
 
+PlainDate* temporal_rs_PlainDate_clone(const PlainDate* self);
+
 void temporal_rs_PlainDate_destroy(PlainDate* self);
 
 

--- a/temporal_capi/bindings/c/PlainDateTime.h
+++ b/temporal_capi/bindings/c/PlainDateTime.h
@@ -143,6 +143,8 @@ temporal_rs_PlainDateTime_to_zoned_date_time_result temporal_rs_PlainDateTime_to
 typedef struct temporal_rs_PlainDateTime_to_ixdtf_string_result {union { TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_to_ixdtf_string_result;
 temporal_rs_PlainDateTime_to_ixdtf_string_result temporal_rs_PlainDateTime_to_ixdtf_string(const PlainDateTime* self, ToStringRoundingOptions options, DisplayCalendar display_calendar, DiplomatWrite* write);
 
+PlainDateTime* temporal_rs_PlainDateTime_clone(const PlainDateTime* self);
+
 void temporal_rs_PlainDateTime_destroy(PlainDateTime* self);
 
 

--- a/temporal_capi/bindings/c/PlainMonthDay.h
+++ b/temporal_capi/bindings/c/PlainMonthDay.h
@@ -60,6 +60,8 @@ temporal_rs_PlainMonthDay_epoch_ms_for_result temporal_rs_PlainMonthDay_epoch_ms
 
 void temporal_rs_PlainMonthDay_to_ixdtf_string(const PlainMonthDay* self, DisplayCalendar display_calendar, DiplomatWrite* write);
 
+PlainMonthDay* temporal_rs_PlainMonthDay_clone(const PlainMonthDay* self);
+
 void temporal_rs_PlainMonthDay_destroy(PlainMonthDay* self);
 
 

--- a/temporal_capi/bindings/c/PlainTime.h
+++ b/temporal_capi/bindings/c/PlainTime.h
@@ -86,6 +86,8 @@ temporal_rs_PlainTime_round_result temporal_rs_PlainTime_round(const PlainTime* 
 typedef struct temporal_rs_PlainTime_to_ixdtf_string_result {union { TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_to_ixdtf_string_result;
 temporal_rs_PlainTime_to_ixdtf_string_result temporal_rs_PlainTime_to_ixdtf_string(const PlainTime* self, ToStringRoundingOptions options, DiplomatWrite* write);
 
+PlainTime* temporal_rs_PlainTime_clone(const PlainTime* self);
+
 void temporal_rs_PlainTime_destroy(PlainTime* self);
 
 

--- a/temporal_capi/bindings/c/PlainYearMonth.h
+++ b/temporal_capi/bindings/c/PlainYearMonth.h
@@ -46,6 +46,8 @@ void temporal_rs_PlainYearMonth_padded_iso_year_string(const PlainYearMonth* sel
 
 uint8_t temporal_rs_PlainYearMonth_iso_month(const PlainYearMonth* self);
 
+uint8_t temporal_rs_PlainYearMonth_iso_day(const PlainYearMonth* self);
+
 int32_t temporal_rs_PlainYearMonth_year(const PlainYearMonth* self);
 
 uint8_t temporal_rs_PlainYearMonth_month(const PlainYearMonth* self);
@@ -90,6 +92,8 @@ typedef struct temporal_rs_PlainYearMonth_epoch_ms_for_result {union {int64_t ok
 temporal_rs_PlainYearMonth_epoch_ms_for_result temporal_rs_PlainYearMonth_epoch_ms_for(const PlainYearMonth* self, const TimeZone* time_zone);
 
 void temporal_rs_PlainYearMonth_to_ixdtf_string(const PlainYearMonth* self, DisplayCalendar display_calendar, DiplomatWrite* write);
+
+PlainYearMonth* temporal_rs_PlainYearMonth_clone(const PlainYearMonth* self);
 
 void temporal_rs_PlainYearMonth_destroy(PlainYearMonth* self);
 

--- a/temporal_capi/bindings/c/ZonedDateTime.h
+++ b/temporal_capi/bindings/c/ZonedDateTime.h
@@ -170,6 +170,8 @@ void temporal_rs_ZonedDateTime_era(const ZonedDateTime* self, DiplomatWrite* wri
 typedef struct temporal_rs_ZonedDateTime_era_year_result {union {int32_t ok; }; bool is_ok;} temporal_rs_ZonedDateTime_era_year_result;
 temporal_rs_ZonedDateTime_era_year_result temporal_rs_ZonedDateTime_era_year(const ZonedDateTime* self);
 
+ZonedDateTime* temporal_rs_ZonedDateTime_clone(const ZonedDateTime* self);
+
 void temporal_rs_ZonedDateTime_destroy(ZonedDateTime* self);
 
 

--- a/temporal_capi/bindings/cpp/temporal_rs/Duration.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Duration.d.hpp
@@ -101,6 +101,8 @@ public:
 
   inline diplomat::result<double, temporal_rs::TemporalError> total(temporal_rs::Unit unit, temporal_rs::RelativeTo relative_to) const;
 
+  inline std::unique_ptr<temporal_rs::Duration> clone() const;
+
   inline const temporal_rs::capi::Duration* AsFFI() const;
   inline temporal_rs::capi::Duration* AsFFI();
   inline static const temporal_rs::Duration* FromFFI(const temporal_rs::capi::Duration* ptr);

--- a/temporal_capi/bindings/cpp/temporal_rs/Duration.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Duration.hpp
@@ -97,6 +97,8 @@ namespace capi {
     typedef struct temporal_rs_Duration_total_result {union {double ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Duration_total_result;
     temporal_rs_Duration_total_result temporal_rs_Duration_total(const temporal_rs::capi::Duration* self, temporal_rs::capi::Unit unit, temporal_rs::capi::RelativeTo relative_to);
 
+    temporal_rs::capi::Duration* temporal_rs_Duration_clone(const temporal_rs::capi::Duration* self);
+
     void temporal_rs_Duration_destroy(Duration* self);
 
     } // extern "C"
@@ -285,6 +287,11 @@ inline diplomat::result<double, temporal_rs::TemporalError> temporal_rs::Duratio
     unit.AsFFI(),
     relative_to.AsFFI());
   return result.is_ok ? diplomat::result<double, temporal_rs::TemporalError>(diplomat::Ok<double>(result.ok)) : diplomat::result<double, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+}
+
+inline std::unique_ptr<temporal_rs::Duration> temporal_rs::Duration::clone() const {
+  auto result = temporal_rs::capi::temporal_rs_Duration_clone(this->AsFFI());
+  return std::unique_ptr<temporal_rs::Duration>(temporal_rs::Duration::FromFFI(result));
 }
 
 inline const temporal_rs::capi::Duration* temporal_rs::Duration::AsFFI() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/Instant.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Instant.d.hpp
@@ -76,6 +76,8 @@ public:
 
   inline std::unique_ptr<temporal_rs::ZonedDateTime> to_zoned_date_time_iso(const temporal_rs::TimeZone& zone) const;
 
+  inline std::unique_ptr<temporal_rs::Instant> clone() const;
+
   inline const temporal_rs::capi::Instant* AsFFI() const;
   inline temporal_rs::capi::Instant* AsFFI();
   inline static const temporal_rs::Instant* FromFFI(const temporal_rs::capi::Instant* ptr);

--- a/temporal_capi/bindings/cpp/temporal_rs/Instant.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Instant.hpp
@@ -73,6 +73,8 @@ namespace capi {
 
     temporal_rs::capi::ZonedDateTime* temporal_rs_Instant_to_zoned_date_time_iso(const temporal_rs::capi::Instant* self, const temporal_rs::capi::TimeZone* zone);
 
+    temporal_rs::capi::Instant* temporal_rs_Instant_clone(const temporal_rs::capi::Instant* self);
+
     void temporal_rs_Instant_destroy(Instant* self);
 
     } // extern "C"
@@ -188,6 +190,11 @@ inline std::unique_ptr<temporal_rs::ZonedDateTime> temporal_rs::Instant::to_zone
   auto result = temporal_rs::capi::temporal_rs_Instant_to_zoned_date_time_iso(this->AsFFI(),
     zone.AsFFI());
   return std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result));
+}
+
+inline std::unique_ptr<temporal_rs::Instant> temporal_rs::Instant::clone() const {
+  auto result = temporal_rs::capi::temporal_rs_Instant_clone(this->AsFFI());
+  return std::unique_ptr<temporal_rs::Instant>(temporal_rs::Instant::FromFFI(result));
 }
 
 inline const temporal_rs::capi::Instant* temporal_rs::Instant::AsFFI() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
@@ -135,6 +135,8 @@ public:
   template<typename W>
   inline void to_ixdtf_string_write(temporal_rs::DisplayCalendar display_calendar, W& writeable_output) const;
 
+  inline std::unique_ptr<temporal_rs::PlainDate> clone() const;
+
   inline const temporal_rs::capi::PlainDate* AsFFI() const;
   inline temporal_rs::capi::PlainDate* AsFFI();
   inline static const temporal_rs::PlainDate* FromFFI(const temporal_rs::capi::PlainDate* ptr);

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
@@ -134,6 +134,8 @@ namespace capi {
 
     void temporal_rs_PlainDate_to_ixdtf_string(const temporal_rs::capi::PlainDate* self, temporal_rs::capi::DisplayCalendar display_calendar, diplomat::capi::DiplomatWrite* write);
 
+    temporal_rs::capi::PlainDate* temporal_rs_PlainDate_clone(const temporal_rs::capi::PlainDate* self);
+
     void temporal_rs_PlainDate_destroy(PlainDate* self);
 
     } // extern "C"
@@ -395,6 +397,11 @@ inline void temporal_rs::PlainDate::to_ixdtf_string_write(temporal_rs::DisplayCa
   temporal_rs::capi::temporal_rs_PlainDate_to_ixdtf_string(this->AsFFI(),
     display_calendar.AsFFI(),
     &write);
+}
+
+inline std::unique_ptr<temporal_rs::PlainDate> temporal_rs::PlainDate::clone() const {
+  auto result = temporal_rs::capi::temporal_rs_PlainDate_clone(this->AsFFI());
+  return std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result));
 }
 
 inline const temporal_rs::capi::PlainDate* temporal_rs::PlainDate::AsFFI() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
@@ -144,6 +144,8 @@ public:
   template<typename W>
   inline diplomat::result<std::monostate, temporal_rs::TemporalError> to_ixdtf_string_write(temporal_rs::ToStringRoundingOptions options, temporal_rs::DisplayCalendar display_calendar, W& writeable_output) const;
 
+  inline std::unique_ptr<temporal_rs::PlainDateTime> clone() const;
+
   inline const temporal_rs::capi::PlainDateTime* AsFFI() const;
   inline temporal_rs::capi::PlainDateTime* AsFFI();
   inline static const temporal_rs::PlainDateTime* FromFFI(const temporal_rs::capi::PlainDateTime* ptr);

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
@@ -146,6 +146,8 @@ namespace capi {
     typedef struct temporal_rs_PlainDateTime_to_ixdtf_string_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_to_ixdtf_string_result;
     temporal_rs_PlainDateTime_to_ixdtf_string_result temporal_rs_PlainDateTime_to_ixdtf_string(const temporal_rs::capi::PlainDateTime* self, temporal_rs::capi::ToStringRoundingOptions options, temporal_rs::capi::DisplayCalendar display_calendar, diplomat::capi::DiplomatWrite* write);
 
+    temporal_rs::capi::PlainDateTime* temporal_rs_PlainDateTime_clone(const temporal_rs::capi::PlainDateTime* self);
+
     void temporal_rs_PlainDateTime_destroy(PlainDateTime* self);
 
     } // extern "C"
@@ -444,6 +446,11 @@ inline diplomat::result<std::monostate, temporal_rs::TemporalError> temporal_rs:
     display_calendar.AsFFI(),
     &write);
   return result.is_ok ? diplomat::result<std::monostate, temporal_rs::TemporalError>(diplomat::Ok<std::monostate>()) : diplomat::result<std::monostate, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+}
+
+inline std::unique_ptr<temporal_rs::PlainDateTime> temporal_rs::PlainDateTime::clone() const {
+  auto result = temporal_rs::capi::temporal_rs_PlainDateTime_clone(this->AsFFI());
+  return std::unique_ptr<temporal_rs::PlainDateTime>(temporal_rs::PlainDateTime::FromFFI(result));
 }
 
 inline const temporal_rs::capi::PlainDateTime* temporal_rs::PlainDateTime::AsFFI() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
@@ -72,6 +72,8 @@ public:
   template<typename W>
   inline void to_ixdtf_string_write(temporal_rs::DisplayCalendar display_calendar, W& writeable_output) const;
 
+  inline std::unique_ptr<temporal_rs::PlainMonthDay> clone() const;
+
   inline const temporal_rs::capi::PlainMonthDay* AsFFI() const;
   inline temporal_rs::capi::PlainMonthDay* AsFFI();
   inline static const temporal_rs::PlainMonthDay* FromFFI(const temporal_rs::capi::PlainMonthDay* ptr);

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
@@ -63,6 +63,8 @@ namespace capi {
 
     void temporal_rs_PlainMonthDay_to_ixdtf_string(const temporal_rs::capi::PlainMonthDay* self, temporal_rs::capi::DisplayCalendar display_calendar, diplomat::capi::DiplomatWrite* write);
 
+    temporal_rs::capi::PlainMonthDay* temporal_rs_PlainMonthDay_clone(const temporal_rs::capi::PlainMonthDay* self);
+
     void temporal_rs_PlainMonthDay_destroy(PlainMonthDay* self);
 
     } // extern "C"
@@ -173,6 +175,11 @@ inline void temporal_rs::PlainMonthDay::to_ixdtf_string_write(temporal_rs::Displ
   temporal_rs::capi::temporal_rs_PlainMonthDay_to_ixdtf_string(this->AsFFI(),
     display_calendar.AsFFI(),
     &write);
+}
+
+inline std::unique_ptr<temporal_rs::PlainMonthDay> temporal_rs::PlainMonthDay::clone() const {
+  auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_clone(this->AsFFI());
+  return std::unique_ptr<temporal_rs::PlainMonthDay>(temporal_rs::PlainMonthDay::FromFFI(result));
 }
 
 inline const temporal_rs::capi::PlainMonthDay* temporal_rs::PlainMonthDay::AsFFI() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainTime.d.hpp
@@ -88,6 +88,8 @@ public:
   template<typename W>
   inline diplomat::result<std::monostate, temporal_rs::TemporalError> to_ixdtf_string_write(temporal_rs::ToStringRoundingOptions options, W& writeable_output) const;
 
+  inline std::unique_ptr<temporal_rs::PlainTime> clone() const;
+
   inline const temporal_rs::capi::PlainTime* AsFFI() const;
   inline temporal_rs::capi::PlainTime* AsFFI();
   inline static const temporal_rs::PlainTime* FromFFI(const temporal_rs::capi::PlainTime* ptr);

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainTime.hpp
@@ -89,6 +89,8 @@ namespace capi {
     typedef struct temporal_rs_PlainTime_to_ixdtf_string_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_to_ixdtf_string_result;
     temporal_rs_PlainTime_to_ixdtf_string_result temporal_rs_PlainTime_to_ixdtf_string(const temporal_rs::capi::PlainTime* self, temporal_rs::capi::ToStringRoundingOptions options, diplomat::capi::DiplomatWrite* write);
 
+    temporal_rs::capi::PlainTime* temporal_rs_PlainTime_clone(const temporal_rs::capi::PlainTime* self);
+
     void temporal_rs_PlainTime_destroy(PlainTime* self);
 
     } // extern "C"
@@ -247,6 +249,11 @@ inline diplomat::result<std::monostate, temporal_rs::TemporalError> temporal_rs:
     options.AsFFI(),
     &write);
   return result.is_ok ? diplomat::result<std::monostate, temporal_rs::TemporalError>(diplomat::Ok<std::monostate>()) : diplomat::result<std::monostate, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+}
+
+inline std::unique_ptr<temporal_rs::PlainTime> temporal_rs::PlainTime::clone() const {
+  auto result = temporal_rs::capi::temporal_rs_PlainTime_clone(this->AsFFI());
+  return std::unique_ptr<temporal_rs::PlainTime>(temporal_rs::PlainTime::FromFFI(result));
 }
 
 inline const temporal_rs::capi::PlainTime* temporal_rs::PlainTime::AsFFI() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.d.hpp
@@ -59,6 +59,8 @@ public:
 
   inline uint8_t iso_month() const;
 
+  inline uint8_t iso_day() const;
+
   inline int32_t year() const;
 
   inline uint8_t month() const;
@@ -102,6 +104,8 @@ public:
   inline std::string to_ixdtf_string(temporal_rs::DisplayCalendar display_calendar) const;
   template<typename W>
   inline void to_ixdtf_string_write(temporal_rs::DisplayCalendar display_calendar, W& writeable_output) const;
+
+  inline std::unique_ptr<temporal_rs::PlainYearMonth> clone() const;
 
   inline const temporal_rs::capi::PlainYearMonth* AsFFI() const;
   inline temporal_rs::capi::PlainYearMonth* AsFFI();

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.hpp
@@ -49,6 +49,8 @@ namespace capi {
 
     uint8_t temporal_rs_PlainYearMonth_iso_month(const temporal_rs::capi::PlainYearMonth* self);
 
+    uint8_t temporal_rs_PlainYearMonth_iso_day(const temporal_rs::capi::PlainYearMonth* self);
+
     int32_t temporal_rs_PlainYearMonth_year(const temporal_rs::capi::PlainYearMonth* self);
 
     uint8_t temporal_rs_PlainYearMonth_month(const temporal_rs::capi::PlainYearMonth* self);
@@ -93,6 +95,8 @@ namespace capi {
     temporal_rs_PlainYearMonth_epoch_ms_for_result temporal_rs_PlainYearMonth_epoch_ms_for(const temporal_rs::capi::PlainYearMonth* self, const temporal_rs::capi::TimeZone* time_zone);
 
     void temporal_rs_PlainYearMonth_to_ixdtf_string(const temporal_rs::capi::PlainYearMonth* self, temporal_rs::capi::DisplayCalendar display_calendar, diplomat::capi::DiplomatWrite* write);
+
+    temporal_rs::capi::PlainYearMonth* temporal_rs_PlainYearMonth_clone(const temporal_rs::capi::PlainYearMonth* self);
 
     void temporal_rs_PlainYearMonth_destroy(PlainYearMonth* self);
 
@@ -153,6 +157,11 @@ inline void temporal_rs::PlainYearMonth::padded_iso_year_string_write(W& writeab
 
 inline uint8_t temporal_rs::PlainYearMonth::iso_month() const {
   auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_iso_month(this->AsFFI());
+  return result;
+}
+
+inline uint8_t temporal_rs::PlainYearMonth::iso_day() const {
+  auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_iso_day(this->AsFFI());
   return result;
 }
 
@@ -290,6 +299,11 @@ inline void temporal_rs::PlainYearMonth::to_ixdtf_string_write(temporal_rs::Disp
   temporal_rs::capi::temporal_rs_PlainYearMonth_to_ixdtf_string(this->AsFFI(),
     display_calendar.AsFFI(),
     &write);
+}
+
+inline std::unique_ptr<temporal_rs::PlainYearMonth> temporal_rs::PlainYearMonth::clone() const {
+  auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_clone(this->AsFFI());
+  return std::unique_ptr<temporal_rs::PlainYearMonth>(temporal_rs::PlainYearMonth::FromFFI(result));
 }
 
 inline const temporal_rs::capi::PlainYearMonth* temporal_rs::PlainYearMonth::AsFFI() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.d.hpp
@@ -169,6 +169,8 @@ public:
 
   inline std::optional<int32_t> era_year() const;
 
+  inline std::unique_ptr<temporal_rs::ZonedDateTime> clone() const;
+
   inline const temporal_rs::capi::ZonedDateTime* AsFFI() const;
   inline temporal_rs::capi::ZonedDateTime* AsFFI();
   inline static const temporal_rs::ZonedDateTime* FromFFI(const temporal_rs::capi::ZonedDateTime* ptr);

--- a/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.hpp
@@ -173,6 +173,8 @@ namespace capi {
     typedef struct temporal_rs_ZonedDateTime_era_year_result {union {int32_t ok; }; bool is_ok;} temporal_rs_ZonedDateTime_era_year_result;
     temporal_rs_ZonedDateTime_era_year_result temporal_rs_ZonedDateTime_era_year(const temporal_rs::capi::ZonedDateTime* self);
 
+    temporal_rs::capi::ZonedDateTime* temporal_rs_ZonedDateTime_clone(const temporal_rs::capi::ZonedDateTime* self);
+
     void temporal_rs_ZonedDateTime_destroy(ZonedDateTime* self);
 
     } // extern "C"
@@ -515,6 +517,11 @@ inline void temporal_rs::ZonedDateTime::era_write(W& writeable) const {
 inline std::optional<int32_t> temporal_rs::ZonedDateTime::era_year() const {
   auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_era_year(this->AsFFI());
   return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
+}
+
+inline std::unique_ptr<temporal_rs::ZonedDateTime> temporal_rs::ZonedDateTime::clone() const {
+  auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_clone(this->AsFFI());
+  return std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result));
 }
 
 inline const temporal_rs::capi::ZonedDateTime* temporal_rs::ZonedDateTime::AsFFI() const {

--- a/temporal_capi/src/duration.rs
+++ b/temporal_capi/src/duration.rs
@@ -324,6 +324,11 @@ pub mod ffi {
                 .map(|x| x.as_inner())
                 .map_err(Into::into)
         }
+
+        #[allow(clippy::should_implement_trait)]
+        pub fn clone(&self) -> Box<Self> {
+            Box::new(Self(self.0))
+        }
     }
 }
 

--- a/temporal_capi/src/instant.rs
+++ b/temporal_capi/src/instant.rs
@@ -166,6 +166,11 @@ pub mod ffi {
         pub fn to_zoned_date_time_iso(&self, zone: &TimeZone) -> Box<ZonedDateTime> {
             Box::new(ZonedDateTime(self.0.to_zoned_date_time_iso(zone.0.clone())))
         }
+
+        #[allow(clippy::should_implement_trait)]
+        pub fn clone(&self) -> Box<Self> {
+            Box::new(Self(self.0))
+        }
     }
 }
 

--- a/temporal_capi/src/plain_date.rs
+++ b/temporal_capi/src/plain_date.rs
@@ -309,6 +309,11 @@ pub mod ffi {
             // don't care about that.
             let _ = writeable.write_to(write);
         }
+
+        #[allow(clippy::should_implement_trait)]
+        pub fn clone(&self) -> Box<Self> {
+            Box::new(Self(self.0.clone()))
+        }
     }
 }
 

--- a/temporal_capi/src/plain_date_time.rs
+++ b/temporal_capi/src/plain_date_time.rs
@@ -359,6 +359,11 @@ pub mod ffi {
             let _ = writeable.write_to(write);
             Ok(())
         }
+
+        #[allow(clippy::should_implement_trait)]
+        pub fn clone(&self) -> Box<Self> {
+            Box::new(Self(self.0.clone()))
+        }
     }
 }
 

--- a/temporal_capi/src/plain_month_day.rs
+++ b/temporal_capi/src/plain_month_day.rs
@@ -139,5 +139,10 @@ pub mod ffi {
             // don't care about that.
             let _ = writeable.write_to(write);
         }
+
+        #[allow(clippy::should_implement_trait)]
+        pub fn clone(&self) -> Box<Self> {
+            Box::new(Self(self.0.clone()))
+        }
     }
 }

--- a/temporal_capi/src/plain_time.rs
+++ b/temporal_capi/src/plain_time.rs
@@ -224,6 +224,11 @@ pub mod ffi {
 
             Ok(())
         }
+
+        #[allow(clippy::should_implement_trait)]
+        pub fn clone(&self) -> Box<Self> {
+            Box::new(Self(self.0))
+        }
     }
 }
 

--- a/temporal_capi/src/plain_year_month.rs
+++ b/temporal_capi/src/plain_year_month.rs
@@ -92,6 +92,10 @@ pub mod ffi {
             self.0.iso_month()
         }
 
+        pub fn iso_day(&self) -> u8 {
+            self.0.iso_month()
+        }
+
         pub fn year(&self) -> i32 {
             self.0.year()
         }
@@ -216,6 +220,11 @@ pub mod ffi {
             // This can only fail in cases where the DiplomatWriteable is capped, we
             // don't care about that.
             let _ = writeable.write_to(write);
+        }
+
+        #[allow(clippy::should_implement_trait)]
+        pub fn clone(&self) -> Box<Self> {
+            Box::new(Self(self.0.clone()))
         }
     }
 }

--- a/temporal_capi/src/zoned_date_time.rs
+++ b/temporal_capi/src/zoned_date_time.rs
@@ -481,6 +481,11 @@ pub mod ffi {
         pub fn era_year(&self) -> Option<i32> {
             self.0.era_year().unwrap_or_default()
         }
+
+        #[allow(clippy::should_implement_trait)]
+        pub fn clone(&self) -> Box<Self> {
+            Box::new(Self(self.0.clone()))
+        }
     }
 }
 


### PR DESCRIPTION
Without this ToTemporalYearMonth isn't possible to implement since you cannot extract the reference day.

Decided to add clone everywhere since it's a useful enough operation and ToTemporalFoo always needs it (even though it can usually be implemented differently)