### PR TITLE
Reuse ZDT parsing logic from PartialZDT

### DIFF
--- a/temporal_capi/src/zoned_date_time.rs
+++ b/temporal_capi/src/zoned_date_time.rs
@@ -508,7 +508,7 @@ impl TryFrom<ffi::PartialZonedDateTime<'_>> for temporal_rs::partial::PartialZon
         };
         Ok(Self {
             date: other.date.try_into()?,
-            time: other.time.into(),
+            time: Some(other.time.into()),
             // These fields are only true when parsing
             has_utc_designator: false,
             match_minutes: false,


### PR DESCRIPTION
Progress on #408

I don't like having two very similar pieces of code; especially since all of our tests use `ZDT::from_utf8` but implementors will have to use `PartialZDT::try_from_utf8` to deal with #408.

....and I switched things over and immediately discovered a problem in that `START-OF-DAY` wasn't representable in `PartialZDT`. Good thing I did; this may have implications down the line for the rest of #408 (though by and large `START-OF-DAY` is only important for ZDT, it seems)


As I work on #408, I plan to do the same for all of the other callers. This also helps ensure that I won't break any tests in implementors using Partial types for parsing.
