### PR TITLE
Fix posix logic that was causing panics

### DIFF
--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -1530,4 +1530,22 @@ mod tests {
             "pads 4 decimal places to 9"
         );
     }
+
+    #[cfg(feature = "tzdb")]
+    #[test]
+    fn to_zoned_date_time_edge_cases() {
+        use crate::{options::Disambiguation, tzdb::CompiledTzdbProvider, TimeZone};
+        let provider = &CompiledTzdbProvider::default();
+        let pdt = PlainDateTime::try_new_iso(2020, 3, 8, 2, 30, 0, 0, 0, 0).unwrap();
+        let zdt = pdt
+            .to_zoned_date_time_with_provider(
+                &TimeZone::try_from_identifier_str_with_provider("America/Los_Angeles", provider)
+                    .unwrap(),
+                Disambiguation::Compatible,
+                provider,
+            )
+            .unwrap();
+
+        assert_eq!(zdt.hour(), Ok(3));
+    }
 }


### PR DESCRIPTION
Closes #445 and #199.

We were not properly resolving the offset for the POSIX time zone for epoch seconds.

This updates the logic to correctly handling determining which offset we are in.