### PR TITLE
Reduce (and lint-disallow) panics in main code

### DIFF
--- a/provider/src/lib.rs
+++ b/provider/src/lib.rs
@@ -5,6 +5,10 @@
 //!
 
 #![no_std]
+#![cfg_attr(
+    not(test),
+    warn(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)
+)]
 
 extern crate alloc;
 

--- a/provider/src/posix.rs
+++ b/provider/src/posix.rs
@@ -16,6 +16,7 @@ pub struct PosixZone {
 }
 
 #[cfg(feature = "datagen")]
+#[allow(clippy::unwrap_used, reason = "Datagen only")]
 impl From<&PosixTimeZone> for PosixZone {
     fn from(value: &PosixTimeZone) -> Self {
         let abbr = TinyAsciiStr::<5>::try_from_str(&value.abbr.formatted).unwrap();
@@ -48,6 +49,7 @@ pub struct ZeroPosixTransition {
 }
 
 #[cfg(feature = "datagen")]
+#[allow(clippy::unwrap_used, reason = "Datagen only")]
 impl From<&PosixTransition> for ZeroPosixTransition {
     fn from(value: &PosixTransition) -> Self {
         let abbr = TinyAsciiStr::<5>::try_from_str(&value.abbr.formatted).unwrap();

--- a/provider/src/tzdb.rs
+++ b/provider/src/tzdb.rs
@@ -114,6 +114,7 @@ pub enum IanaDataError {
 }
 
 #[cfg(feature = "datagen")]
+#[allow(clippy::expect_used, clippy::unwrap_used, reason = "Datagen only")]
 impl IanaIdentifierNormalizer<'_> {
     pub fn build(tzdata_path: &Path) -> Result<Self, IanaDataError> {
         let provider = TzdbDataSource::try_from_zoneinfo_directory(tzdata_path)

--- a/provider/src/tzif.rs
+++ b/provider/src/tzif.rs
@@ -109,6 +109,7 @@ pub enum ZoneInfoDataError {
 }
 
 #[cfg(feature = "datagen")]
+#[allow(clippy::expect_used, clippy::unwrap_used, reason = "Datagen only")]
 impl ZoneInfoProvider<'_> {
     pub fn build(tzdata: &Path) -> Result<Self, ZoneInfoDataError> {
         let tzdb_source = TzdbDataSource::try_from_rearguard_zoneinfo_dir(tzdata).unwrap();

--- a/src/builtins/compiled/zoneddatetime.rs
+++ b/src/builtins/compiled/zoneddatetime.rs
@@ -18,16 +18,17 @@ impl core::fmt::Display for ZonedDateTime {
     ///
     /// Enable with the `compiled_data` feature flag.
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str(
-            &self
-                .to_ixdtf_string(
-                    DisplayOffset::Auto,
-                    DisplayTimeZone::Auto,
-                    DisplayCalendar::Auto,
-                    ToStringRoundingOptions::default(),
-                )
-                .expect("A valid ZonedDateTime string with default options."),
-        )
+        let string = self.to_ixdtf_string(
+            DisplayOffset::Auto,
+            DisplayTimeZone::Auto,
+            DisplayCalendar::Auto,
+            ToStringRoundingOptions::default(),
+        );
+        debug_assert!(
+            string.is_ok(),
+            "A valid ZonedDateTime string with default options."
+        );
+        f.write_str(&string.map_err(|_| Default::default())?)
     }
 }
 

--- a/src/builtins/core/datetime.rs
+++ b/src/builtins/core/datetime.rs
@@ -183,10 +183,15 @@ pub struct PlainDateTime {
 
 impl core::fmt::Display for PlainDateTime {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let ixdtf_str = self
-            .to_ixdtf_string(ToStringRoundingOptions::default(), DisplayCalendar::Auto)
-            .expect("ixdtf default configuration should not fail.");
-        f.write_str(&ixdtf_str)
+        let string =
+            self.to_ixdtf_string(ToStringRoundingOptions::default(), DisplayCalendar::Auto);
+
+        debug_assert!(
+            string.is_ok(),
+            "Duration must return a valid string with default options."
+        );
+
+        f.write_str(&string.map_err(|_| Default::default())?)
     }
 }
 

--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -299,11 +299,13 @@ pub struct Duration {
 
 impl core::fmt::Display for Duration {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str(
-            &self
-                .as_temporal_string(ToStringRoundingOptions::default())
-                .expect("Duration must return a valid string with default options."),
-        )
+        let string = self.as_temporal_string(ToStringRoundingOptions::default());
+
+        debug_assert!(
+            string.is_ok(),
+            "Duration must return a valid string with default options."
+        );
+        f.write_str(&string.map_err(|_| Default::default())?)
     }
 }
 

--- a/src/builtins/core/duration/normalized.rs
+++ b/src/builtins/core/duration/normalized.rs
@@ -14,7 +14,7 @@ use crate::{
     primitive::FiniteF64,
     provider::TimeZoneProvider,
     rounding::IncrementRounder,
-    Calendar, TemporalError, TemporalResult, TemporalUnwrap, NS_PER_DAY,
+    Calendar, TemporalError, TemporalResult, TemporalUnwrap, NS_PER_DAY, NS_PER_DAY_NONZERO,
 };
 
 use super::{DateDuration, Duration, Sign, TimeDuration};
@@ -157,7 +157,7 @@ impl NormalizedTimeDuration {
     ) -> TemporalResult<i64> {
         let adjusted_increment = increment
             .as_extended_increment()
-            .saturating_mul(NonZeroU128::new(NS_PER_DAY as u128).expect("cannot fail"));
+            .saturating_mul(NS_PER_DAY_NONZERO);
         let rounded =
             IncrementRounder::<i128>::from_signed_num(self.0, adjusted_increment)?.round(mode);
         Ok((rounded / NS_PER_DAY_128BIT) as i64)

--- a/src/builtins/core/duration/normalized.rs
+++ b/src/builtins/core/duration/normalized.rs
@@ -831,11 +831,10 @@ impl NormalizedDurationRecord {
         // 5. Let done be false.
         // 6. Repeat, while unitIndex ≥ largestUnitIndex and done is false,
         //     a. Let unit be the value in the "Value" column of Table 21 in the row whose ordinal index is unitIndex.
-        for unit in UNIT_VALUE_TABLE[largest_unit_index..smallest_unit_index]
-            .iter()
-            .rev()
-            .copied()
-        {
+        let unit_values = UNIT_VALUE_TABLE
+            .get(largest_unit_index..smallest_unit_index)
+            .temporal_unwrap()?;
+        for unit in unit_values.iter().rev().copied() {
             // b. If unit is not week, or largestUnit is week, then
             if unit != Unit::Week || largest_unit == Unit::Week {
                 let end_duration = match unit {

--- a/src/builtins/core/zoneddatetime.rs
+++ b/src/builtins/core/zoneddatetime.rs
@@ -1461,11 +1461,9 @@ pub(crate) fn interpret_isodatetime_offset(
                 // c. If matchBehaviour is match-minutes, then
                 if match_minutes {
                     // i. Let roundedCandidateNanoseconds be RoundNumberToIncrement(candidateOffset, 60 × 10**9, half-expand).
-                    let rounded_candidate = IncrementRounder::from_signed_num(
-                        candidate_offset,
-                        NonZeroU128::new(60_000_000_000).expect("cannot be zero"), // TODO: Add back const { } after MSRV can be bumped
-                    )?
-                    .round(RoundingMode::HalfExpand);
+                    let rounded_candidate =
+                        IncrementRounder::from_signed_num(candidate_offset, NS_PER_MINUTE_NONZERO)?
+                            .round(RoundingMode::HalfExpand);
                     // ii. If roundedCandidateNanoseconds = offsetNanoseconds, then
                     if rounded_candidate == offset.into() {
                         // 1. Return candidate.

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -537,7 +537,9 @@ impl IsoDate {
 impl IsoDate {
     /// Creates `[[ISOYear]]`, `[[isoMonth]]`, `[[isoDay]]` fields from `ICU4X`'s `Date<Iso>` struct.
     pub(crate) fn to_icu4x(self) -> IcuDate<Iso> {
-        IcuDate::try_new_iso(self.year, self.month, self.day).expect("must not fail.")
+        let d = IcuDate::try_new_iso(self.year, self.month, self.day);
+        debug_assert!(d.is_ok(), "ICU4X ISODate conversion must not fail");
+        d.unwrap_or_else(|_| IcuDate::from_rata_die(icu_calendar::types::RataDie::new(0), Iso))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
 // We wish to reduce the number of panics, .expect() must be justified
 // to never occur. Opt to have GIGO or .temporal_unwrap() behavior where possible.
-#![cfg_attr(not(test), warn(clippy::expect_used))]
+#![cfg_attr(not(test), warn(clippy::expect_used, clippy::indexing_slicing))]
 #![allow(
     // Currently throws a false positive regarding dependencies that are only used in benchmarks.
     unused_crate_dependencies,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,9 @@
 )]
 #![no_std]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
+// We wish to reduce the number of panics, .expect() must be justified
+// to never occur. Opt to have GIGO or .temporal_unwrap() behavior where possible.
+#![cfg_attr(not(test), warn(clippy::expect_used))]
 #![allow(
     // Currently throws a false positive regarding dependencies that are only used in benchmarks.
     unused_crate_dependencies,
@@ -220,6 +223,15 @@ impl<T> TemporalUnwrap for Option<T> {
     }
 }
 
+impl<T> TemporalUnwrap for TemporalResult<T> {
+    type Output = T;
+
+    fn temporal_unwrap(self) -> Self {
+        debug_assert!(self.is_ok(), "Assertion failed: {:?}", self.err());
+        self.map_err(|e| TemporalError::assert().with_message(e.into_message()))
+    }
+}
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! temporal_assert {
@@ -276,6 +288,12 @@ impl Sign {
 // Relevant numeric constants
 /// Nanoseconds per day constant: 8.64e+13
 pub const NS_PER_DAY: u64 = MS_PER_DAY as u64 * 1_000_000;
+pub const NS_PER_DAY_NONZERO: core::num::NonZeroU128 =
+    if let Some(nz) = core::num::NonZeroU128::new(NS_PER_DAY as u128) {
+        nz
+    } else {
+        unreachable!()
+    };
 /// Milliseconds per day constant: 8.64e+7
 pub const MS_PER_DAY: u32 = 24 * 60 * 60 * 1000;
 /// Max Instant nanosecond constant

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,6 +4,7 @@
 //! operation may be completed.
 
 use crate::parsers::Precision;
+use crate::TemporalUnwrap;
 use crate::{error::ErrorMessage, TemporalError, TemporalResult, MS_PER_DAY, NS_PER_DAY};
 use core::num::NonZeroU128;
 use core::ops::Add;
@@ -91,7 +92,7 @@ impl ToStringRoundingOptions {
                         smallest_unit: Unit::Millisecond,
                         rounding_mode,
                         increment: RoundingIncrement::try_new(10_u32.pow(3 - d as u32))
-                            .expect("a valid increment"),
+                            .temporal_unwrap()?,
                     })
                 }
                 Precision::Digit(d) if (4..=6).contains(&d) => {
@@ -100,7 +101,7 @@ impl ToStringRoundingOptions {
                         smallest_unit: Unit::Microsecond,
                         rounding_mode,
                         increment: RoundingIncrement::try_new(10_u32.pow(6 - d as u32))
-                            .expect("a valid increment"),
+                            .temporal_unwrap()?,
                     })
                 }
                 Precision::Digit(d) if (7..=9).contains(&d) => {
@@ -109,7 +110,7 @@ impl ToStringRoundingOptions {
                         smallest_unit: Unit::Nanosecond,
                         rounding_mode,
                         increment: RoundingIncrement::try_new(10_u32.pow(9 - d as u32))
-                            .expect("a valid increment"),
+                            .temporal_unwrap()?,
                     })
                 }
                 _ => Err(TemporalError::range()

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -213,15 +213,14 @@ fn write_nanosecond<W: core::fmt::Write + ?Sized>(
 pub fn u32_to_digits(mut value: u32) -> ([u8; 9], usize) {
     let mut output = [0; 9];
     let mut precision = 0;
-    let mut i = 9;
-    while i != 0 {
+    for (i, out) in output.iter_mut().enumerate().rev() {
         let v = (value % 10) as u8;
         value /= 10;
         if precision == 0 && v != 0 {
-            precision = i;
+            // i is 0-indexed, but we want a 1-indexed precision
+            precision = i + 1;
         }
-        output[i - 1] = v;
-        i -= 1;
+        *out = v;
     }
 
     (output, precision)

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -67,8 +67,9 @@ impl<T: Roundable> IncrementRounder<T> {
             rounded = rounded.neg();
         }
         // TODO: Add unit tests for the below
-        rounded
-            * <i128 as NumCast>::from(self.divisor).expect("increment is representable by a u64")
+        let divisor = <i128 as NumCast>::from(self.divisor);
+        debug_assert!(divisor.is_some(), "increment is representable by a u64");
+        rounded.saturating_mul(divisor.unwrap_or_default())
     }
     #[inline]
     /// https://tc39.es/proposal-temporal/#sec-temporal-roundnumbertoincrementasifpositive
@@ -81,8 +82,9 @@ impl<T: Roundable> IncrementRounder<T> {
             apply_unsigned_rounding_mode(self.dividend, self.divisor, unsigned_rounding_mode);
 
         // TODO: Add unit tests for the below
-        rounded
-            * <i128 as NumCast>::from(self.divisor).expect("increment is representable by a u64")
+        let divisor = <i128 as NumCast>::from(self.divisor);
+        debug_assert!(divisor.is_some(), "increment is representable by a u64");
+        rounded.saturating_mul(divisor.unwrap_or_default())
     }
 }
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -34,6 +34,7 @@ impl Temporal {
     ///
     /// For the non-panicking version of this API, see [`Self::try_now`].
     pub fn now() -> Now {
+        #[allow(clippy::expect_used, reason = "We are okay with panics in the sys API")]
         Self::try_now().expect("failed to retrieve and validate system values.")
     }
 

--- a/temporal_capi/src/lib.rs
+++ b/temporal_capi/src/lib.rs
@@ -14,6 +14,10 @@
 //! [`temporal_rs`]: http://crates.io/crates/temporal_rs
 
 #![no_std]
+#![cfg_attr(
+    not(test),
+    forbid(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)
+)]
 
 extern crate alloc;
 


### PR DESCRIPTION
Aside from datagen/sys code, this stops `temporal_rs` from panicking when unexpected things occur. In general a JS engine should not panic; it should throw an error or have GIGO behavior.

ICU4X follows a similar policy.

It would be nice to make sure none of the arithmetic can panic as well; though at least in release builds it'll wrap or do other GIGO, which seems fine.