### PR TITLE
Use ISO day of week unconditionally

### DIFF
--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -413,11 +413,7 @@ impl Calendar {
 
     /// `CalendarDaysInWeek`
     pub fn days_in_week(&self, _iso_date: &IsoDate) -> TemporalResult<u16> {
-        if self.is_iso() {
-            return Ok(7);
-        }
-        // TODO: Research in ICU4X and determine best approach.
-        Err(TemporalError::range().with_message("Not yet implemented."))
+        Ok(7)
     }
 
     /// `CalendarDaysInMonth`

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -381,11 +381,7 @@ impl Calendar {
 
     /// `CalendarDayOfWeek`
     pub fn day_of_week(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
-        if self.is_iso() {
-            return Ok(iso_date.to_icu4x().day_of_week() as u16);
-        }
-        // TODO: Update or update in icu_calendar
-        Err(TemporalError::range().with_message("dayOfWeek is not for the provided calendar."))
+        Ok(iso_date.to_icu4x().day_of_week() as u16)
     }
 
     /// `CalendarDayOfYear`

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -380,8 +380,8 @@ impl Calendar {
     }
 
     /// `CalendarDayOfWeek`
-    pub fn day_of_week(&self, iso_date: &IsoDate) -> TemporalResult<u16> {
-        Ok(iso_date.to_icu4x().day_of_week() as u16)
+    pub fn day_of_week(&self, iso_date: &IsoDate) -> u16 {
+        iso_date.to_icu4x().day_of_week() as u16
     }
 
     /// `CalendarDayOfYear`
@@ -412,8 +412,8 @@ impl Calendar {
     }
 
     /// `CalendarDaysInWeek`
-    pub fn days_in_week(&self, _iso_date: &IsoDate) -> TemporalResult<u16> {
-        Ok(7)
+    pub fn days_in_week(&self, _iso_date: &IsoDate) -> u16 {
+        7
     }
 
     /// `CalendarDaysInMonth`

--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -643,7 +643,7 @@ impl PlainDate {
     }
 
     /// Returns the calendar day of week value.
-    pub fn day_of_week(&self) -> TemporalResult<u16> {
+    pub fn day_of_week(&self) -> u16 {
         self.calendar.day_of_week(&self.iso)
     }
 
@@ -663,7 +663,7 @@ impl PlainDate {
     }
 
     /// Returns the calendar days in week value.
-    pub fn days_in_week(&self) -> TemporalResult<u16> {
+    pub fn days_in_week(&self) -> u16 {
         self.calendar.days_in_week(&self.iso)
     }
 

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -765,7 +765,7 @@ impl PlainDateTime {
     }
 
     /// Returns the calendar day of week value.
-    pub fn day_of_week(&self) -> TemporalResult<u16> {
+    pub fn day_of_week(&self) -> u16 {
         self.calendar.day_of_week(&self.iso.date)
     }
 
@@ -785,7 +785,7 @@ impl PlainDateTime {
     }
 
     /// Returns the calendar days in week value.
-    pub fn days_in_week(&self) -> TemporalResult<u16> {
+    pub fn days_in_week(&self) -> u16 {
         self.calendar.days_in_week(&self.iso.date)
     }
 

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -996,7 +996,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.day_of_week(&pdt.iso.date)
+        Ok(self.calendar.day_of_week(&pdt.iso.date))
     }
 
     /// Returns the calendar day of year value.
@@ -1036,7 +1036,7 @@ impl ZonedDateTime {
     ) -> TemporalResult<u16> {
         let iso = self.tz.get_iso_datetime_for(&self.instant, provider)?;
         let pdt = PlainDateTime::new_unchecked(iso, self.calendar.clone());
-        self.calendar.days_in_week(&pdt.iso.date)
+        Ok(self.calendar.days_in_week(&pdt.iso.date))
     }
 
     /// Returns the calendar days in month value.

--- a/temporal_capi/bindings/c/Calendar.h
+++ b/temporal_capi/bindings/c/Calendar.h
@@ -65,8 +65,7 @@ temporal_rs_Calendar_month_code_result temporal_rs_Calendar_month_code(const Cal
 
 uint8_t temporal_rs_Calendar_day(const Calendar* self, IsoDate date);
 
-typedef struct temporal_rs_Calendar_day_of_week_result {union {uint16_t ok; TemporalError err;}; bool is_ok;} temporal_rs_Calendar_day_of_week_result;
-temporal_rs_Calendar_day_of_week_result temporal_rs_Calendar_day_of_week(const Calendar* self, IsoDate date);
+uint16_t temporal_rs_Calendar_day_of_week(const Calendar* self, IsoDate date);
 
 uint16_t temporal_rs_Calendar_day_of_year(const Calendar* self, IsoDate date);
 
@@ -76,8 +75,7 @@ temporal_rs_Calendar_week_of_year_result temporal_rs_Calendar_week_of_year(const
 typedef struct temporal_rs_Calendar_year_of_week_result {union {int32_t ok; }; bool is_ok;} temporal_rs_Calendar_year_of_week_result;
 temporal_rs_Calendar_year_of_week_result temporal_rs_Calendar_year_of_week(const Calendar* self, IsoDate date);
 
-typedef struct temporal_rs_Calendar_days_in_week_result {union {uint16_t ok; TemporalError err;}; bool is_ok;} temporal_rs_Calendar_days_in_week_result;
-temporal_rs_Calendar_days_in_week_result temporal_rs_Calendar_days_in_week(const Calendar* self, IsoDate date);
+uint16_t temporal_rs_Calendar_days_in_week(const Calendar* self, IsoDate date);
 
 uint16_t temporal_rs_Calendar_days_in_month(const Calendar* self, IsoDate date);
 

--- a/temporal_capi/bindings/c/PlainDate.h
+++ b/temporal_capi/bindings/c/PlainDate.h
@@ -90,8 +90,7 @@ void temporal_rs_PlainDate_month_code(const PlainDate* self, DiplomatWrite* writ
 
 uint8_t temporal_rs_PlainDate_day(const PlainDate* self);
 
-typedef struct temporal_rs_PlainDate_day_of_week_result {union {uint16_t ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_day_of_week_result;
-temporal_rs_PlainDate_day_of_week_result temporal_rs_PlainDate_day_of_week(const PlainDate* self);
+uint16_t temporal_rs_PlainDate_day_of_week(const PlainDate* self);
 
 uint16_t temporal_rs_PlainDate_day_of_year(const PlainDate* self);
 
@@ -101,8 +100,7 @@ temporal_rs_PlainDate_week_of_year_result temporal_rs_PlainDate_week_of_year(con
 typedef struct temporal_rs_PlainDate_year_of_week_result {union {int32_t ok; }; bool is_ok;} temporal_rs_PlainDate_year_of_week_result;
 temporal_rs_PlainDate_year_of_week_result temporal_rs_PlainDate_year_of_week(const PlainDate* self);
 
-typedef struct temporal_rs_PlainDate_days_in_week_result {union {uint16_t ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_days_in_week_result;
-temporal_rs_PlainDate_days_in_week_result temporal_rs_PlainDate_days_in_week(const PlainDate* self);
+uint16_t temporal_rs_PlainDate_days_in_week(const PlainDate* self);
 
 uint16_t temporal_rs_PlainDate_days_in_month(const PlainDate* self);
 

--- a/temporal_capi/bindings/c/PlainDateTime.h
+++ b/temporal_capi/bindings/c/PlainDateTime.h
@@ -85,8 +85,7 @@ void temporal_rs_PlainDateTime_month_code(const PlainDateTime* self, DiplomatWri
 
 uint8_t temporal_rs_PlainDateTime_day(const PlainDateTime* self);
 
-typedef struct temporal_rs_PlainDateTime_day_of_week_result {union {uint16_t ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_day_of_week_result;
-temporal_rs_PlainDateTime_day_of_week_result temporal_rs_PlainDateTime_day_of_week(const PlainDateTime* self);
+uint16_t temporal_rs_PlainDateTime_day_of_week(const PlainDateTime* self);
 
 uint16_t temporal_rs_PlainDateTime_day_of_year(const PlainDateTime* self);
 
@@ -96,8 +95,7 @@ temporal_rs_PlainDateTime_week_of_year_result temporal_rs_PlainDateTime_week_of_
 typedef struct temporal_rs_PlainDateTime_year_of_week_result {union {int32_t ok; }; bool is_ok;} temporal_rs_PlainDateTime_year_of_week_result;
 temporal_rs_PlainDateTime_year_of_week_result temporal_rs_PlainDateTime_year_of_week(const PlainDateTime* self);
 
-typedef struct temporal_rs_PlainDateTime_days_in_week_result {union {uint16_t ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_days_in_week_result;
-temporal_rs_PlainDateTime_days_in_week_result temporal_rs_PlainDateTime_days_in_week(const PlainDateTime* self);
+uint16_t temporal_rs_PlainDateTime_days_in_week(const PlainDateTime* self);
 
 uint16_t temporal_rs_PlainDateTime_days_in_month(const PlainDateTime* self);
 

--- a/temporal_capi/bindings/cpp/temporal_rs/Calendar.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Calendar.d.hpp
@@ -77,7 +77,7 @@ public:
 
   inline uint8_t day(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_week(temporal_rs::IsoDate date) const;
+  inline uint16_t day_of_week(temporal_rs::IsoDate date) const;
 
   inline uint16_t day_of_year(temporal_rs::IsoDate date) const;
 
@@ -85,7 +85,7 @@ public:
 
   inline std::optional<int32_t> year_of_week(temporal_rs::IsoDate date) const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_week(temporal_rs::IsoDate date) const;
+  inline uint16_t days_in_week(temporal_rs::IsoDate date) const;
 
   inline uint16_t days_in_month(temporal_rs::IsoDate date) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/Calendar.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Calendar.hpp
@@ -68,8 +68,7 @@ namespace capi {
 
     uint8_t temporal_rs_Calendar_day(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
 
-    typedef struct temporal_rs_Calendar_day_of_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_day_of_week_result;
-    temporal_rs_Calendar_day_of_week_result temporal_rs_Calendar_day_of_week(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
+    uint16_t temporal_rs_Calendar_day_of_week(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
 
     uint16_t temporal_rs_Calendar_day_of_year(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
 
@@ -79,8 +78,7 @@ namespace capi {
     typedef struct temporal_rs_Calendar_year_of_week_result {union {int32_t ok; }; bool is_ok;} temporal_rs_Calendar_year_of_week_result;
     temporal_rs_Calendar_year_of_week_result temporal_rs_Calendar_year_of_week(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
 
-    typedef struct temporal_rs_Calendar_days_in_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Calendar_days_in_week_result;
-    temporal_rs_Calendar_days_in_week_result temporal_rs_Calendar_days_in_week(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
+    uint16_t temporal_rs_Calendar_days_in_week(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
 
     uint16_t temporal_rs_Calendar_days_in_month(const temporal_rs::capi::Calendar* self, temporal_rs::capi::IsoDate date);
 
@@ -213,10 +211,10 @@ inline uint8_t temporal_rs::Calendar::day(temporal_rs::IsoDate date) const {
   return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::Calendar::day_of_week(temporal_rs::IsoDate date) const {
+inline uint16_t temporal_rs::Calendar::day_of_week(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_day_of_week(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline uint16_t temporal_rs::Calendar::day_of_year(temporal_rs::IsoDate date) const {
@@ -237,10 +235,10 @@ inline std::optional<int32_t> temporal_rs::Calendar::year_of_week(temporal_rs::I
   return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::Calendar::days_in_week(temporal_rs::IsoDate date) const {
+inline uint16_t temporal_rs::Calendar::days_in_week(temporal_rs::IsoDate date) const {
   auto result = temporal_rs::capi::temporal_rs_Calendar_days_in_week(this->AsFFI(),
     date.AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline uint16_t temporal_rs::Calendar::days_in_month(temporal_rs::IsoDate date) const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
@@ -99,7 +99,7 @@ public:
 
   inline uint8_t day() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_week() const;
+  inline uint16_t day_of_week() const;
 
   inline uint16_t day_of_year() const;
 
@@ -107,7 +107,7 @@ public:
 
   inline std::optional<int32_t> year_of_week() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_week() const;
+  inline uint16_t days_in_week() const;
 
   inline uint16_t days_in_month() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
@@ -93,8 +93,7 @@ namespace capi {
 
     uint8_t temporal_rs_PlainDate_day(const temporal_rs::capi::PlainDate* self);
 
-    typedef struct temporal_rs_PlainDate_day_of_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_day_of_week_result;
-    temporal_rs_PlainDate_day_of_week_result temporal_rs_PlainDate_day_of_week(const temporal_rs::capi::PlainDate* self);
+    uint16_t temporal_rs_PlainDate_day_of_week(const temporal_rs::capi::PlainDate* self);
 
     uint16_t temporal_rs_PlainDate_day_of_year(const temporal_rs::capi::PlainDate* self);
 
@@ -104,8 +103,7 @@ namespace capi {
     typedef struct temporal_rs_PlainDate_year_of_week_result {union {int32_t ok; }; bool is_ok;} temporal_rs_PlainDate_year_of_week_result;
     temporal_rs_PlainDate_year_of_week_result temporal_rs_PlainDate_year_of_week(const temporal_rs::capi::PlainDate* self);
 
-    typedef struct temporal_rs_PlainDate_days_in_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_days_in_week_result;
-    temporal_rs_PlainDate_days_in_week_result temporal_rs_PlainDate_days_in_week(const temporal_rs::capi::PlainDate* self);
+    uint16_t temporal_rs_PlainDate_days_in_week(const temporal_rs::capi::PlainDate* self);
 
     uint16_t temporal_rs_PlainDate_days_in_month(const temporal_rs::capi::PlainDate* self);
 
@@ -296,9 +294,9 @@ inline uint8_t temporal_rs::PlainDate::day() const {
   return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDate::day_of_week() const {
+inline uint16_t temporal_rs::PlainDate::day_of_week() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_day_of_week(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline uint16_t temporal_rs::PlainDate::day_of_year() const {
@@ -316,9 +314,9 @@ inline std::optional<int32_t> temporal_rs::PlainDate::year_of_week() const {
   return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDate::days_in_week() const {
+inline uint16_t temporal_rs::PlainDate::days_in_week() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_days_in_week(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline uint16_t temporal_rs::PlainDate::days_in_month() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
@@ -96,7 +96,7 @@ public:
 
   inline uint8_t day() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_week() const;
+  inline uint16_t day_of_week() const;
 
   inline uint16_t day_of_year() const;
 
@@ -104,7 +104,7 @@ public:
 
   inline std::optional<int32_t> year_of_week() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_week() const;
+  inline uint16_t days_in_week() const;
 
   inline uint16_t days_in_month() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
@@ -88,8 +88,7 @@ namespace capi {
 
     uint8_t temporal_rs_PlainDateTime_day(const temporal_rs::capi::PlainDateTime* self);
 
-    typedef struct temporal_rs_PlainDateTime_day_of_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_day_of_week_result;
-    temporal_rs_PlainDateTime_day_of_week_result temporal_rs_PlainDateTime_day_of_week(const temporal_rs::capi::PlainDateTime* self);
+    uint16_t temporal_rs_PlainDateTime_day_of_week(const temporal_rs::capi::PlainDateTime* self);
 
     uint16_t temporal_rs_PlainDateTime_day_of_year(const temporal_rs::capi::PlainDateTime* self);
 
@@ -99,8 +98,7 @@ namespace capi {
     typedef struct temporal_rs_PlainDateTime_year_of_week_result {union {int32_t ok; }; bool is_ok;} temporal_rs_PlainDateTime_year_of_week_result;
     temporal_rs_PlainDateTime_year_of_week_result temporal_rs_PlainDateTime_year_of_week(const temporal_rs::capi::PlainDateTime* self);
 
-    typedef struct temporal_rs_PlainDateTime_days_in_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_days_in_week_result;
-    temporal_rs_PlainDateTime_days_in_week_result temporal_rs_PlainDateTime_days_in_week(const temporal_rs::capi::PlainDateTime* self);
+    uint16_t temporal_rs_PlainDateTime_days_in_week(const temporal_rs::capi::PlainDateTime* self);
 
     uint16_t temporal_rs_PlainDateTime_days_in_month(const temporal_rs::capi::PlainDateTime* self);
 
@@ -302,9 +300,9 @@ inline uint8_t temporal_rs::PlainDateTime::day() const {
   return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDateTime::day_of_week() const {
+inline uint16_t temporal_rs::PlainDateTime::day_of_week() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_day_of_week(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline uint16_t temporal_rs::PlainDateTime::day_of_year() const {
@@ -322,9 +320,9 @@ inline std::optional<int32_t> temporal_rs::PlainDateTime::year_of_week() const {
   return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::PlainDateTime::days_in_week() const {
+inline uint16_t temporal_rs::PlainDateTime::days_in_week() const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_days_in_week(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline uint16_t temporal_rs::PlainDateTime::days_in_month() const {

--- a/temporal_capi/src/calendar.rs
+++ b/temporal_capi/src/calendar.rs
@@ -173,8 +173,8 @@ pub mod ffi {
         pub fn day(&self, date: IsoDate) -> u8 {
             self.0.day(&date.into())
         }
-        pub fn day_of_week(&self, date: IsoDate) -> Result<u16, TemporalError> {
-            self.0.day_of_week(&date.into()).map_err(Into::into)
+        pub fn day_of_week(&self, date: IsoDate) -> u16 {
+            self.0.day_of_week(&date.into())
         }
         pub fn day_of_year(&self, date: IsoDate) -> u16 {
             self.0.day_of_year(&date.into())
@@ -185,8 +185,8 @@ pub mod ffi {
         pub fn year_of_week(&self, date: IsoDate) -> Option<i32> {
             self.0.year_of_week(&date.into())
         }
-        pub fn days_in_week(&self, date: IsoDate) -> Result<u16, TemporalError> {
-            self.0.days_in_week(&date.into()).map_err(Into::into)
+        pub fn days_in_week(&self, date: IsoDate) -> u16 {
+            self.0.days_in_week(&date.into())
         }
         pub fn days_in_month(&self, date: IsoDate) -> u16 {
             self.0.days_in_month(&date.into())

--- a/temporal_capi/src/plain_date.rs
+++ b/temporal_capi/src/plain_date.rs
@@ -224,8 +224,8 @@ pub mod ffi {
         pub fn day(&self) -> u8 {
             self.0.day()
         }
-        pub fn day_of_week(&self) -> Result<u16, TemporalError> {
-            self.0.day_of_week().map_err(Into::into)
+        pub fn day_of_week(&self) -> u16 {
+            self.0.day_of_week()
         }
         pub fn day_of_year(&self) -> u16 {
             self.0.day_of_year()
@@ -236,8 +236,8 @@ pub mod ffi {
         pub fn year_of_week(&self) -> Option<i32> {
             self.0.year_of_week()
         }
-        pub fn days_in_week(&self) -> Result<u16, TemporalError> {
-            self.0.days_in_week().map_err(Into::into)
+        pub fn days_in_week(&self) -> u16 {
+            self.0.days_in_week()
         }
         pub fn days_in_month(&self) -> u16 {
             self.0.days_in_month()

--- a/temporal_capi/src/plain_date_time.rs
+++ b/temporal_capi/src/plain_date_time.rs
@@ -198,8 +198,8 @@ pub mod ffi {
         pub fn day(&self) -> u8 {
             self.0.day()
         }
-        pub fn day_of_week(&self) -> Result<u16, TemporalError> {
-            self.0.day_of_week().map_err(Into::into)
+        pub fn day_of_week(&self) -> u16 {
+            self.0.day_of_week()
         }
         pub fn day_of_year(&self) -> u16 {
             self.0.day_of_year()
@@ -210,8 +210,8 @@ pub mod ffi {
         pub fn year_of_week(&self) -> Option<i32> {
             self.0.year_of_week()
         }
-        pub fn days_in_week(&self) -> Result<u16, TemporalError> {
-            self.0.days_in_week().map_err(Into::into)
+        pub fn days_in_week(&self) -> u16 {
+            self.0.days_in_week()
         }
         pub fn days_in_month(&self) -> u16 {
             self.0.days_in_month()


### PR DESCRIPTION
According to proposal-intl-era-monthcode, `[[DayOfWeek]]` is:

> The day of the week corresponding to the date. The value should be 1-based, where 1 is the day corresponding to Monday in the given calendar.


which is calendar-agnostic.

The CAPI changes are mitigated in V8 in https://chromium-review.googlesource.com/c/v8/v8/+/6805173.