### PR TITLE
Make ZonedDateTime {day_of,days_in}_week() FFI infallible

### DIFF
--- a/temporal_capi/bindings/c/ZonedDateTime.h
+++ b/temporal_capi/bindings/c/ZonedDateTime.h
@@ -143,8 +143,7 @@ void temporal_rs_ZonedDateTime_month_code(const ZonedDateTime* self, DiplomatWri
 
 uint8_t temporal_rs_ZonedDateTime_day(const ZonedDateTime* self);
 
-typedef struct temporal_rs_ZonedDateTime_day_of_week_result {union {uint16_t ok; TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_day_of_week_result;
-temporal_rs_ZonedDateTime_day_of_week_result temporal_rs_ZonedDateTime_day_of_week(const ZonedDateTime* self);
+uint16_t temporal_rs_ZonedDateTime_day_of_week(const ZonedDateTime* self);
 
 uint16_t temporal_rs_ZonedDateTime_day_of_year(const ZonedDateTime* self);
 
@@ -154,8 +153,7 @@ temporal_rs_ZonedDateTime_week_of_year_result temporal_rs_ZonedDateTime_week_of_
 typedef struct temporal_rs_ZonedDateTime_year_of_week_result {union {int32_t ok; }; bool is_ok;} temporal_rs_ZonedDateTime_year_of_week_result;
 temporal_rs_ZonedDateTime_year_of_week_result temporal_rs_ZonedDateTime_year_of_week(const ZonedDateTime* self);
 
-typedef struct temporal_rs_ZonedDateTime_days_in_week_result {union {uint16_t ok; TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_days_in_week_result;
-temporal_rs_ZonedDateTime_days_in_week_result temporal_rs_ZonedDateTime_days_in_week(const ZonedDateTime* self);
+uint16_t temporal_rs_ZonedDateTime_days_in_week(const ZonedDateTime* self);
 
 uint16_t temporal_rs_ZonedDateTime_days_in_month(const ZonedDateTime* self);
 

--- a/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.d.hpp
@@ -145,7 +145,7 @@ public:
 
   inline uint8_t day() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> day_of_week() const;
+  inline uint16_t day_of_week() const;
 
   inline uint16_t day_of_year() const;
 
@@ -153,7 +153,7 @@ public:
 
   inline std::optional<int32_t> year_of_week() const;
 
-  inline diplomat::result<uint16_t, temporal_rs::TemporalError> days_in_week() const;
+  inline uint16_t days_in_week() const;
 
   inline uint16_t days_in_month() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.hpp
@@ -146,8 +146,7 @@ namespace capi {
 
     uint8_t temporal_rs_ZonedDateTime_day(const temporal_rs::capi::ZonedDateTime* self);
 
-    typedef struct temporal_rs_ZonedDateTime_day_of_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_day_of_week_result;
-    temporal_rs_ZonedDateTime_day_of_week_result temporal_rs_ZonedDateTime_day_of_week(const temporal_rs::capi::ZonedDateTime* self);
+    uint16_t temporal_rs_ZonedDateTime_day_of_week(const temporal_rs::capi::ZonedDateTime* self);
 
     uint16_t temporal_rs_ZonedDateTime_day_of_year(const temporal_rs::capi::ZonedDateTime* self);
 
@@ -157,8 +156,7 @@ namespace capi {
     typedef struct temporal_rs_ZonedDateTime_year_of_week_result {union {int32_t ok; }; bool is_ok;} temporal_rs_ZonedDateTime_year_of_week_result;
     temporal_rs_ZonedDateTime_year_of_week_result temporal_rs_ZonedDateTime_year_of_week(const temporal_rs::capi::ZonedDateTime* self);
 
-    typedef struct temporal_rs_ZonedDateTime_days_in_week_result {union {uint16_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_days_in_week_result;
-    temporal_rs_ZonedDateTime_days_in_week_result temporal_rs_ZonedDateTime_days_in_week(const temporal_rs::capi::ZonedDateTime* self);
+    uint16_t temporal_rs_ZonedDateTime_days_in_week(const temporal_rs::capi::ZonedDateTime* self);
 
     uint16_t temporal_rs_ZonedDateTime_days_in_month(const temporal_rs::capi::ZonedDateTime* self);
 
@@ -455,9 +453,9 @@ inline uint8_t temporal_rs::ZonedDateTime::day() const {
   return result;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::day_of_week() const {
+inline uint16_t temporal_rs::ZonedDateTime::day_of_week() const {
   auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_day_of_week(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline uint16_t temporal_rs::ZonedDateTime::day_of_year() const {
@@ -475,9 +473,9 @@ inline std::optional<int32_t> temporal_rs::ZonedDateTime::year_of_week() const {
   return result.is_ok ? std::optional<int32_t>(result.ok) : std::nullopt;
 }
 
-inline diplomat::result<uint16_t, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::days_in_week() const {
+inline uint16_t temporal_rs::ZonedDateTime::days_in_week() const {
   auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_days_in_week(this->AsFFI());
-  return result.is_ok ? diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Ok<uint16_t>(result.ok)) : diplomat::result<uint16_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result;
 }
 
 inline uint16_t temporal_rs::ZonedDateTime::days_in_month() const {

--- a/temporal_capi/src/zoned_date_time.rs
+++ b/temporal_capi/src/zoned_date_time.rs
@@ -433,8 +433,8 @@ pub mod ffi {
             self.0.day().unwrap_or_default()
         }
 
-        pub fn day_of_week(&self) -> Result<u16, TemporalError> {
-            self.0.day_of_week().map_err(Into::into)
+        pub fn day_of_week(&self) -> u16 {
+            self.0.day_of_week().unwrap_or_default()
         }
 
         pub fn day_of_year(&self) -> u16 {
@@ -449,8 +449,8 @@ pub mod ffi {
             self.0.year_of_week().unwrap_or_default()
         }
 
-        pub fn days_in_week(&self) -> Result<u16, TemporalError> {
-            self.0.days_in_week().map_err(Into::into)
+        pub fn days_in_week(&self) -> u16 {
+            self.0.days_in_week().unwrap_or_default()
         }
 
         pub fn days_in_month(&self) -> u16 {


### PR DESCRIPTION
This was missed in https://github.com/boa-dev/temporal/pull/471. The only possible error is from `get_iso_datetime_for()` which is infallible with compiled data.