### PR TITLE
Add support for non-ISO yearmonths and monthdays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,9 +555,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "ixdtf"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64f97f99b995d752759955a8c14a822b2e009ce99c952a4957c2ec94989ba3e"
+checksum = "08b741faae9005d3c809ca4b8566d75745c408171b3c6bbb54d2b00d04910c1c"
 dependencies = [
  "displaydoc",
 ]

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -282,7 +282,7 @@ impl Calendar {
         PlainYearMonth::new_with_overflow(
             Iso.year_info(&iso).year,
             Iso.month(&iso).ordinal,
-            Some(Iso.days_in_month(&iso)),
+            Some(Iso.day_of_month(&iso).0),
             self.clone(),
             overflow,
         )

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -196,7 +196,7 @@ impl Calendar {
         if self.is_iso() {
             // Resolve month and monthCode;
             return PlainDate::new_with_overflow(
-                resolved_fields.era_year.year,
+                resolved_fields.era_year.arithmetic_year,
                 resolved_fields.month_code.to_month_integer(),
                 resolved_fields.day,
                 self.clone(),
@@ -260,7 +260,7 @@ impl Calendar {
         )?;
         if self.is_iso() {
             return PlainYearMonth::new_with_overflow(
-                resolved_fields.era_year.year,
+                resolved_fields.era_year.arithmetic_year,
                 resolved_fields.month_code.to_month_integer(),
                 Some(resolved_fields.day),
                 self.clone(),

--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -241,9 +241,24 @@ impl Calendar {
             );
         }
 
-        // TODO: This may get complicated...
-        // For reference: https://github.com/tc39/proposal-temporal/blob/main/polyfill/lib/calendar.mjs#L1275.
-        Err(TemporalError::range().with_message("Not yet implemented/supported."))
+        // We trust ResolvedCalendarFields to have calculated an appropriate reference year for us
+        let calendar_date = self
+            .0
+            .from_codes(
+                resolved_fields.era_year.era.as_ref().map(|e| e.0.as_str()),
+                resolved_fields.era_year.year,
+                IcuMonthCode(resolved_fields.month_code.0),
+                resolved_fields.day,
+            )
+            .map_err(TemporalError::from_icu4x)?;
+        let iso = self.0.to_iso(&calendar_date);
+        PlainMonthDay::new_with_overflow(
+            Iso.month(&iso).ordinal,
+            Iso.day_of_month(&iso).0,
+            self.clone(),
+            overflow,
+            Some(Iso.extended_year(&iso)),
+        )
     }
 
     /// `CalendarPlainYearMonthFromFields`

--- a/src/builtins/core/calendar/types.rs
+++ b/src/builtins/core/calendar/types.rs
@@ -225,7 +225,7 @@ impl EraYear {
             }
         }
         // For simple calendars with a single leap day.
-        // This needs the date of 1972-12-31 represented in that calendar, the month-day of th eleap day,
+        // This needs the date of 1972-12-31 represented in that calendar, the month-day of the leap day,
         // and the first reference year where the leap day occurs on or before 1972-12-31
         fn threshold_with_leap_day(
             month: u8,

--- a/src/builtins/core/calendar/types.rs
+++ b/src/builtins/core/calendar/types.rs
@@ -135,6 +135,24 @@ impl EraYear {
         resolution_type: ResolutionType,
     ) -> TemporalResult<Self> {
         match (partial.year, partial.era, partial.era_year) {
+            _ if resolution_type == ResolutionType::MonthDay => {
+                let day = partial
+                    .day
+                    .ok_or(TemporalError::assert().with_message("MonthDay must specify day"))?;
+                let arithmetic_year = Self::reference_arithmetic_year_for_month_day(
+                    &partial.calendar,
+                    partial.month_code,
+                    partial.month,
+                    day,
+                )?;
+                Ok(Self {
+                    // We should just specify these as arithmetic years, no need
+                    // to muck with eras
+                    era: None,
+                    arithmetic_year,
+                    year: arithmetic_year,
+                })
+            }
             (maybe_year, Some(era), Some(era_year)) => {
                 let Some(era_info) = partial.calendar.get_era_info(&era) else {
                     return Err(TemporalError::range().with_message("Invalid era provided."));
@@ -169,14 +187,185 @@ impl EraYear {
                 year,
                 arithmetic_year: year,
             }),
-            (None, None, None) if resolution_type == ResolutionType::MonthDay => Ok(Self {
-                era: None,
-                year: 1972,
-                arithmetic_year: 1972,
-            }),
             _ => Err(TemporalError::r#type()
                 .with_message("Required fields missing to determine an era and year.")),
         }
+    }
+
+    fn reference_arithmetic_year_for_month_day(
+        calendar: &Calendar,
+        month_code: Option<MonthCode>,
+        ordinal_month: Option<u8>,
+        day: u8,
+    ) -> TemporalResult<i32> {
+        let ordinal_month_for_leapless = || {
+            ordinal_month
+                .or_else(|| month_code.map(|c| MonthCode::to_month_integer(&c)))
+                .ok_or(TemporalError::assert().with_message("Neither month nor monthCode provided"))
+        };
+        let require_month_code = || {
+            if let Some(month_code) = month_code {
+                Ok(month_code)
+            } else {
+                Err(TemporalError::r#type()
+                    .with_message("Must specify month codes with MonthDay for lunar calendars"))
+            }
+        };
+        // For simple calendars without leap days
+        // (or if leap days have already been handled)
+        // This needs the date of 1972-12-31 represented in that calendar
+        fn threshold(month: u8, day: u8, dec_31_1972: (i32, u8, u8)) -> i32 {
+            // If it's after the day of dec 31 in the primary reference year,
+            // go one year earlier
+            if month == dec_31_1972.1 && day > dec_31_1972.2 || month > dec_31_1972.1 {
+                dec_31_1972.0 - 1
+            } else {
+                // Return the primary reference year
+                dec_31_1972.0
+            }
+        }
+        // For simple calendars with a single leap day.
+        // This needs the date of 1972-12-31 represented in that calendar, the month-day of th eleap day,
+        // and the first reference year where the leap day occurs on or before 1972-12-31
+        fn threshold_with_leap_day(
+            month: u8,
+            day: u8,
+            dec_31_1972: (i32, u8, u8),
+            leap_day: (u8, u8),
+            leap_year: i32,
+        ) -> i32 {
+            // If it's a leap day, just return the leap year
+            if (month, day) == leap_day {
+                leap_year
+            } else {
+                threshold(month, day, dec_31_1972)
+            }
+        }
+
+        // The reference date is the latest ISO 8601 date corresponding to the calendar date, that is also earlier than
+        // or equal to the ISO 8601 date December 31, 1972. If that calendar date never occurs on or before the ISO 8601 date December 31, 1972,
+        // then the reference date is the earliest ISO 8601 date corresponding to that calendar date.
+        // The reference year is almost always 1972 (the first ISO 8601 leap year after the epoch), with exceptions
+        // for calendars where some dates (e.g. leap days or days in leap months) didn't occur during that ISO 8601 year.
+        // For example, Hebrew calendar leap month Adar I occurred in calendar years 5730 and 5733 (respectively overlapping
+        // ISO 8601 February/March 1970 and February/March 1973), but did not occur between them, so the reference year for days of that month is 1970.
+
+        Ok(match calendar.kind() {
+            AnyCalendarKind::Iso | AnyCalendarKind::Gregorian => 1972,
+            // These calendars just wrap Gregorian with a different epoch
+            AnyCalendarKind::Buddhist => 1972 + 543,
+            AnyCalendarKind::Roc => 1972 - 1911,
+
+            AnyCalendarKind::Indian => {
+                let month = ordinal_month_for_leapless()?;
+                threshold_with_leap_day(month, day, (1894, 10, 10), (1, 30), 1984)
+            }
+            AnyCalendarKind::Persian => {
+                let month = ordinal_month_for_leapless()?;
+                threshold_with_leap_day(month, day, (1351, 10, 10), (12, 30), 1350)
+            }
+            AnyCalendarKind::HijriTabularTypeIIFriday => {
+                let month = ordinal_month_for_leapless()?;
+                threshold_with_leap_day(month, day, (1392, 11, 25), (12, 30), 1390)
+            }
+            AnyCalendarKind::HijriTabularTypeIIThursday => {
+                let month = ordinal_month_for_leapless()?;
+                threshold_with_leap_day(month, day, (1392, 11, 26), (12, 30), 1390)
+            }
+            AnyCalendarKind::Coptic => {
+                let month = ordinal_month_for_leapless()?;
+                threshold_with_leap_day(month, day, (1689, 4, 22), (13, 6), 1687)
+            }
+            AnyCalendarKind::Ethiopian => {
+                let month = ordinal_month_for_leapless()?;
+                threshold_with_leap_day(month, day, (1965, 4, 22), (13, 6), 1963)
+            }
+            AnyCalendarKind::EthiopianAmeteAlem => {
+                let month = ordinal_month_for_leapless()?;
+                threshold_with_leap_day(month, day, (7465, 4, 22), (13, 6), 7463)
+            }
+            AnyCalendarKind::Hebrew => {
+                let month_code = require_month_code()?;
+
+                // 1972-12-31 is y=5733 am, m=4, d=26. We must produce year 5723 or lower
+                if month_code.is_leap_month() {
+                    // 5730 is a leap year
+                    5730
+                } else {
+                    let month = month_code.to_month_integer();
+                    if (month == 4 && day == 26) || month > 4 {
+                        // 5733 will produce dates after 1972, return 5722 instead
+                        5732
+                    } else {
+                        // All months have 29 days
+                        if day <= 29 {
+                            5733
+                        // Ḥeshvan/Kislev only have 30 days sometimes
+                        // Fortunately 5732 has 30 days for both
+                        } else if month == 2 || month == 3 {
+                            5732
+                        } else {
+                            // Some other month, we don't actually need to check
+                            5733
+                        }
+                    }
+                }
+            }
+
+            // TODO(Manishearth) Chinese, Dangi, waiting on https://github.com/unicode-org/icu4x/pull/6762
+            // and https://github.com/tc39/proposal-intl-era-monthcode/issues/60
+
+            // These lunar calendars are iffier: The ones above are mathematically defined,
+            // the algorithm for these may change. This data may need to be updated on occasion.
+            AnyCalendarKind::HijriUmmAlQura => {
+                let month = ordinal_month_for_leapless()?;
+                if day < 30 {
+                    threshold(month, day, (1392, 11, 25))
+                } else {
+                    match month {
+                        1 => 1392,
+                        2 => 1390,
+                        3 => 1391,
+                        4 => 1392,
+                        5 => 1391,
+                        6 => 1392,
+                        7 => 1389,
+                        8 => 1392,
+                        9 => 1392,
+                        10 => 1390,
+                        11 => 1391,
+                        12 => 1390,
+                        _ => 1392,
+                    }
+                }
+            }
+            AnyCalendarKind::HijriSimulatedMecca => {
+                let month = ordinal_month_for_leapless()?;
+                if day < 30 {
+                    threshold(month, day, (1392, 11, 24))
+                } else {
+                    match month {
+                        1 => 1390,
+                        2 => 1391,
+                        3 => 1392,
+                        4 => 1391,
+                        5 => 1390,
+                        6 => 1392,
+                        7 => 1392,
+                        8 => 1392,
+                        9 => 1390,
+                        10 => 1392,
+                        11 => 1390,
+                        12 => 1391,
+                        _ => 1392,
+                    }
+                }
+            }
+            _ => {
+                return Err(TemporalError::range()
+                    .with_message("Do not currently support MonthDay with this calendar"))
+            }
+        })
     }
 }
 

--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -70,6 +70,18 @@ impl PartialDate {
     crate::impl_with_fallback_method!(with_fallback_date, (with_day: day) PlainDate);
     crate::impl_with_fallback_method!(with_fallback_datetime, (with_day:day) PlainDateTime);
     crate::impl_field_keys_to_ignore!((with_day:day));
+
+    pub(crate) fn try_from_month_day(month_day: &PlainMonthDay) -> TemporalResult<Self> {
+        Ok(Self {
+            year: None,
+            month: None,
+            month_code: Some(month_day.month_code()),
+            era: None,
+            era_year: None,
+            day: Some(month_day.day()),
+            calendar: month_day.calendar().clone(),
+        })
+    }
 }
 
 /// The return value of CalendarFieldKeysToIgnore

--- a/src/builtins/core/month_day.rs
+++ b/src/builtins/core/month_day.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 
 use super::{calendar::month_to_month_code, PartialDate, PlainDate};
-use writeable::Writeable;
 use icu_calendar::AnyCalendarKind;
+use writeable::Writeable;
 
 /// The native Rust implementation of `Temporal.PlainMonthDay`.
 ///
@@ -215,7 +215,8 @@ impl PlainMonthDay {
         // Note: parse_month_day will refuse to parse MM-DD format month-days for non-ISO, but
         // it will happily parse YYYY-MM-DD[u-ca=CAL]. These will be valid ISO dates; but they
         // could potentially be out of Temporal range.
-        let iso = IsoDate::new_unchecked(parsed.record.year, parsed.record.month, parsed.record.day);
+        let iso =
+            IsoDate::new_unchecked(parsed.record.year, parsed.record.month, parsed.record.day);
         iso.check_validity()?;
 
         // 13. Set result to ISODateToFields(calendar, isoDate, month-day).

--- a/src/builtins/core/month_day.rs
+++ b/src/builtins/core/month_day.rs
@@ -220,20 +220,13 @@ impl PlainMonthDay {
         iso.check_validity()?;
 
         // 13. Set result to ISODateToFields(calendar, isoDate, month-day).
+
+        let intermediate = Self::new_unchecked(iso, Calendar::new(parsed.calendar));
+        let partial = PartialDate::try_from_month_day(&intermediate)?;
         // 14. NOTE: The following operation is called with constrain regardless of the value of overflow, in
         // order for the calendar to store a canonical value in the [[Year]] field of the [[ISODate]] internal slot of the result.
         // 15. Set isoDate to ? CalendarMonthDayFromFields(calendar, result, constrain).
-
-        // TODO(Manishearth) this must tweak the year to something valid
-        // https://github.com/boa-dev/temporal/issues/450
-        // https://github.com/tc39/proposal-intl-era-monthcode/issues/60
-        Self::new_with_overflow(
-            parsed.record.month,
-            parsed.record.day,
-            calendar,
-            ArithmeticOverflow::Reject,
-            Some(parsed.record.year),
-        )
+        PlainMonthDay::from_partial(partial, Some(ArithmeticOverflow::Constrain))
     }
 
     /// Create a `PlainYearMonth` from a `PartialDate`
@@ -334,6 +327,12 @@ impl PlainMonthDay {
         self.calendar.day(&self.iso)
     }
 
+    /// Returns the internal reference year used by this MonthDay.
+    #[inline]
+    pub fn reference_year(&self) -> i32 {
+        self.calendar.year(&self.iso)
+    }
+
     /// Create a [`PlainDate`] from the current `PlainMonthDay`.
     pub fn to_plain_date(&self, year: Option<PartialDate>) -> TemporalResult<PlainDate> {
         let year_partial = match &year {
@@ -409,7 +408,6 @@ impl FromStr for PlainMonthDay {
 mod tests {
     use super::*;
     use crate::builtins::core::PartialDate;
-    use crate::Calendar;
     use tinystr::tinystr;
 
     #[test]
@@ -558,6 +556,130 @@ mod tests {
         ];
         for test in TESTS {
             assert!(PlainMonthDay::from_utf8(test.as_bytes()).is_err());
+        }
+    }
+
+    #[test]
+    /// This test is for calendars where we don't wish to hardcode dates; but we do wish to know
+    /// that monthcodes can be constructed without issue
+    fn automated_reference_year() {
+        let reference_iso = IsoDate::new_unchecked(1972, 12, 31);
+        for cal in [
+            AnyCalendarKind::HijriSimulatedMecca,
+            AnyCalendarKind::HijriUmmAlQura,
+        ] {
+            let calendar = Calendar::new(cal);
+            for month in 1..=12 {
+                for day in [29, 30] {
+                    let month_code = crate::builtins::calendar::month_to_month_code(month).unwrap();
+
+                    let partial = PartialDate {
+                        month_code: Some(month_code),
+                        day: Some(day),
+                        calendar: calendar.clone(),
+                        ..Default::default()
+                    };
+
+                    let md = PlainMonthDay::from_partial(partial, Some(ArithmeticOverflow::Reject))
+                        .unwrap();
+
+                    assert!(
+                        md.iso <= reference_iso,
+                        "Reference ISO for {month}-{day} must be before 1972-12-31, found, {:?}",
+                        md.iso,
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn manual_test_reference_year() {
+        // monthCode, day, ISO string, expectedReferenceYear
+        // Some of these parsed strings are deliberately not using the reference year
+        // so that we can test all code paths. By default, when adding new strings, it is easier
+        // to just add the reference year
+        const TESTS: &[(&str, u8, &str, i32)] = &[
+            ("M10", 30, "1868-10-30[u-ca=gregory]", 1972),
+            ("M08", 8, "1868-10-30[u-ca=indian]", 1894),
+            ("M09", 21, "2000-12-12[u-ca=indian]", 1894),
+            // Dates in the earlier half of the year get pushed back a year
+            ("M10", 22, "2000-01-12[u-ca=indian]", 1893),
+            ("M01", 11, "2000-03-30[u-ca=persian]", 1351),
+            ("M09", 22, "2000-12-12[u-ca=persian]", 1351),
+            ("M12", 29, "2025-03-19[u-ca=persian]", 1350),
+            // Leap day
+            ("M12", 30, "2025-03-20[u-ca=persian]", 1350),
+            ("M01", 1, "2025-03-21[u-ca=persian]", 1351),
+            ("M01", 1, "2025-03-21[u-ca=persian]", 1351),
+            ("M01", 1, "1972-01-01[u-ca=roc]", 61),
+            ("M02", 29, "2024-02-29[u-ca=roc]", 61),
+            ("M12", 1, "1972-12-01[u-ca=roc]", 61),
+            ("M01", 1, "1972-09-11[u-ca=coptic]", 1689),
+            ("M12", 1, "1972-08-07[u-ca=coptic]", 1688),
+            ("M13", 5, "1972-09-10[u-ca=coptic]", 1688),
+            ("M13", 6, "1971-09-11[u-ca=coptic]", 1687),
+            ("M01", 1, "1972-09-11[u-ca=ethiopic]", 1965),
+            ("M12", 1, "1972-08-07[u-ca=ethiopic]", 1964),
+            ("M13", 5, "1972-09-10[u-ca=ethiopic]", 1964),
+            ("M13", 6, "1971-09-11[u-ca=ethiopic]", 1963),
+            ("M01", 1, "1972-09-11[u-ca=ethioaa]", 7465),
+            ("M12", 1, "1972-08-07[u-ca=ethioaa]", 7464),
+            ("M13", 5, "1972-09-10[u-ca=ethioaa]", 7464),
+            ("M13", 6, "1971-09-11[u-ca=ethioaa]", 7463),
+            ("M01", 1, "1972-09-09[u-ca=hebrew]", 5733),
+            ("M02", 29, "1972-11-06[u-ca=hebrew]", 5733),
+            ("M03", 29, "1972-12-05[u-ca=hebrew]", 5733),
+            ("M03", 30, "1971-12-18[u-ca=hebrew]", 5732),
+            ("M05L", 29, "1970-03-07[u-ca=hebrew]", 5730),
+            ("M07", 1, "1972-03-16[u-ca=hebrew]", 5732),
+            ("M01", 1, "1972-02-16[u-ca=islamic-civil]", 1392),
+            ("M12", 29, "1972-02-15[u-ca=islamic-civil]", 1391),
+            ("M12", 30, "1971-02-26[u-ca=islamic-civil]", 1390),
+            ("M01", 1, "1972-02-15[u-ca=islamic-tbla]", 1392),
+            ("M12", 29, "1972-02-14[u-ca=islamic-tbla]", 1391),
+            ("M12", 30, "1971-02-25[u-ca=islamic-tbla]", 1390),
+        ];
+        let reference_iso = IsoDate::new_unchecked(1972, 12, 31);
+        for (month_code, day, string, year) in TESTS {
+            let md = PlainMonthDay::from_str(string).expect(string);
+
+            let partial = PartialDate {
+                month_code: Some(month_code.parse().unwrap()),
+                day: Some(*day),
+                calendar: md.calendar.clone(),
+                ..Default::default()
+            };
+
+            let md_from_partial =
+                PlainMonthDay::from_partial(partial, Some(ArithmeticOverflow::Reject))
+                    .expect(string);
+
+            assert_eq!(
+                md,
+                md_from_partial,
+                "Parsed {string}, compared with {}: Expected {}-{}, Found {}-{}",
+                md_from_partial.to_ixdtf_string(Default::default()),
+                md_from_partial.month_code().0,
+                md_from_partial.day(),
+                md.month_code().0,
+                md.day()
+            );
+
+            assert_eq!(
+                md_from_partial.reference_year(),
+                *year,
+                "Reference year for {string} ({month_code}-{day}) must be {year}",
+            );
+
+            assert!(
+                md.iso <= reference_iso && md_from_partial.iso <= reference_iso,
+                "Reference ISO for {string} ({}-{}) must be before 1972-12-31, found, {:?} / {:?}",
+                md.month_code().0,
+                md.day(),
+                md.iso,
+                md_from_partial.iso
+            );
         }
     }
 }

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -1232,4 +1232,42 @@ mod tests {
         assert!(min.since(&max, Default::default()).is_err());
         assert!(min.since(&epoch, Default::default()).is_err());
     }
+
+    #[test]
+    fn test_reference_day() {
+        assert_eq!(
+            PlainYearMonth::from_str("1868-10-30[u-ca=japanese]")
+                .unwrap()
+                .reference_day(),
+            23
+        );
+        // Still happens for dates that are in the previous era but same month
+        assert_eq!(
+            PlainYearMonth::from_str("1868-10-20[u-ca=japanese]")
+                .unwrap()
+                .reference_day(),
+            23
+        );
+        // Won't happen for dates in other months
+        assert_eq!(
+            PlainYearMonth::from_str("1868-09-30[u-ca=japanese]")
+                .unwrap()
+                .reference_day(),
+            1
+        );
+
+        // Always 1 in other calendars
+        assert_eq!(
+            PlainYearMonth::from_str("2000-09-30[u-ca=chinese]")
+                .unwrap()
+                .reference_day(),
+            1
+        );
+        assert_eq!(
+            PlainYearMonth::from_str("2000-09-30[u-ca=hebrew]")
+                .unwrap()
+                .reference_day(),
+            1
+        );
+    }
 }

--- a/src/parsed_intermediates.rs
+++ b/src/parsed_intermediates.rs
@@ -52,14 +52,7 @@ impl ParsedDate {
         let parse_record = parsers::parse_year_month(s)?;
 
         let calendar = extract_kind(parse_record.calendar)?;
-        // ParseISODateTime
-        // Step 4.a.ii.3
-        // If goal is TemporalMonthDayString or TemporalYearMonthString, calendar is
-        // not empty, and the ASCII-lowercase of calendar is not "iso8601", throw a
-        // RangeError exception.
-        if calendar != AnyCalendarKind::Iso {
-            return Err(TemporalError::range().with_message("non-ISO calendar not supported."));
-        }
+
         // Assertion: PlainDate must exist on a DateTime parse.
         let record = parse_record.date.temporal_unwrap()?;
 
@@ -70,15 +63,6 @@ impl ParsedDate {
         let parse_record = parsers::parse_month_day(s)?;
 
         let calendar = extract_kind(parse_record.calendar)?;
-
-        // ParseISODateTime
-        // Step 4.a.ii.3
-        // If goal is TemporalMonthDayString or TemporalYearMonthString, calendar is
-        // not empty, and the ASCII-lowercase of calendar is not "iso8601", throw a
-        // RangeError exception.
-        if calendar != AnyCalendarKind::Iso {
-            return Err(TemporalError::range().with_message("non-ISO calendar not supported."));
-        }
 
         // Assertion: PlainDate must exist on a DateTime parse.
         let record = parse_record.date.temporal_unwrap()?;

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -696,6 +696,8 @@ fn parse_ixdtf(source: &[u8], variant: ParseVariant) -> TemporalResult<IxdtfPars
     }
     .map_err(|e| TemporalError::range().with_message(format!("{e}")))?;
 
+    record.calendar = first_calendar.map(|v| v.value);
+
     // Note: this method only handles the specific AnnotatedFoo nonterminals;
     // so if we are parsing MonthDay/YearMonth we will never have a DateDay/DateYear parse node.
     //
@@ -726,8 +728,6 @@ fn parse_ixdtf(source: &[u8], variant: ParseVariant) -> TemporalResult<IxdtfPars
             TemporalError::range().with_message("DateTime strings must contain a Date value.")
         );
     }
-
-    record.calendar = first_calendar.map(|v| v.value);
 
     Ok(record)
 }

--- a/temporal_capi/bindings/c/PlainMonthDay.h
+++ b/temporal_capi/bindings/c/PlainMonthDay.h
@@ -52,6 +52,8 @@ uint8_t temporal_rs_PlainMonthDay_iso_month(const PlainMonthDay* self);
 
 uint8_t temporal_rs_PlainMonthDay_iso_day(const PlainMonthDay* self);
 
+uint8_t temporal_rs_PlainMonthDay_day(const PlainMonthDay* self);
+
 const Calendar* temporal_rs_PlainMonthDay_calendar(const PlainMonthDay* self);
 
 void temporal_rs_PlainMonthDay_month_code(const PlainMonthDay* self, DiplomatWrite* write);

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
@@ -62,6 +62,8 @@ public:
 
   inline uint8_t iso_day() const;
 
+  inline uint8_t day() const;
+
   inline const temporal_rs::Calendar& calendar() const;
 
   inline std::string month_code() const;

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
@@ -55,6 +55,8 @@ namespace capi {
 
     uint8_t temporal_rs_PlainMonthDay_iso_day(const temporal_rs::capi::PlainMonthDay* self);
 
+    uint8_t temporal_rs_PlainMonthDay_day(const temporal_rs::capi::PlainMonthDay* self);
+
     const temporal_rs::capi::Calendar* temporal_rs_PlainMonthDay_calendar(const temporal_rs::capi::PlainMonthDay* self);
 
     void temporal_rs_PlainMonthDay_month_code(const temporal_rs::capi::PlainMonthDay* self, diplomat::capi::DiplomatWrite* write);
@@ -136,6 +138,11 @@ inline uint8_t temporal_rs::PlainMonthDay::iso_month() const {
 
 inline uint8_t temporal_rs::PlainMonthDay::iso_day() const {
   auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_iso_day(this->AsFFI());
+  return result;
+}
+
+inline uint8_t temporal_rs::PlainMonthDay::day() const {
+  auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_day(this->AsFFI());
   return result;
 }
 

--- a/temporal_capi/src/plain_month_day.rs
+++ b/temporal_capi/src/plain_month_day.rs
@@ -97,6 +97,9 @@ pub mod ffi {
             self.0.iso_day()
         }
 
+        pub fn day(&self) -> u8 {
+            self.0.day()
+        }
         pub fn calendar<'a>(&'a self) -> &'a Calendar {
             Calendar::transparent_convert(self.0.calendar())
         }


### PR DESCRIPTION
This adds support for non-ISO yearmonths, as well as *some* non-ISO monthdays.

It currently does not support this for Ethiopic or Chinese/Dangi, since it needs working extended years.