### PR TITLE
Check that year values are in safe arithmetical range

### DIFF
--- a/src/builtins/core/calendar/types.rs
+++ b/src/builtins/core/calendar/types.rs
@@ -37,6 +37,7 @@ impl ResolvedCalendarFields {
         overflow: ArithmeticOverflow,
         resolve_type: ResolutionType,
     ) -> TemporalResult<Self> {
+        fields.check_year_in_safe_arithmetical_range()?;
         let era_year = EraYear::try_from_fields(calendar, fields, resolve_type)?;
         if calendar.is_iso() {
             let month_code = resolve_iso_month(calendar, fields, overflow)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -172,6 +172,7 @@ pub(crate) enum ErrorMessage {
     IntermediateDateTimeOutOfRange,
     ZDTOutOfDayBounds,
     LargestUnitCannotBeDateUnit,
+    DateOutOfRange,
 
     // Numerical errors
     NumberNotFinite,
@@ -214,6 +215,7 @@ impl ErrorMessage {
             }
             Self::ZDTOutOfDayBounds => "ZonedDateTime is outside the expected day bounds",
             Self::LargestUnitCannotBeDateUnit => "Largest unit cannot be a date unit",
+            Self::DateOutOfRange => "Date is not within ISO date time limits.",
             Self::NumberNotFinite => "number value is not a finite value.",
             Self::NumberNotIntegral => "value must be integral.",
             Self::NumberNotPositive => "integer must be positive.",

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -305,9 +305,7 @@ impl IsoDate {
     ) -> TemporalResult<Self> {
         let date = Self::regulate(year, month, day, overflow)?;
         if !iso_dt_within_valid_limits(date, &IsoTime::noon()) {
-            return Err(
-                TemporalError::range().with_message("Date is not within ISO date time limits.")
-            );
+            return Err(TemporalError::range().with_enum(ErrorMessage::DateOutOfRange));
         }
         Ok(date)
     }


### PR DESCRIPTION
This won't fix all the issues around this (calendar-internal invariants still fail within the valid Temporal range) but it should reduce failures.