### PR TITLE
Make ISO getters crate private

### DIFF
--- a/src/builtins/core/month_day.rs
+++ b/src/builtins/core/month_day.rs
@@ -177,6 +177,22 @@ impl PlainMonthDay {
         Self { iso, calendar }
     }
 
+    /// Returns the ISO month value of `PlainMonthDay`.
+    #[inline]
+    #[must_use]
+    pub(crate) fn iso_month(&self) -> u8 {
+        self.iso.month
+    }
+
+    /// Returns the ISO year value of `PlainMonthDay`.
+    #[inline]
+    #[must_use]
+    pub(crate) fn iso_year(&self) -> i32 {
+        self.iso.year
+    }
+}
+
+impl PlainMonthDay {
     /// Creates a new valid `PlainMonthDay`.
     #[inline]
     pub fn new_with_overflow(
@@ -270,27 +286,6 @@ impl PlainMonthDay {
         // 11. Return ! CreateTemporalMonthDay(isoDate, calendar).
         self.calendar
             .month_day_from_fields(merged, overflow.unwrap_or(Overflow::Constrain))
-    }
-
-    /// Returns the ISO day value of `PlainMonthDay`.
-    #[inline]
-    #[must_use]
-    pub fn iso_day(&self) -> u8 {
-        self.iso.day
-    }
-
-    // Returns the ISO month value of `PlainMonthDay`.
-    #[inline]
-    #[must_use]
-    pub fn iso_month(&self) -> u8 {
-        self.iso.month
-    }
-
-    // Returns the ISO year value of `PlainMonthDay`.
-    #[inline]
-    #[must_use]
-    pub fn iso_year(&self) -> i32 {
-        self.iso.year
     }
 
     /// Returns the string identifier for the current `Calendar`.

--- a/src/builtins/core/plain_date.rs
+++ b/src/builtins/core/plain_date.rs
@@ -310,6 +310,27 @@ impl PlainDate {
     fn days_until(&self, other: &Self) -> i32 {
         other.iso.to_epoch_days() - self.iso.to_epoch_days()
     }
+
+    /// Returns this `PlainDate`'s ISO year value.
+    #[inline]
+    #[must_use]
+    pub(crate) const fn iso_year(&self) -> i32 {
+        self.iso.year
+    }
+
+    /// Returns this `PlainDate`'s ISO month value.
+    #[inline]
+    #[must_use]
+    pub(crate) const fn iso_month(&self) -> u8 {
+        self.iso.month
+    }
+
+    /// Returns this `PlainDate`'s ISO day value.
+    #[inline]
+    #[must_use]
+    pub(crate) const fn iso_day(&self) -> u8 {
+        self.iso.day
+    }
 }
 
 // ==== Public API ====
@@ -430,27 +451,6 @@ impl PlainDate {
     /// Creates a new `PlainDate` from the current `PlainDate` and the provided calendar.
     pub fn with_calendar(&self, calendar: Calendar) -> Self {
         Self::new_unchecked(self.iso, calendar)
-    }
-
-    #[inline]
-    #[must_use]
-    /// Returns this `PlainDate`'s ISO year value.
-    pub const fn iso_year(&self) -> i32 {
-        self.iso.year
-    }
-
-    #[inline]
-    #[must_use]
-    /// Returns this `PlainDate`'s ISO month value.
-    pub const fn iso_month(&self) -> u8 {
-        self.iso.month
-    }
-
-    #[inline]
-    #[must_use]
-    /// Returns this `PlainDate`'s ISO day value.
-    pub const fn iso_day(&self) -> u8 {
-        self.iso.day
     }
 
     #[inline]

--- a/src/builtins/core/plain_date_time.rs
+++ b/src/builtins/core/plain_date_time.rs
@@ -345,6 +345,27 @@ impl PlainDateTime {
             unit,
         )
     }
+
+    /// Returns this `PlainDateTime`'s ISO year value.
+    #[inline]
+    #[must_use]
+    pub const fn iso_year(&self) -> i32 {
+        self.iso.date.year
+    }
+
+    /// Returns this `PlainDateTime`'s ISO month value.
+    #[inline]
+    #[must_use]
+    pub const fn iso_month(&self) -> u8 {
+        self.iso.date.month
+    }
+
+    /// Returns this `PlainDateTime`'s ISO day value.
+    #[inline]
+    #[must_use]
+    pub const fn iso_day(&self) -> u8 {
+        self.iso.date.day
+    }
 }
 
 // ==== Public PlainDateTime API ====
@@ -662,27 +683,6 @@ impl PlainDateTime {
     #[inline]
     pub fn with_calendar(&self, calendar: Calendar) -> Self {
         Self::new_unchecked(self.iso, calendar)
-    }
-
-    /// Returns this `PlainDateTime`'s ISO year value.
-    #[inline]
-    #[must_use]
-    pub const fn iso_year(&self) -> i32 {
-        self.iso.date.year
-    }
-
-    /// Returns this `PlainDateTime`'s ISO month value.
-    #[inline]
-    #[must_use]
-    pub const fn iso_month(&self) -> u8 {
-        self.iso.date.month
-    }
-
-    /// Returns this `PlainDateTime`'s ISO day value.
-    #[inline]
-    #[must_use]
-    pub const fn iso_day(&self) -> u8 {
-        self.iso.date.day
     }
 
     /// Returns the hour value

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -347,6 +347,20 @@ impl PlainYearMonth {
             DifferenceOperation::Until => Ok(result),
         }
     }
+
+    /// Returns the iso month value for this `YearMonth`.
+    #[inline]
+    #[must_use]
+    pub(crate) fn iso_month(&self) -> u8 {
+        self.iso.month
+    }
+
+    /// Returns the iso year value for this `YearMonth`.
+    #[inline]
+    #[must_use]
+    pub(crate) fn iso_year(&self) -> i32 {
+        self.iso.year
+    }
 }
 
 // ==== Public method implementations ====
