### PR TITLE
cleanup: Remove parsing functionality from PartialZDT

### DIFF
--- a/src/builtins/core/calendar/fields.rs
+++ b/src/builtins/core/calendar/fields.rs
@@ -1,6 +1,5 @@
 use alloc::format;
 
-use ixdtf::records::DateRecord;
 use tinystr::TinyAsciiStr;
 
 use super::types::month_to_month_code;
@@ -102,17 +101,6 @@ impl CalendarFields {
 impl CalendarFields {
     pub fn is_empty(&self) -> bool {
         *self == Self::new()
-    }
-
-    pub(crate) fn from_date_record(date_record: DateRecord) -> Self {
-        Self {
-            year: Some(date_record.year),
-            month: Some(date_record.month),
-            month_code: None,
-            day: Some(date_record.day),
-            era: None,
-            era_year: None,
-        }
     }
 
     pub(crate) fn from_month_day(month_day: &PlainMonthDay) -> Self {

--- a/src/builtins/core/time.rs
+++ b/src/builtins/core/time.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     builtins::core::{duration::TimeDuration, Duration},
-    error::ErrorMessage,
     iso::IsoTime,
     options::{
         ArithmeticOverflow, DifferenceOperation, DifferenceSettings, ResolvedRoundingOptions,
@@ -13,7 +12,6 @@ use crate::{
 };
 use alloc::string::String;
 use core::str::FromStr;
-use ixdtf::records::TimeRecord;
 use writeable::Writeable;
 
 use super::{duration::normalized::NormalizedTimeDuration, PlainDateTime};
@@ -52,34 +50,6 @@ impl PartialTime {
             microsecond: None,
             nanosecond: None,
         }
-    }
-
-    pub(crate) fn from_time_record(time_record: TimeRecord) -> TemporalResult<Self> {
-        use crate::TemporalUnwrap;
-        use num_traits::Euclid;
-
-        let fractional_seconds = time_record
-            .fraction
-            .map(|x| {
-                x.to_nanoseconds().ok_or(
-                    TemporalError::range()
-                        .with_enum(ErrorMessage::FractionalTimeMoreThanNineDigits),
-                )
-            })
-            .transpose()?
-            .unwrap_or(0);
-
-        let (millisecond, rem) = fractional_seconds.div_rem_euclid(&1_000_000);
-        let (micros, nanos) = rem.div_rem_euclid(&1_000);
-
-        Ok(Self {
-            hour: Some(time_record.hour),
-            minute: Some(time_record.minute),
-            second: Some(time_record.second),
-            millisecond: Some(u16::try_from(millisecond).ok().temporal_unwrap()?),
-            microsecond: Some(u16::try_from(micros).ok().temporal_unwrap()?),
-            nanosecond: Some(u16::try_from(nanos).ok().temporal_unwrap()?),
-        })
     }
 
     pub const fn with_hour(mut self, hour: Option<u8>) -> Self {

--- a/temporal_capi/src/zoned_date_time.rs
+++ b/temporal_capi/src/zoned_date_time.rs
@@ -520,7 +520,7 @@ impl TryFrom<ffi::PartialZonedDateTime<'_>> for temporal_rs::fields::ZonedDateTi
         };
         Ok(Self {
             calendar_fields: other.date.try_into()?,
-            time: Some(other.time.into()),
+            time: other.time.into(),
             offset,
         })
     }

--- a/temporal_capi/src/zoned_date_time.rs
+++ b/temporal_capi/src/zoned_date_time.rs
@@ -504,9 +504,6 @@ impl TryFrom<ffi::PartialZonedDateTime<'_>> for temporal_rs::partial::PartialZon
         let calendar = temporal_rs::Calendar::new(other.date.calendar.into());
         Ok(Self {
             fields: other.try_into()?,
-            // These fields are only true when parsing
-            has_utc_designator: false,
-            match_minutes: false,
             timezone,
             calendar,
         })


### PR DESCRIPTION
This behavior was introduced in #420, but we now have separate parsed variants for everything (#486). These are no longer necessary; and the additional bits of data for dealing with matchMinutes, START-OF-DAY, and hasUTCDesignator are similarly extraneous.