### PR TITLE
Fix panics from calling abs on i64::MIN

### DIFF
--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -1245,15 +1245,15 @@ pub(crate) fn is_valid_duration(
     }
     // 3. If abs(years) ≥ 2**32, return false.
     // n.b. u32::MAX is 2**32 - 1
-    if years.abs() > u32::MAX as i64 {
+    if years.saturating_abs() > u32::MAX as i64 {
         return false;
     };
     // 4. If abs(months) ≥ 2**32, return false.
-    if months.abs() > u32::MAX as i64 {
+    if months.saturating_abs() > u32::MAX as i64 {
         return false;
     };
     // 5. If abs(weeks) ≥ 2**32, return false.
-    if weeks.abs() > u32::MAX as i64 {
+    if weeks.saturating_abs() > u32::MAX as i64 {
         return false;
     };
 
@@ -1289,7 +1289,7 @@ pub(crate) fn is_valid_duration(
 
     let total_normalized_seconds = normalized_nanoseconds + normalized_subseconds_parts;
     // 8. If abs(normalizedSeconds) ≥ 2**53, return false.
-    if total_normalized_seconds.abs() >= MAX_SAFE_NS_PRECISION {
+    if total_normalized_seconds.saturating_abs() >= MAX_SAFE_NS_PRECISION {
         return false;
     }
 


### PR DESCRIPTION
Missed a couple more panics when calling with `i64::MIN`. Double checked in Boa, and this does cover everything and the test passes now.