@@ -448,32 +462,11 @@ impl PlainYearMonth {
             .year_month_from_fields(fields, Overflow::Constrain)
     }
 
-    /// Returns the iso year value for this `YearMonth`.
-    #[inline]
-    #[must_use]
-    pub fn iso_year(&self) -> i32 {
-        self.iso.year
-    }
-
     /// Returns the padded ISO year string
     #[inline]
     #[must_use]
     pub fn padded_iso_year_string(&self) -> String {
         pad_iso_year(self.iso.year)
-    }
-
-    /// Returns the iso month value for this `YearMonth`.
-    #[inline]
-    #[must_use]
-    pub fn iso_month(&self) -> u8 {
-        self.iso.month
-    }
-
-    /// Returns the internal ISO day for this `YearMonth`.
-    #[inline]
-    #[must_use]
-    pub fn iso_reference_day(&self) -> u8 {
-        self.iso.day
     }
 
     /// Returns the calendar era of the current `PlainYearMonth`

--- a/temporal_capi/bindings/c/PlainDate.h
+++ b/temporal_capi/bindings/c/PlainDate.h
@@ -63,12 +63,6 @@ temporal_rs_PlainDate_from_utf8_result temporal_rs_PlainDate_from_utf8(DiplomatS
 typedef struct temporal_rs_PlainDate_from_utf16_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_utf16_result;
 temporal_rs_PlainDate_from_utf16_result temporal_rs_PlainDate_from_utf16(DiplomatString16View s);
 
-int32_t temporal_rs_PlainDate_iso_year(const PlainDate* self);
-
-uint8_t temporal_rs_PlainDate_iso_month(const PlainDate* self);
-
-uint8_t temporal_rs_PlainDate_iso_day(const PlainDate* self);
-
 const Calendar* temporal_rs_PlainDate_calendar(const PlainDate* self);
 
 bool temporal_rs_PlainDate_is_valid(const PlainDate* self);

--- a/temporal_capi/bindings/c/PlainDateTime.h
+++ b/temporal_capi/bindings/c/PlainDateTime.h
@@ -64,12 +64,6 @@ temporal_rs_PlainDateTime_from_utf8_result temporal_rs_PlainDateTime_from_utf8(D
 typedef struct temporal_rs_PlainDateTime_from_utf16_result {union {PlainDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_utf16_result;
 temporal_rs_PlainDateTime_from_utf16_result temporal_rs_PlainDateTime_from_utf16(DiplomatString16View s);
 
-int32_t temporal_rs_PlainDateTime_iso_year(const PlainDateTime* self);
-
-uint8_t temporal_rs_PlainDateTime_iso_month(const PlainDateTime* self);
-
-uint8_t temporal_rs_PlainDateTime_iso_day(const PlainDateTime* self);
-
 uint8_t temporal_rs_PlainDateTime_hour(const PlainDateTime* self);
 
 uint8_t temporal_rs_PlainDateTime_minute(const PlainDateTime* self);

--- a/temporal_capi/bindings/c/PlainMonthDay.h
+++ b/temporal_capi/bindings/c/PlainMonthDay.h
@@ -39,19 +39,11 @@ temporal_rs_PlainMonthDay_with_result temporal_rs_PlainMonthDay_with(const Plain
 
 bool temporal_rs_PlainMonthDay_equals(const PlainMonthDay* self, const PlainMonthDay* other);
 
-int8_t temporal_rs_PlainMonthDay_compare(const PlainMonthDay* one, const PlainMonthDay* two);
-
 typedef struct temporal_rs_PlainMonthDay_from_utf8_result {union {PlainMonthDay* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_from_utf8_result;
 temporal_rs_PlainMonthDay_from_utf8_result temporal_rs_PlainMonthDay_from_utf8(DiplomatStringView s);
 
 typedef struct temporal_rs_PlainMonthDay_from_utf16_result {union {PlainMonthDay* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_from_utf16_result;
 temporal_rs_PlainMonthDay_from_utf16_result temporal_rs_PlainMonthDay_from_utf16(DiplomatString16View s);
-
-int32_t temporal_rs_PlainMonthDay_iso_year(const PlainMonthDay* self);
-
-uint8_t temporal_rs_PlainMonthDay_iso_month(const PlainMonthDay* self);
-
-uint8_t temporal_rs_PlainMonthDay_iso_day(const PlainMonthDay* self);
 
 uint8_t temporal_rs_PlainMonthDay_day(const PlainMonthDay* self);
 

--- a/temporal_capi/bindings/c/PlainYearMonth.h
+++ b/temporal_capi/bindings/c/PlainYearMonth.h
@@ -45,13 +45,7 @@ temporal_rs_PlainYearMonth_from_utf8_result temporal_rs_PlainYearMonth_from_utf8
 typedef struct temporal_rs_PlainYearMonth_from_utf16_result {union {PlainYearMonth* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_from_utf16_result;
 temporal_rs_PlainYearMonth_from_utf16_result temporal_rs_PlainYearMonth_from_utf16(DiplomatString16View s);
 
-int32_t temporal_rs_PlainYearMonth_iso_year(const PlainYearMonth* self);
-
 void temporal_rs_PlainYearMonth_padded_iso_year_string(const PlainYearMonth* self, DiplomatWrite* write);
-
-uint8_t temporal_rs_PlainYearMonth_iso_month(const PlainYearMonth* self);
-
-uint8_t temporal_rs_PlainYearMonth_iso_day(const PlainYearMonth* self);
 
 int32_t temporal_rs_PlainYearMonth_year(const PlainYearMonth* self);
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
@@ -75,12 +75,6 @@ public:
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_utf16(std::u16string_view s);
 
-  inline int32_t iso_year() const;
-
-  inline uint8_t iso_month() const;
-
-  inline uint8_t iso_day() const;
-
   inline const temporal_rs::Calendar& calendar() const;
 
   inline bool is_valid() const;

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
@@ -66,12 +66,6 @@ namespace capi {
     typedef struct temporal_rs_PlainDate_from_utf16_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_utf16_result;
     temporal_rs_PlainDate_from_utf16_result temporal_rs_PlainDate_from_utf16(diplomat::capi::DiplomatString16View s);
 
-    int32_t temporal_rs_PlainDate_iso_year(const temporal_rs::capi::PlainDate* self);
-
-    uint8_t temporal_rs_PlainDate_iso_month(const temporal_rs::capi::PlainDate* self);
-
-    uint8_t temporal_rs_PlainDate_iso_day(const temporal_rs::capi::PlainDate* self);
-
     const temporal_rs::capi::Calendar* temporal_rs_PlainDate_calendar(const temporal_rs::capi::PlainDate* self);
 
     bool temporal_rs_PlainDate_is_valid(const temporal_rs::capi::PlainDate* self);
@@ -220,21 +214,6 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::Te
 inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::from_utf16(std::u16string_view s) {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_from_utf16({s.data(), s.size()});
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
-}
-
-inline int32_t temporal_rs::PlainDate::iso_year() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainDate_iso_year(this->AsFFI());
-  return result;
-}
-
-inline uint8_t temporal_rs::PlainDate::iso_month() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainDate_iso_month(this->AsFFI());
-  return result;
-}
-
-inline uint8_t temporal_rs::PlainDate::iso_day() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainDate_iso_day(this->AsFFI());
-  return result;
 }
 
 inline const temporal_rs::Calendar& temporal_rs::PlainDate::calendar() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
@@ -74,12 +74,6 @@ public:
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> from_utf16(std::u16string_view s);
 
-  inline int32_t iso_year() const;
-
-  inline uint8_t iso_month() const;
-
-  inline uint8_t iso_day() const;
-
   inline uint8_t hour() const;
 
   inline uint8_t minute() const;

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
@@ -67,12 +67,6 @@ namespace capi {
     typedef struct temporal_rs_PlainDateTime_from_utf16_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_utf16_result;
     temporal_rs_PlainDateTime_from_utf16_result temporal_rs_PlainDateTime_from_utf16(diplomat::capi::DiplomatString16View s);
 
-    int32_t temporal_rs_PlainDateTime_iso_year(const temporal_rs::capi::PlainDateTime* self);
-
-    uint8_t temporal_rs_PlainDateTime_iso_month(const temporal_rs::capi::PlainDateTime* self);
-
-    uint8_t temporal_rs_PlainDateTime_iso_day(const temporal_rs::capi::PlainDateTime* self);
-
     uint8_t temporal_rs_PlainDateTime_hour(const temporal_rs::capi::PlainDateTime* self);
 
     uint8_t temporal_rs_PlainDateTime_minute(const temporal_rs::capi::PlainDateTime* self);
@@ -239,21 +233,6 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs
 inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::from_utf16(std::u16string_view s) {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_from_utf16({s.data(), s.size()});
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDateTime>>(std::unique_ptr<temporal_rs::PlainDateTime>(temporal_rs::PlainDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
-}
-
-inline int32_t temporal_rs::PlainDateTime::iso_year() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainDateTime_iso_year(this->AsFFI());
-  return result;
-}
-
-inline uint8_t temporal_rs::PlainDateTime::iso_month() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainDateTime_iso_month(this->AsFFI());
-  return result;
-}
-
-inline uint8_t temporal_rs::PlainDateTime::iso_day() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainDateTime_iso_day(this->AsFFI());
-  return result;
 }
 
 inline uint8_t temporal_rs::PlainDateTime::hour() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
@@ -52,17 +52,9 @@ public:
 
   inline bool equals(const temporal_rs::PlainMonthDay& other) const;
 
-  inline static int8_t compare(const temporal_rs::PlainMonthDay& one, const temporal_rs::PlainMonthDay& two);
-
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> from_utf8(std::string_view s);
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> from_utf16(std::u16string_view s);
-
-  inline int32_t iso_year() const;
-
-  inline uint8_t iso_month() const;
-
-  inline uint8_t iso_day() const;
 
   inline uint8_t day() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
@@ -42,19 +42,11 @@ namespace capi {
 
     bool temporal_rs_PlainMonthDay_equals(const temporal_rs::capi::PlainMonthDay* self, const temporal_rs::capi::PlainMonthDay* other);
 
-    int8_t temporal_rs_PlainMonthDay_compare(const temporal_rs::capi::PlainMonthDay* one, const temporal_rs::capi::PlainMonthDay* two);
-
     typedef struct temporal_rs_PlainMonthDay_from_utf8_result {union {temporal_rs::capi::PlainMonthDay* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_from_utf8_result;
     temporal_rs_PlainMonthDay_from_utf8_result temporal_rs_PlainMonthDay_from_utf8(diplomat::capi::DiplomatStringView s);
 
     typedef struct temporal_rs_PlainMonthDay_from_utf16_result {union {temporal_rs::capi::PlainMonthDay* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_from_utf16_result;
     temporal_rs_PlainMonthDay_from_utf16_result temporal_rs_PlainMonthDay_from_utf16(diplomat::capi::DiplomatString16View s);
-
-    int32_t temporal_rs_PlainMonthDay_iso_year(const temporal_rs::capi::PlainMonthDay* self);
-
-    uint8_t temporal_rs_PlainMonthDay_iso_month(const temporal_rs::capi::PlainMonthDay* self);
-
-    uint8_t temporal_rs_PlainMonthDay_iso_day(const temporal_rs::capi::PlainMonthDay* self);
 
     uint8_t temporal_rs_PlainMonthDay_day(const temporal_rs::capi::PlainMonthDay* self);
 
@@ -114,12 +106,6 @@ inline bool temporal_rs::PlainMonthDay::equals(const temporal_rs::PlainMonthDay&
   return result;
 }
 
-inline int8_t temporal_rs::PlainMonthDay::compare(const temporal_rs::PlainMonthDay& one, const temporal_rs::PlainMonthDay& two) {
-  auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_compare(one.AsFFI(),
-    two.AsFFI());
-  return result;
-}
-
 inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> temporal_rs::PlainMonthDay::from_utf8(std::string_view s) {
   auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_from_utf8({s.data(), s.size()});
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainMonthDay>>(std::unique_ptr<temporal_rs::PlainMonthDay>(temporal_rs::PlainMonthDay::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
@@ -128,21 +114,6 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs
 inline diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError> temporal_rs::PlainMonthDay::from_utf16(std::u16string_view s) {
   auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_from_utf16({s.data(), s.size()});
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainMonthDay>>(std::unique_ptr<temporal_rs::PlainMonthDay>(temporal_rs::PlainMonthDay::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainMonthDay>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
-}
-
-inline int32_t temporal_rs::PlainMonthDay::iso_year() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_iso_year(this->AsFFI());
-  return result;
-}
-
-inline uint8_t temporal_rs::PlainMonthDay::iso_month() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_iso_month(this->AsFFI());
-  return result;
-}
-
-inline uint8_t temporal_rs::PlainMonthDay::iso_day() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_iso_day(this->AsFFI());
-  return result;
 }
 
 inline uint8_t temporal_rs::PlainMonthDay::day() const {

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.d.hpp
@@ -57,15 +57,9 @@ public:
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError> from_utf16(std::u16string_view s);
 
-  inline int32_t iso_year() const;
-
   inline std::string padded_iso_year_string() const;
   template<typename W>
   inline void padded_iso_year_string_write(W& writeable_output) const;
-
-  inline uint8_t iso_month() const;
-
-  inline uint8_t iso_day() const;
 
   inline int32_t year() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.hpp
@@ -48,13 +48,7 @@ namespace capi {
     typedef struct temporal_rs_PlainYearMonth_from_utf16_result {union {temporal_rs::capi::PlainYearMonth* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_from_utf16_result;
     temporal_rs_PlainYearMonth_from_utf16_result temporal_rs_PlainYearMonth_from_utf16(diplomat::capi::DiplomatString16View s);
 
-    int32_t temporal_rs_PlainYearMonth_iso_year(const temporal_rs::capi::PlainYearMonth* self);
-
     void temporal_rs_PlainYearMonth_padded_iso_year_string(const temporal_rs::capi::PlainYearMonth* self, diplomat::capi::DiplomatWrite* write);
-
-    uint8_t temporal_rs_PlainYearMonth_iso_month(const temporal_rs::capi::PlainYearMonth* self);
-
-    uint8_t temporal_rs_PlainYearMonth_iso_day(const temporal_rs::capi::PlainYearMonth* self);
 
     int32_t temporal_rs_PlainYearMonth_year(const temporal_rs::capi::PlainYearMonth* self);
 
@@ -149,11 +143,6 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_r
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainYearMonth>>(std::unique_ptr<temporal_rs::PlainYearMonth>(temporal_rs::PlainYearMonth::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline int32_t temporal_rs::PlainYearMonth::iso_year() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_iso_year(this->AsFFI());
-  return result;
-}
-
 inline std::string temporal_rs::PlainYearMonth::padded_iso_year_string() const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
@@ -166,16 +155,6 @@ inline void temporal_rs::PlainYearMonth::padded_iso_year_string_write(W& writeab
   diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
   temporal_rs::capi::temporal_rs_PlainYearMonth_padded_iso_year_string(this->AsFFI(),
     &write);
-}
-
-inline uint8_t temporal_rs::PlainYearMonth::iso_month() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_iso_month(this->AsFFI());
-  return result;
-}
-
-inline uint8_t temporal_rs::PlainYearMonth::iso_day() const {
-  auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_iso_day(this->AsFFI());
-  return result;
 }
 
 inline int32_t temporal_rs::PlainYearMonth::year() const {

--- a/temporal_capi/src/plain_date.rs
+++ b/temporal_capi/src/plain_date.rs
@@ -198,16 +198,6 @@ pub mod ffi {
                 .map_err(Into::into)
         }
 
-        pub fn iso_year(&self) -> i32 {
-            self.0.iso_year()
-        }
-        pub fn iso_month(&self) -> u8 {
-            self.0.iso_month()
-        }
-        pub fn iso_day(&self) -> u8 {
-            self.0.iso_day()
-        }
-
         pub fn calendar<'a>(&'a self) -> &'a Calendar {
             Calendar::transparent_convert(self.0.calendar())
         }
@@ -262,10 +252,7 @@ pub mod ffi {
         }
 
         pub fn compare(one: &Self, two: &Self) -> core::cmp::Ordering {
-            let tuple1 = (one.iso_year(), one.iso_month(), one.iso_day());
-            let tuple2 = (two.iso_year(), two.iso_month(), two.iso_day());
-
-            tuple1.cmp(&tuple2)
+            one.0.compare_iso(&two.0)
         }
         pub fn year(&self) -> i32 {
             self.0.year()

--- a/temporal_capi/src/plain_date_time.rs
+++ b/temporal_capi/src/plain_date_time.rs
@@ -178,16 +178,6 @@ pub mod ffi {
                 .map_err(Into::into)
         }
 
-        pub fn iso_year(&self) -> i32 {
-            self.0.iso_year()
-        }
-        pub fn iso_month(&self) -> u8 {
-            self.0.iso_month()
-        }
-        pub fn iso_day(&self) -> u8 {
-            self.0.iso_day()
-        }
-
         pub fn hour(&self) -> u8 {
             self.0.hour()
         }
@@ -311,30 +301,7 @@ pub mod ffi {
         }
 
         pub fn compare(one: &Self, two: &Self) -> core::cmp::Ordering {
-            let tuple1 = (
-                one.iso_year(),
-                one.iso_month(),
-                one.iso_day(),
-                one.hour(),
-                one.minute(),
-                one.second(),
-                one.millisecond(),
-                one.microsecond(),
-                one.nanosecond(),
-            );
-            let tuple2 = (
-                two.iso_year(),
-                two.iso_month(),
-                two.iso_day(),
-                two.hour(),
-                two.minute(),
-                two.second(),
-                two.millisecond(),
-                two.microsecond(),
-                two.nanosecond(),
-            );
-
-            tuple1.cmp(&tuple2)
+            one.0.compare_iso(&two.0)
         }
 
         pub fn round(&self, options: RoundingOptions) -> Result<Box<Self>, TemporalError> {

--- a/temporal_capi/src/plain_month_day.rs
+++ b/temporal_capi/src/plain_month_day.rs
@@ -70,10 +70,6 @@ pub mod ffi {
             self.0 == other.0
         }
 
-        pub fn compare(one: &Self, two: &Self) -> core::cmp::Ordering {
-            (one.iso_year(), one.iso_month()).cmp(&(two.iso_year(), two.iso_month()))
-        }
-
         pub fn from_utf8(s: &DiplomatStr) -> Result<Box<Self>, TemporalError> {
             temporal_rs::PlainMonthDay::from_utf8(s)
                 .map(|c| Box::new(Self(c)))
@@ -86,16 +82,6 @@ pub mod ffi {
             temporal_rs::PlainMonthDay::from_str(&s)
                 .map(|c| Box::new(Self(c)))
                 .map_err(Into::into)
-        }
-
-        pub fn iso_year(&self) -> i32 {
-            self.0.iso_year()
-        }
-        pub fn iso_month(&self) -> u8 {
-            self.0.iso_month()
-        }
-        pub fn iso_day(&self) -> u8 {
-            self.0.iso_day()
         }
 
         pub fn day(&self) -> u8 {

--- a/temporal_capi/src/plain_year_month.rs
+++ b/temporal_capi/src/plain_year_month.rs
@@ -83,23 +83,11 @@ pub mod ffi {
                 .map_err(Into::into)
         }
 
-        pub fn iso_year(&self) -> i32 {
-            self.0.iso_year()
-        }
-
         pub fn padded_iso_year_string(&self, write: &mut DiplomatWrite) {
             // TODO this double-allocates, an API returning a Writeable or impl Write would be better
             let string = self.0.padded_iso_year_string();
             // throw away the error, the write itself should always succeed
             let _ = write.write_str(&string);
-        }
-
-        pub fn iso_month(&self) -> u8 {
-            self.0.iso_month()
-        }
-
-        pub fn iso_day(&self) -> u8 {
-            self.0.iso_month()
         }
 
         pub fn year(&self) -> i32 {


### PR DESCRIPTION
Closes #566

This PR removes the ISO getters from the public facing API.

I did end up keeping them for crate private because they are nice short hand for dt.iso.date.year, etc.

Per the issue, removing these from the public API will open a question about debug printing over FFI that we should probably have a plan for prior to merging.