### PR TITLE
Updates to PlainTime API based on review

### DIFF
--- a/src/builtins/core/mod.rs
+++ b/src/builtins/core/mod.rs
@@ -14,7 +14,7 @@ mod instant;
 mod month_day;
 mod plain_date;
 mod plain_date_time;
-mod time;
+mod plain_time;
 mod year_month;
 pub(crate) mod zoned_date_time;
 
@@ -34,7 +34,7 @@ pub use plain_date::{PartialDate, PlainDate};
 #[doc(inline)]
 pub use plain_date_time::{DateTimeFields, PartialDateTime, PlainDateTime};
 #[doc(inline)]
-pub use time::{PartialTime, PlainTime};
+pub use plain_time::{PartialTime, PlainTime};
 #[doc(inline)]
 pub use year_month::{PartialYearMonth, PlainYearMonth};
 #[doc(inline)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -177,6 +177,7 @@ pub(crate) enum ErrorMessage {
     FractionalDigitsPrecisionInvalid,
 
     // Options validity
+    SmallestUnitIsRequired,
     SmallestUnitNotTimeUnit,
     SmallestUnitLargerThanLargestUnit,
     UnitNotDate,
@@ -222,6 +223,7 @@ impl ErrorMessage {
             Self::NumberNotPositive => "integer must be positive.",
             Self::NumberOutOfRange => "number exceeded a valid range.",
             Self::FractionalDigitsPrecisionInvalid => "Invalid fractionalDigits precision value",
+            Self::SmallestUnitIsRequired => "smallestUnit is required",
             Self::SmallestUnitNotTimeUnit => "smallestUnit must be a valid time unit.",
             Self::SmallestUnitLargerThanLargestUnit => {
                 "smallestUnit was larger than largestunit in DifferenceeSettings"

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -845,23 +845,6 @@ impl IsoTime {
         }
     }
 
-    /// Checks if the time is a valid `IsoTime`
-    pub(crate) fn is_valid(&self) -> bool {
-        if !(0..=23).contains(&self.hour) {
-            return false;
-        }
-
-        let min_sec = 0..=59;
-        if !min_sec.contains(&self.minute) || !min_sec.contains(&self.second) {
-            return false;
-        }
-
-        let sub_second = 0..=999;
-        sub_second.contains(&self.millisecond)
-            && sub_second.contains(&self.microsecond)
-            && sub_second.contains(&self.nanosecond)
-    }
-
     pub(crate) fn add(&self, norm: TimeDuration) -> (i64, Self) {
         // 1. Set second to second + TimeDurationSeconds(norm).
         let seconds = i64::from(self.second) + norm.seconds();

--- a/temporal_capi/bindings/c/PlainTime.h
+++ b/temporal_capi/bindings/c/PlainTime.h
@@ -12,11 +12,10 @@
 #include "Duration.d.h"
 #include "PartialTime.d.h"
 #include "Provider.d.h"
-#include "RoundingMode.d.h"
+#include "RoundingOptions.d.h"
 #include "TemporalError.d.h"
 #include "TimeZone.d.h"
 #include "ToStringRoundingOptions.d.h"
-#include "Unit.d.h"
 
 #include "PlainTime.d.h"
 
@@ -78,7 +77,7 @@ bool temporal_rs_PlainTime_equals(const PlainTime* self, const PlainTime* other)
 int8_t temporal_rs_PlainTime_compare(const PlainTime* one, const PlainTime* two);
 
 typedef struct temporal_rs_PlainTime_round_result {union {PlainTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_round_result;
-temporal_rs_PlainTime_round_result temporal_rs_PlainTime_round(const PlainTime* self, Unit smallest_unit, OptionF64 rounding_increment, RoundingMode_option rounding_mode);
+temporal_rs_PlainTime_round_result temporal_rs_PlainTime_round(const PlainTime* self, RoundingOptions options);
 
 typedef struct temporal_rs_PlainTime_to_ixdtf_string_result {union { TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_to_ixdtf_string_result;
 temporal_rs_PlainTime_to_ixdtf_string_result temporal_rs_PlainTime_to_ixdtf_string(const PlainTime* self, ToStringRoundingOptions options, DiplomatWrite* write);

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainTime.d.hpp
@@ -22,11 +22,10 @@ namespace capi { struct TimeZone; }
 class TimeZone;
 struct DifferenceSettings;
 struct PartialTime;
+struct RoundingOptions;
 struct TemporalError;
 struct ToStringRoundingOptions;
 class ArithmeticOverflow;
-class RoundingMode;
-class Unit;
 }
 
 
@@ -80,7 +79,7 @@ public:
 
   inline static int8_t compare(const temporal_rs::PlainTime& one, const temporal_rs::PlainTime& two);
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> round(temporal_rs::Unit smallest_unit, std::optional<double> rounding_increment, std::optional<temporal_rs::RoundingMode> rounding_mode) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> round(temporal_rs::RoundingOptions options) const;
 
   inline diplomat::result<std::string, temporal_rs::TemporalError> to_ixdtf_string(temporal_rs::ToStringRoundingOptions options) const;
   template<typename W>

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainTime.hpp
@@ -17,11 +17,10 @@
 #include "Duration.hpp"
 #include "PartialTime.hpp"
 #include "Provider.hpp"
-#include "RoundingMode.hpp"
+#include "RoundingOptions.hpp"
 #include "TemporalError.hpp"
 #include "TimeZone.hpp"
 #include "ToStringRoundingOptions.hpp"
-#include "Unit.hpp"
 
 
 namespace temporal_rs {
@@ -81,7 +80,7 @@ namespace capi {
     int8_t temporal_rs_PlainTime_compare(const temporal_rs::capi::PlainTime* one, const temporal_rs::capi::PlainTime* two);
 
     typedef struct temporal_rs_PlainTime_round_result {union {temporal_rs::capi::PlainTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_round_result;
-    temporal_rs_PlainTime_round_result temporal_rs_PlainTime_round(const temporal_rs::capi::PlainTime* self, temporal_rs::capi::Unit smallest_unit, diplomat::capi::OptionF64 rounding_increment, temporal_rs::capi::RoundingMode_option rounding_mode);
+    temporal_rs_PlainTime_round_result temporal_rs_PlainTime_round(const temporal_rs::capi::PlainTime* self, temporal_rs::capi::RoundingOptions options);
 
     typedef struct temporal_rs_PlainTime_to_ixdtf_string_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_to_ixdtf_string_result;
     temporal_rs_PlainTime_to_ixdtf_string_result temporal_rs_PlainTime_to_ixdtf_string(const temporal_rs::capi::PlainTime* self, temporal_rs::capi::ToStringRoundingOptions options, diplomat::capi::DiplomatWrite* write);
@@ -218,11 +217,9 @@ inline int8_t temporal_rs::PlainTime::compare(const temporal_rs::PlainTime& one,
   return result;
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> temporal_rs::PlainTime::round(temporal_rs::Unit smallest_unit, std::optional<double> rounding_increment, std::optional<temporal_rs::RoundingMode> rounding_mode) const {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> temporal_rs::PlainTime::round(temporal_rs::RoundingOptions options) const {
   auto result = temporal_rs::capi::temporal_rs_PlainTime_round(this->AsFFI(),
-    smallest_unit.AsFFI(),
-    rounding_increment.has_value() ? (diplomat::capi::OptionF64{ { rounding_increment.value() }, true }) : (diplomat::capi::OptionF64{ {}, false }),
-    rounding_mode.has_value() ? (temporal_rs::capi::RoundingMode_option{ { rounding_mode.value().AsFFI() }, true }) : (temporal_rs::capi::RoundingMode_option{ {}, false }));
+    options.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainTime>>(std::unique_ptr<temporal_rs::PlainTime>(temporal_rs::PlainTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 

--- a/temporal_capi/src/plain_time.rs
+++ b/temporal_capi/src/plain_time.rs
@@ -7,7 +7,7 @@ pub mod ffi {
     use crate::duration::ffi::Duration;
     use crate::error::ffi::TemporalError;
     use crate::options::ffi::{
-        ArithmeticOverflow, DifferenceSettings, RoundingMode, ToStringRoundingOptions, Unit,
+        ArithmeticOverflow, DifferenceSettings, RoundingOptions, ToStringRoundingOptions,
     };
     use crate::provider::ffi::Provider;
     use alloc::string::String;
@@ -185,18 +185,9 @@ pub mod ffi {
 
             tuple1.cmp(&tuple2)
         }
-        pub fn round(
-            &self,
-            smallest_unit: Unit,
-            rounding_increment: Option<f64>,
-            rounding_mode: Option<RoundingMode>,
-        ) -> Result<Box<Self>, TemporalError> {
+        pub fn round(&self, options: RoundingOptions) -> Result<Box<Self>, TemporalError> {
             self.0
-                .round(
-                    smallest_unit.into(),
-                    rounding_increment,
-                    rounding_mode.map(Into::into),
-                )
+                .round(options.try_into()?)
                 .map(|x| Box::new(Self(x)))
                 .map_err(Into::into)
         }


### PR DESCRIPTION
This PR reviews the API for PlainTime.

In general a variety of changes were made.

- rename module from time.rs to plain_time.rs
- Update the round method to use RoundingOptions over individual options.
- Adds a new variant to ErrorMessage enum

It's worth noting the update was also made to temporal_capi.