### PR TITLE
Remove yoke dep from temporal_capi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,6 @@ dependencies = [
  "temporal_rs",
  "timezone_provider",
  "writeable",
- "yoke",
  "zoneinfo64",
 ]
 

--- a/temporal_capi/Cargo.toml
+++ b/temporal_capi/Cargo.toml
@@ -26,12 +26,11 @@ timezone_provider = { workspace = true, default-features = false }
 icu_calendar = { version = "2.0.2", default-features = false }
 icu_locale = { version = "2.0.0" }
 writeable = "0.6.1"
-yoke = { version = "0.8.0", optional = true }
 zoneinfo64 = { workspace = true, optional = true }
 
 [features]
 compiled_data = ["temporal_rs/compiled_data"]
-zoneinfo64 = ["dep:zoneinfo64", "timezone_provider/zoneinfo64", "yoke"]
+zoneinfo64 = ["dep:zoneinfo64", "timezone_provider/zoneinfo64"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Yoke is already a transitive dep so this doesn't need a release.