### PR TITLE
Fix overflow when validating Duration

### DIFF
--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -1283,8 +1283,9 @@ pub(crate) fn is_valid_duration(
         + minutes as i128 * 60_000_000_000
         + seconds as i128 * 1_000_000_000;
     // Subseconds part
-    let normalized_subseconds_parts =
-        (milliseconds as i128 * 1_000_000) + (microseconds * 1_000) + nanoseconds;
+    let normalized_subseconds_parts = (milliseconds as i128).saturating_mul(1_000_000)
+        + microseconds.saturating_mul(1_000)
+        + nanoseconds;
 
     let total_normalized_seconds = normalized_nanoseconds + normalized_subseconds_parts;
     // 8. If abs(normalizedSeconds) ≥ 2**53, return false.


### PR DESCRIPTION
Boa currently panics when running the test suite in debug. This fix addresses that issue.

Relevant test: test/built-ins/Temporal/Duration/large-number.js

Boa's conformance results:
https://boajs.dev/conformance?version=main&testPath=built-ins%2FTemporal%2FDuration&selectedTest=large-number.js
