### PR TITLE
Make TimeZone no longer allocate over FFI

### DIFF
--- a/src/builtins/compiled/instant.rs
+++ b/src/builtins/compiled/instant.rs
@@ -11,7 +11,7 @@ impl Instant {
     /// Enable with the `compiled_data` feature flag.
     pub fn to_ixdtf_string(
         &self,
-        timezone: Option<&TimeZone>,
+        timezone: Option<TimeZone>,
         options: ToStringRoundingOptions,
     ) -> TemporalResult<String> {
         self.to_ixdtf_string_with_provider(timezone, options, &*TZ_PROVIDER)
@@ -23,7 +23,7 @@ impl Instant {
     /// Enable with the `compiled_data` feature flag.
     pub fn to_ixdtf_writeable(
         &self,
-        timezone: Option<&TimeZone>,
+        timezone: Option<TimeZone>,
         options: ToStringRoundingOptions,
     ) -> TemporalResult<impl writeable::Writeable + '_> {
         self.to_ixdtf_writeable_with_provider(timezone, options, &*TZ_PROVIDER)

--- a/src/builtins/compiled/plain_month_day.rs
+++ b/src/builtins/compiled/plain_month_day.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 
 impl PlainMonthDay {
-    pub fn epoch_ns_for(&self, time_zone: &TimeZone) -> TemporalResult<EpochNanoseconds> {
+    pub fn epoch_ns_for(&self, time_zone: TimeZone) -> TemporalResult<EpochNanoseconds> {
         self.epoch_ns_for_with_provider(time_zone, &*TZ_PROVIDER)
     }
 }

--- a/src/builtins/compiled/plain_year_month.rs
+++ b/src/builtins/compiled/plain_year_month.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 
 impl PlainYearMonth {
-    pub fn epoch_ns_for(&self, time_zone: &TimeZone) -> TemporalResult<EpochNanoseconds> {
+    pub fn epoch_ns_for(&self, time_zone: TimeZone) -> TemporalResult<EpochNanoseconds> {
         self.epoch_ns_for_with_provider(time_zone, &*TZ_PROVIDER)
     }
 }

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -402,7 +402,7 @@ impl Instant {
 impl Instant {
     pub fn to_ixdtf_string_with_provider(
         &self,
-        timezone: Option<&TimeZone>,
+        timezone: Option<TimeZone>,
         options: ToStringRoundingOptions,
         provider: &impl TimeZoneProvider,
     ) -> TemporalResult<String> {
@@ -412,7 +412,7 @@ impl Instant {
 
     pub fn to_ixdtf_writeable_with_provider(
         &self,
-        timezone: Option<&TimeZone>,
+        timezone: Option<TimeZone>,
         options: ToStringRoundingOptions,
         provider: &impl TimeZoneProvider,
     ) -> TemporalResult<impl Writeable + '_> {

--- a/src/builtins/core/plain_month_day.rs
+++ b/src/builtins/core/plain_month_day.rs
@@ -352,7 +352,7 @@ impl PlainMonthDay {
     // Useful for implementing HandleDateTimeTemporalYearMonth
     pub fn epoch_ns_for_with_provider(
         &self,
-        time_zone: &TimeZone,
+        time_zone: TimeZone,
         provider: &impl TimeZoneProvider,
     ) -> TemporalResult<EpochNanoseconds> {
         // 2. Let isoDateTime be CombineISODateAndTimeRecord(temporalYearMonth.[[ISODate]], NoonTimeRecord()).

--- a/src/builtins/core/plain_year_month.rs
+++ b/src/builtins/core/plain_year_month.rs
@@ -614,7 +614,7 @@ impl PlainYearMonth {
     // Useful for implementing HandleDateTimeTemporalYearMonth
     pub fn epoch_ns_for_with_provider(
         &self,
-        time_zone: &TimeZone,
+        time_zone: TimeZone,
         provider: &impl TimeZoneProvider,
     ) -> TemporalResult<EpochNanoseconds> {
         // 2. Let isoDateTime be CombineISODateAndTimeRecord(temporalYearMonth.[[ISODate]], NoonTimeRecord()).

--- a/temporal_capi/bindings/c/Instant.h
+++ b/temporal_capi/bindings/c/Instant.h
@@ -60,16 +60,16 @@ int64_t temporal_rs_Instant_epoch_milliseconds(const Instant* self);
 I128Nanoseconds temporal_rs_Instant_epoch_nanoseconds(const Instant* self);
 
 typedef struct temporal_rs_Instant_to_ixdtf_string_with_compiled_data_result {union { TemporalError err;}; bool is_ok;} temporal_rs_Instant_to_ixdtf_string_with_compiled_data_result;
-temporal_rs_Instant_to_ixdtf_string_with_compiled_data_result temporal_rs_Instant_to_ixdtf_string_with_compiled_data(const Instant* self, const TimeZone* zone, ToStringRoundingOptions options, DiplomatWrite* write);
+temporal_rs_Instant_to_ixdtf_string_with_compiled_data_result temporal_rs_Instant_to_ixdtf_string_with_compiled_data(const Instant* self, TimeZone_option zone, ToStringRoundingOptions options, DiplomatWrite* write);
 
 typedef struct temporal_rs_Instant_to_ixdtf_string_with_provider_result {union { TemporalError err;}; bool is_ok;} temporal_rs_Instant_to_ixdtf_string_with_provider_result;
-temporal_rs_Instant_to_ixdtf_string_with_provider_result temporal_rs_Instant_to_ixdtf_string_with_provider(const Instant* self, const TimeZone* zone, ToStringRoundingOptions options, const Provider* p, DiplomatWrite* write);
+temporal_rs_Instant_to_ixdtf_string_with_provider_result temporal_rs_Instant_to_ixdtf_string_with_provider(const Instant* self, TimeZone_option zone, ToStringRoundingOptions options, const Provider* p, DiplomatWrite* write);
 
 typedef struct temporal_rs_Instant_to_zoned_date_time_iso_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_Instant_to_zoned_date_time_iso_result;
-temporal_rs_Instant_to_zoned_date_time_iso_result temporal_rs_Instant_to_zoned_date_time_iso(const Instant* self, const TimeZone* zone);
+temporal_rs_Instant_to_zoned_date_time_iso_result temporal_rs_Instant_to_zoned_date_time_iso(const Instant* self, TimeZone zone);
 
 typedef struct temporal_rs_Instant_to_zoned_date_time_iso_with_provider_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_Instant_to_zoned_date_time_iso_with_provider_result;
-temporal_rs_Instant_to_zoned_date_time_iso_with_provider_result temporal_rs_Instant_to_zoned_date_time_iso_with_provider(const Instant* self, const TimeZone* zone, const Provider* p);
+temporal_rs_Instant_to_zoned_date_time_iso_with_provider_result temporal_rs_Instant_to_zoned_date_time_iso_with_provider(const Instant* self, TimeZone zone, const Provider* p);
 
 Instant* temporal_rs_Instant_clone(const Instant* self);
 

--- a/temporal_capi/bindings/c/PartialZonedDateTime.d.h
+++ b/temporal_capi/bindings/c/PartialZonedDateTime.d.h
@@ -18,7 +18,7 @@ typedef struct PartialZonedDateTime {
   PartialDate date;
   PartialTime time;
   OptionStringView offset;
-  const TimeZone* timezone;
+  TimeZone_option timezone;
 } PartialZonedDateTime;
 
 typedef struct PartialZonedDateTime_option {union { PartialZonedDateTime ok; }; bool is_ok; } PartialZonedDateTime_option;

--- a/temporal_capi/bindings/c/PlainDate.h
+++ b/temporal_capi/bindings/c/PlainDate.h
@@ -47,10 +47,10 @@ typedef struct temporal_rs_PlainDate_from_parsed_result {union {PlainDate* ok; T
 temporal_rs_PlainDate_from_parsed_result temporal_rs_PlainDate_from_parsed(const ParsedDate* parsed);
 
 typedef struct temporal_rs_PlainDate_from_epoch_milliseconds_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_epoch_milliseconds_result;
-temporal_rs_PlainDate_from_epoch_milliseconds_result temporal_rs_PlainDate_from_epoch_milliseconds(int64_t ms, const TimeZone* tz);
+temporal_rs_PlainDate_from_epoch_milliseconds_result temporal_rs_PlainDate_from_epoch_milliseconds(int64_t ms, TimeZone tz);
 
 typedef struct temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result;
-temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result temporal_rs_PlainDate_from_epoch_milliseconds_with_provider(int64_t ms, const TimeZone* tz, const Provider* p);
+temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result temporal_rs_PlainDate_from_epoch_milliseconds_with_provider(int64_t ms, TimeZone tz, const Provider* p);
 
 typedef struct temporal_rs_PlainDate_with_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_with_result;
 temporal_rs_PlainDate_with_result temporal_rs_PlainDate_with(const PlainDate* self, PartialDate partial, ArithmeticOverflow_option overflow);
@@ -126,10 +126,10 @@ typedef struct temporal_rs_PlainDate_to_plain_year_month_result {union {PlainYea
 temporal_rs_PlainDate_to_plain_year_month_result temporal_rs_PlainDate_to_plain_year_month(const PlainDate* self);
 
 typedef struct temporal_rs_PlainDate_to_zoned_date_time_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_to_zoned_date_time_result;
-temporal_rs_PlainDate_to_zoned_date_time_result temporal_rs_PlainDate_to_zoned_date_time(const PlainDate* self, const TimeZone* time_zone, const PlainTime* time);
+temporal_rs_PlainDate_to_zoned_date_time_result temporal_rs_PlainDate_to_zoned_date_time(const PlainDate* self, TimeZone time_zone, const PlainTime* time);
 
 typedef struct temporal_rs_PlainDate_to_zoned_date_time_with_provider_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_to_zoned_date_time_with_provider_result;
-temporal_rs_PlainDate_to_zoned_date_time_with_provider_result temporal_rs_PlainDate_to_zoned_date_time_with_provider(const PlainDate* self, const TimeZone* time_zone, const PlainTime* time, const Provider* p);
+temporal_rs_PlainDate_to_zoned_date_time_with_provider_result temporal_rs_PlainDate_to_zoned_date_time_with_provider(const PlainDate* self, TimeZone time_zone, const PlainTime* time, const Provider* p);
 
 void temporal_rs_PlainDate_to_ixdtf_string(const PlainDate* self, DisplayCalendar display_calendar, DiplomatWrite* write);
 

--- a/temporal_capi/bindings/c/PlainDateTime.h
+++ b/temporal_capi/bindings/c/PlainDateTime.h
@@ -45,10 +45,10 @@ typedef struct temporal_rs_PlainDateTime_from_parsed_result {union {PlainDateTim
 temporal_rs_PlainDateTime_from_parsed_result temporal_rs_PlainDateTime_from_parsed(const ParsedDateTime* parsed);
 
 typedef struct temporal_rs_PlainDateTime_from_epoch_milliseconds_result {union {PlainDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_epoch_milliseconds_result;
-temporal_rs_PlainDateTime_from_epoch_milliseconds_result temporal_rs_PlainDateTime_from_epoch_milliseconds(int64_t ms, const TimeZone* tz);
+temporal_rs_PlainDateTime_from_epoch_milliseconds_result temporal_rs_PlainDateTime_from_epoch_milliseconds(int64_t ms, TimeZone tz);
 
 typedef struct temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider_result {union {PlainDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider_result;
-temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider_result temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider(int64_t ms, const TimeZone* tz, const Provider* p);
+temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider_result temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider(int64_t ms, TimeZone tz, const Provider* p);
 
 typedef struct temporal_rs_PlainDateTime_with_result {union {PlainDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_with_result;
 temporal_rs_PlainDateTime_with_result temporal_rs_PlainDateTime_with(const PlainDateTime* self, PartialDateTime partial, ArithmeticOverflow_option overflow);
@@ -135,10 +135,10 @@ PlainDate* temporal_rs_PlainDateTime_to_plain_date(const PlainDateTime* self);
 PlainTime* temporal_rs_PlainDateTime_to_plain_time(const PlainDateTime* self);
 
 typedef struct temporal_rs_PlainDateTime_to_zoned_date_time_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_to_zoned_date_time_result;
-temporal_rs_PlainDateTime_to_zoned_date_time_result temporal_rs_PlainDateTime_to_zoned_date_time(const PlainDateTime* self, const TimeZone* time_zone, Disambiguation disambiguation);
+temporal_rs_PlainDateTime_to_zoned_date_time_result temporal_rs_PlainDateTime_to_zoned_date_time(const PlainDateTime* self, TimeZone time_zone, Disambiguation disambiguation);
 
 typedef struct temporal_rs_PlainDateTime_to_zoned_date_time_with_provider_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_to_zoned_date_time_with_provider_result;
-temporal_rs_PlainDateTime_to_zoned_date_time_with_provider_result temporal_rs_PlainDateTime_to_zoned_date_time_with_provider(const PlainDateTime* self, const TimeZone* time_zone, Disambiguation disambiguation, const Provider* p);
+temporal_rs_PlainDateTime_to_zoned_date_time_with_provider_result temporal_rs_PlainDateTime_to_zoned_date_time_with_provider(const PlainDateTime* self, TimeZone time_zone, Disambiguation disambiguation, const Provider* p);
 
 typedef struct temporal_rs_PlainDateTime_to_ixdtf_string_result {union { TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_to_ixdtf_string_result;
 temporal_rs_PlainDateTime_to_ixdtf_string_result temporal_rs_PlainDateTime_to_ixdtf_string(const PlainDateTime* self, ToStringRoundingOptions options, DisplayCalendar display_calendar, DiplomatWrite* write);

--- a/temporal_capi/bindings/c/PlainMonthDay.h
+++ b/temporal_capi/bindings/c/PlainMonthDay.h
@@ -55,10 +55,10 @@ typedef struct temporal_rs_PlainMonthDay_to_plain_date_result {union {PlainDate*
 temporal_rs_PlainMonthDay_to_plain_date_result temporal_rs_PlainMonthDay_to_plain_date(const PlainMonthDay* self, PartialDate_option year);
 
 typedef struct temporal_rs_PlainMonthDay_epoch_ms_for_result {union {int64_t ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_epoch_ms_for_result;
-temporal_rs_PlainMonthDay_epoch_ms_for_result temporal_rs_PlainMonthDay_epoch_ms_for(const PlainMonthDay* self, const TimeZone* time_zone);
+temporal_rs_PlainMonthDay_epoch_ms_for_result temporal_rs_PlainMonthDay_epoch_ms_for(const PlainMonthDay* self, TimeZone time_zone);
 
 typedef struct temporal_rs_PlainMonthDay_epoch_ms_for_with_provider_result {union {int64_t ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_epoch_ms_for_with_provider_result;
-temporal_rs_PlainMonthDay_epoch_ms_for_with_provider_result temporal_rs_PlainMonthDay_epoch_ms_for_with_provider(const PlainMonthDay* self, const TimeZone* time_zone, const Provider* p);
+temporal_rs_PlainMonthDay_epoch_ms_for_with_provider_result temporal_rs_PlainMonthDay_epoch_ms_for_with_provider(const PlainMonthDay* self, TimeZone time_zone, const Provider* p);
 
 void temporal_rs_PlainMonthDay_to_ixdtf_string(const PlainMonthDay* self, DisplayCalendar display_calendar, DiplomatWrite* write);
 

--- a/temporal_capi/bindings/c/PlainTime.h
+++ b/temporal_capi/bindings/c/PlainTime.h
@@ -34,10 +34,10 @@ typedef struct temporal_rs_PlainTime_from_partial_result {union {PlainTime* ok; 
 temporal_rs_PlainTime_from_partial_result temporal_rs_PlainTime_from_partial(PartialTime partial, ArithmeticOverflow_option overflow);
 
 typedef struct temporal_rs_PlainTime_from_epoch_milliseconds_result {union {PlainTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_from_epoch_milliseconds_result;
-temporal_rs_PlainTime_from_epoch_milliseconds_result temporal_rs_PlainTime_from_epoch_milliseconds(int64_t ms, const TimeZone* tz);
+temporal_rs_PlainTime_from_epoch_milliseconds_result temporal_rs_PlainTime_from_epoch_milliseconds(int64_t ms, TimeZone tz);
 
 typedef struct temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result {union {PlainTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result;
-temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result temporal_rs_PlainTime_from_epoch_milliseconds_with_provider(int64_t ms, const TimeZone* tz, const Provider* p);
+temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result temporal_rs_PlainTime_from_epoch_milliseconds_with_provider(int64_t ms, TimeZone tz, const Provider* p);
 
 typedef struct temporal_rs_PlainTime_with_result {union {PlainTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_with_result;
 temporal_rs_PlainTime_with_result temporal_rs_PlainTime_with(const PlainTime* self, PartialTime partial, ArithmeticOverflow_option overflow);

--- a/temporal_capi/bindings/c/PlainYearMonth.h
+++ b/temporal_capi/bindings/c/PlainYearMonth.h
@@ -86,10 +86,10 @@ typedef struct temporal_rs_PlainYearMonth_to_plain_date_result {union {PlainDate
 temporal_rs_PlainYearMonth_to_plain_date_result temporal_rs_PlainYearMonth_to_plain_date(const PlainYearMonth* self, PartialDate_option day);
 
 typedef struct temporal_rs_PlainYearMonth_epoch_ms_for_result {union {int64_t ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_epoch_ms_for_result;
-temporal_rs_PlainYearMonth_epoch_ms_for_result temporal_rs_PlainYearMonth_epoch_ms_for(const PlainYearMonth* self, const TimeZone* time_zone);
+temporal_rs_PlainYearMonth_epoch_ms_for_result temporal_rs_PlainYearMonth_epoch_ms_for(const PlainYearMonth* self, TimeZone time_zone);
 
 typedef struct temporal_rs_PlainYearMonth_epoch_ms_for_with_provider_result {union {int64_t ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_epoch_ms_for_with_provider_result;
-temporal_rs_PlainYearMonth_epoch_ms_for_with_provider_result temporal_rs_PlainYearMonth_epoch_ms_for_with_provider(const PlainYearMonth* self, const TimeZone* time_zone, const Provider* p);
+temporal_rs_PlainYearMonth_epoch_ms_for_with_provider_result temporal_rs_PlainYearMonth_epoch_ms_for_with_provider(const PlainYearMonth* self, TimeZone time_zone, const Provider* p);
 
 void temporal_rs_PlainYearMonth_to_ixdtf_string(const PlainYearMonth* self, DisplayCalendar display_calendar, DiplomatWrite* write);
 

--- a/temporal_capi/bindings/c/TimeZone.d.h
+++ b/temporal_capi/bindings/c/TimeZone.d.h
@@ -11,8 +11,14 @@
 
 
 
-typedef struct TimeZone TimeZone;
+typedef struct TimeZone {
+  int16_t offset_minutes;
+  size_t resolved_id;
+  size_t normalized_id;
+  bool is_iana_id;
+} TimeZone;
 
+typedef struct TimeZone_option {union { TimeZone ok; }; bool is_ok; } TimeZone_option;
 
 
 

--- a/temporal_capi/bindings/c/TimeZone.h
+++ b/temporal_capi/bindings/c/TimeZone.h
@@ -17,42 +17,38 @@
 
 
 
-typedef struct temporal_rs_TimeZone_try_from_identifier_str_result {union {TimeZone* ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_identifier_str_result;
+typedef struct temporal_rs_TimeZone_try_from_identifier_str_result {union {TimeZone ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_identifier_str_result;
 temporal_rs_TimeZone_try_from_identifier_str_result temporal_rs_TimeZone_try_from_identifier_str(DiplomatStringView ident);
 
-typedef struct temporal_rs_TimeZone_try_from_identifier_str_with_provider_result {union {TimeZone* ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_identifier_str_with_provider_result;
+typedef struct temporal_rs_TimeZone_try_from_identifier_str_with_provider_result {union {TimeZone ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_identifier_str_with_provider_result;
 temporal_rs_TimeZone_try_from_identifier_str_with_provider_result temporal_rs_TimeZone_try_from_identifier_str_with_provider(DiplomatStringView ident, const Provider* p);
 
-typedef struct temporal_rs_TimeZone_try_from_offset_str_result {union {TimeZone* ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_offset_str_result;
+typedef struct temporal_rs_TimeZone_try_from_offset_str_result {union {TimeZone ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_offset_str_result;
 temporal_rs_TimeZone_try_from_offset_str_result temporal_rs_TimeZone_try_from_offset_str(DiplomatStringView ident);
 
-typedef struct temporal_rs_TimeZone_try_from_str_result {union {TimeZone* ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_str_result;
+typedef struct temporal_rs_TimeZone_try_from_str_result {union {TimeZone ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_str_result;
 temporal_rs_TimeZone_try_from_str_result temporal_rs_TimeZone_try_from_str(DiplomatStringView ident);
 
-typedef struct temporal_rs_TimeZone_try_from_str_with_provider_result {union {TimeZone* ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_str_with_provider_result;
+typedef struct temporal_rs_TimeZone_try_from_str_with_provider_result {union {TimeZone ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_str_with_provider_result;
 temporal_rs_TimeZone_try_from_str_with_provider_result temporal_rs_TimeZone_try_from_str_with_provider(DiplomatStringView ident, const Provider* p);
 
-void temporal_rs_TimeZone_identifier(const TimeZone* self, DiplomatWrite* write);
+void temporal_rs_TimeZone_identifier(TimeZone self, DiplomatWrite* write);
 
 typedef struct temporal_rs_TimeZone_identifier_with_provider_result {union { TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_identifier_with_provider_result;
-temporal_rs_TimeZone_identifier_with_provider_result temporal_rs_TimeZone_identifier_with_provider(const TimeZone* self, const Provider* p, DiplomatWrite* write);
+temporal_rs_TimeZone_identifier_with_provider_result temporal_rs_TimeZone_identifier_with_provider(TimeZone self, const Provider* p, DiplomatWrite* write);
 
-TimeZone* temporal_rs_TimeZone_utc(void);
+TimeZone temporal_rs_TimeZone_utc(void);
 
-typedef struct temporal_rs_TimeZone_utc_with_provider_result {union {TimeZone* ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_utc_with_provider_result;
+typedef struct temporal_rs_TimeZone_utc_with_provider_result {union {TimeZone ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_utc_with_provider_result;
 temporal_rs_TimeZone_utc_with_provider_result temporal_rs_TimeZone_utc_with_provider(const Provider* p);
 
-TimeZone* temporal_rs_TimeZone_zero(void);
+TimeZone temporal_rs_TimeZone_zero(void);
 
-TimeZone* temporal_rs_TimeZone_clone(const TimeZone* self);
+typedef struct temporal_rs_TimeZone_primary_identifier_result {union {TimeZone ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_primary_identifier_result;
+temporal_rs_TimeZone_primary_identifier_result temporal_rs_TimeZone_primary_identifier(TimeZone self);
 
-typedef struct temporal_rs_TimeZone_primary_identifier_result {union {TimeZone* ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_primary_identifier_result;
-temporal_rs_TimeZone_primary_identifier_result temporal_rs_TimeZone_primary_identifier(const TimeZone* self);
-
-typedef struct temporal_rs_TimeZone_primary_identifier_with_provider_result {union {TimeZone* ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_primary_identifier_with_provider_result;
-temporal_rs_TimeZone_primary_identifier_with_provider_result temporal_rs_TimeZone_primary_identifier_with_provider(const TimeZone* self, const Provider* p);
-
-void temporal_rs_TimeZone_destroy(TimeZone* self);
+typedef struct temporal_rs_TimeZone_primary_identifier_with_provider_result {union {TimeZone ok; TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_primary_identifier_with_provider_result;
+temporal_rs_TimeZone_primary_identifier_with_provider_result temporal_rs_TimeZone_primary_identifier_with_provider(TimeZone self, const Provider* p);
 
 
 

--- a/temporal_capi/bindings/c/ZonedDateTime.h
+++ b/temporal_capi/bindings/c/ZonedDateTime.h
@@ -39,10 +39,10 @@
 
 
 typedef struct temporal_rs_ZonedDateTime_try_new_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_try_new_result;
-temporal_rs_ZonedDateTime_try_new_result temporal_rs_ZonedDateTime_try_new(I128Nanoseconds nanosecond, AnyCalendarKind calendar, const TimeZone* time_zone);
+temporal_rs_ZonedDateTime_try_new_result temporal_rs_ZonedDateTime_try_new(I128Nanoseconds nanosecond, AnyCalendarKind calendar, TimeZone time_zone);
 
 typedef struct temporal_rs_ZonedDateTime_try_new_with_provider_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_try_new_with_provider_result;
-temporal_rs_ZonedDateTime_try_new_with_provider_result temporal_rs_ZonedDateTime_try_new_with_provider(I128Nanoseconds nanosecond, AnyCalendarKind calendar, const TimeZone* time_zone, const Provider* p);
+temporal_rs_ZonedDateTime_try_new_with_provider_result temporal_rs_ZonedDateTime_try_new_with_provider(I128Nanoseconds nanosecond, AnyCalendarKind calendar, TimeZone time_zone, const Provider* p);
 
 typedef struct temporal_rs_ZonedDateTime_from_partial_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_from_partial_result;
 temporal_rs_ZonedDateTime_from_partial_result temporal_rs_ZonedDateTime_from_partial(PartialZonedDateTime partial, ArithmeticOverflow_option overflow, Disambiguation_option disambiguation, OffsetDisambiguation_option offset_option);
@@ -71,10 +71,10 @@ temporal_rs_ZonedDateTime_from_utf16_with_provider_result temporal_rs_ZonedDateT
 int64_t temporal_rs_ZonedDateTime_epoch_milliseconds(const ZonedDateTime* self);
 
 typedef struct temporal_rs_ZonedDateTime_from_epoch_milliseconds_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_from_epoch_milliseconds_result;
-temporal_rs_ZonedDateTime_from_epoch_milliseconds_result temporal_rs_ZonedDateTime_from_epoch_milliseconds(int64_t ms, const TimeZone* tz);
+temporal_rs_ZonedDateTime_from_epoch_milliseconds_result temporal_rs_ZonedDateTime_from_epoch_milliseconds(int64_t ms, TimeZone tz);
 
 typedef struct temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result;
-temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider(int64_t ms, const TimeZone* tz, const Provider* p);
+temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider(int64_t ms, TimeZone tz, const Provider* p);
 
 I128Nanoseconds temporal_rs_ZonedDateTime_epoch_nanoseconds(const ZonedDateTime* self);
 
@@ -89,12 +89,12 @@ typedef struct temporal_rs_ZonedDateTime_with_with_provider_result {union {Zoned
 temporal_rs_ZonedDateTime_with_with_provider_result temporal_rs_ZonedDateTime_with_with_provider(const ZonedDateTime* self, PartialZonedDateTime partial, Disambiguation_option disambiguation, OffsetDisambiguation_option offset_option, ArithmeticOverflow_option overflow, const Provider* p);
 
 typedef struct temporal_rs_ZonedDateTime_with_timezone_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_with_timezone_result;
-temporal_rs_ZonedDateTime_with_timezone_result temporal_rs_ZonedDateTime_with_timezone(const ZonedDateTime* self, const TimeZone* zone);
+temporal_rs_ZonedDateTime_with_timezone_result temporal_rs_ZonedDateTime_with_timezone(const ZonedDateTime* self, TimeZone zone);
 
 typedef struct temporal_rs_ZonedDateTime_with_timezone_with_provider_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_with_timezone_with_provider_result;
-temporal_rs_ZonedDateTime_with_timezone_with_provider_result temporal_rs_ZonedDateTime_with_timezone_with_provider(const ZonedDateTime* self, const TimeZone* zone, const Provider* p);
+temporal_rs_ZonedDateTime_with_timezone_with_provider_result temporal_rs_ZonedDateTime_with_timezone_with_provider(const ZonedDateTime* self, TimeZone zone, const Provider* p);
 
-const TimeZone* temporal_rs_ZonedDateTime_timezone(const ZonedDateTime* self);
+TimeZone temporal_rs_ZonedDateTime_timezone(const ZonedDateTime* self);
 
 int8_t temporal_rs_ZonedDateTime_compare_instant(const ZonedDateTime* self, const ZonedDateTime* other);
 

--- a/temporal_capi/bindings/cpp/temporal_rs/Instant.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Instant.d.hpp
@@ -18,14 +18,13 @@ namespace capi { struct Instant; }
 class Instant;
 namespace capi { struct Provider; }
 class Provider;
-namespace capi { struct TimeZone; }
-class TimeZone;
 namespace capi { struct ZonedDateTime; }
 class ZonedDateTime;
 struct DifferenceSettings;
 struct I128Nanoseconds;
 struct RoundingOptions;
 struct TemporalError;
+struct TimeZone;
 struct ToStringRoundingOptions;
 }
 
@@ -66,17 +65,17 @@ public:
 
   inline temporal_rs::I128Nanoseconds epoch_nanoseconds() const;
 
-  inline diplomat::result<std::string, temporal_rs::TemporalError> to_ixdtf_string_with_compiled_data(const temporal_rs::TimeZone* zone, temporal_rs::ToStringRoundingOptions options) const;
+  inline diplomat::result<std::string, temporal_rs::TemporalError> to_ixdtf_string_with_compiled_data(std::optional<temporal_rs::TimeZone> zone, temporal_rs::ToStringRoundingOptions options) const;
   template<typename W>
-  inline diplomat::result<std::monostate, temporal_rs::TemporalError> to_ixdtf_string_with_compiled_data_write(const temporal_rs::TimeZone* zone, temporal_rs::ToStringRoundingOptions options, W& writeable_output) const;
+  inline diplomat::result<std::monostate, temporal_rs::TemporalError> to_ixdtf_string_with_compiled_data_write(std::optional<temporal_rs::TimeZone> zone, temporal_rs::ToStringRoundingOptions options, W& writeable_output) const;
 
-  inline diplomat::result<std::string, temporal_rs::TemporalError> to_ixdtf_string_with_provider(const temporal_rs::TimeZone* zone, temporal_rs::ToStringRoundingOptions options, const temporal_rs::Provider& p) const;
+  inline diplomat::result<std::string, temporal_rs::TemporalError> to_ixdtf_string_with_provider(std::optional<temporal_rs::TimeZone> zone, temporal_rs::ToStringRoundingOptions options, const temporal_rs::Provider& p) const;
   template<typename W>
-  inline diplomat::result<std::monostate, temporal_rs::TemporalError> to_ixdtf_string_with_provider_write(const temporal_rs::TimeZone* zone, temporal_rs::ToStringRoundingOptions options, const temporal_rs::Provider& p, W& writeable_output) const;
+  inline diplomat::result<std::monostate, temporal_rs::TemporalError> to_ixdtf_string_with_provider_write(std::optional<temporal_rs::TimeZone> zone, temporal_rs::ToStringRoundingOptions options, const temporal_rs::Provider& p, W& writeable_output) const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> to_zoned_date_time_iso(const temporal_rs::TimeZone& zone) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> to_zoned_date_time_iso(temporal_rs::TimeZone zone) const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> to_zoned_date_time_iso_with_provider(const temporal_rs::TimeZone& zone, const temporal_rs::Provider& p) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> to_zoned_date_time_iso_with_provider(temporal_rs::TimeZone zone, const temporal_rs::Provider& p) const;
 
   inline std::unique_ptr<temporal_rs::Instant> clone() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/Instant.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Instant.hpp
@@ -63,16 +63,16 @@ namespace capi {
     temporal_rs::capi::I128Nanoseconds temporal_rs_Instant_epoch_nanoseconds(const temporal_rs::capi::Instant* self);
 
     typedef struct temporal_rs_Instant_to_ixdtf_string_with_compiled_data_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Instant_to_ixdtf_string_with_compiled_data_result;
-    temporal_rs_Instant_to_ixdtf_string_with_compiled_data_result temporal_rs_Instant_to_ixdtf_string_with_compiled_data(const temporal_rs::capi::Instant* self, const temporal_rs::capi::TimeZone* zone, temporal_rs::capi::ToStringRoundingOptions options, diplomat::capi::DiplomatWrite* write);
+    temporal_rs_Instant_to_ixdtf_string_with_compiled_data_result temporal_rs_Instant_to_ixdtf_string_with_compiled_data(const temporal_rs::capi::Instant* self, temporal_rs::capi::TimeZone_option zone, temporal_rs::capi::ToStringRoundingOptions options, diplomat::capi::DiplomatWrite* write);
 
     typedef struct temporal_rs_Instant_to_ixdtf_string_with_provider_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Instant_to_ixdtf_string_with_provider_result;
-    temporal_rs_Instant_to_ixdtf_string_with_provider_result temporal_rs_Instant_to_ixdtf_string_with_provider(const temporal_rs::capi::Instant* self, const temporal_rs::capi::TimeZone* zone, temporal_rs::capi::ToStringRoundingOptions options, const temporal_rs::capi::Provider* p, diplomat::capi::DiplomatWrite* write);
+    temporal_rs_Instant_to_ixdtf_string_with_provider_result temporal_rs_Instant_to_ixdtf_string_with_provider(const temporal_rs::capi::Instant* self, temporal_rs::capi::TimeZone_option zone, temporal_rs::capi::ToStringRoundingOptions options, const temporal_rs::capi::Provider* p, diplomat::capi::DiplomatWrite* write);
 
     typedef struct temporal_rs_Instant_to_zoned_date_time_iso_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Instant_to_zoned_date_time_iso_result;
-    temporal_rs_Instant_to_zoned_date_time_iso_result temporal_rs_Instant_to_zoned_date_time_iso(const temporal_rs::capi::Instant* self, const temporal_rs::capi::TimeZone* zone);
+    temporal_rs_Instant_to_zoned_date_time_iso_result temporal_rs_Instant_to_zoned_date_time_iso(const temporal_rs::capi::Instant* self, temporal_rs::capi::TimeZone zone);
 
     typedef struct temporal_rs_Instant_to_zoned_date_time_iso_with_provider_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_Instant_to_zoned_date_time_iso_with_provider_result;
-    temporal_rs_Instant_to_zoned_date_time_iso_with_provider_result temporal_rs_Instant_to_zoned_date_time_iso_with_provider(const temporal_rs::capi::Instant* self, const temporal_rs::capi::TimeZone* zone, const temporal_rs::capi::Provider* p);
+    temporal_rs_Instant_to_zoned_date_time_iso_with_provider_result temporal_rs_Instant_to_zoned_date_time_iso_with_provider(const temporal_rs::capi::Instant* self, temporal_rs::capi::TimeZone zone, const temporal_rs::capi::Provider* p);
 
     temporal_rs::capi::Instant* temporal_rs_Instant_clone(const temporal_rs::capi::Instant* self);
 
@@ -156,53 +156,53 @@ inline temporal_rs::I128Nanoseconds temporal_rs::Instant::epoch_nanoseconds() co
   return temporal_rs::I128Nanoseconds::FromFFI(result);
 }
 
-inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::Instant::to_ixdtf_string_with_compiled_data(const temporal_rs::TimeZone* zone, temporal_rs::ToStringRoundingOptions options) const {
+inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::Instant::to_ixdtf_string_with_compiled_data(std::optional<temporal_rs::TimeZone> zone, temporal_rs::ToStringRoundingOptions options) const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   auto result = temporal_rs::capi::temporal_rs_Instant_to_ixdtf_string_with_compiled_data(this->AsFFI(),
-    zone ? zone->AsFFI() : nullptr,
+    zone.has_value() ? (temporal_rs::capi::TimeZone_option{ { zone.value().AsFFI() }, true }) : (temporal_rs::capi::TimeZone_option{ {}, false }),
     options.AsFFI(),
     &write);
   return result.is_ok ? diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 template<typename W>
-inline diplomat::result<std::monostate, temporal_rs::TemporalError> temporal_rs::Instant::to_ixdtf_string_with_compiled_data_write(const temporal_rs::TimeZone* zone, temporal_rs::ToStringRoundingOptions options, W& writeable) const {
+inline diplomat::result<std::monostate, temporal_rs::TemporalError> temporal_rs::Instant::to_ixdtf_string_with_compiled_data_write(std::optional<temporal_rs::TimeZone> zone, temporal_rs::ToStringRoundingOptions options, W& writeable) const {
   diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
   auto result = temporal_rs::capi::temporal_rs_Instant_to_ixdtf_string_with_compiled_data(this->AsFFI(),
-    zone ? zone->AsFFI() : nullptr,
+    zone.has_value() ? (temporal_rs::capi::TimeZone_option{ { zone.value().AsFFI() }, true }) : (temporal_rs::capi::TimeZone_option{ {}, false }),
     options.AsFFI(),
     &write);
   return result.is_ok ? diplomat::result<std::monostate, temporal_rs::TemporalError>(diplomat::Ok<std::monostate>()) : diplomat::result<std::monostate, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::Instant::to_ixdtf_string_with_provider(const temporal_rs::TimeZone* zone, temporal_rs::ToStringRoundingOptions options, const temporal_rs::Provider& p) const {
+inline diplomat::result<std::string, temporal_rs::TemporalError> temporal_rs::Instant::to_ixdtf_string_with_provider(std::optional<temporal_rs::TimeZone> zone, temporal_rs::ToStringRoundingOptions options, const temporal_rs::Provider& p) const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   auto result = temporal_rs::capi::temporal_rs_Instant_to_ixdtf_string_with_provider(this->AsFFI(),
-    zone ? zone->AsFFI() : nullptr,
+    zone.has_value() ? (temporal_rs::capi::TimeZone_option{ { zone.value().AsFFI() }, true }) : (temporal_rs::capi::TimeZone_option{ {}, false }),
     options.AsFFI(),
     p.AsFFI(),
     &write);
   return result.is_ok ? diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 template<typename W>
-inline diplomat::result<std::monostate, temporal_rs::TemporalError> temporal_rs::Instant::to_ixdtf_string_with_provider_write(const temporal_rs::TimeZone* zone, temporal_rs::ToStringRoundingOptions options, const temporal_rs::Provider& p, W& writeable) const {
+inline diplomat::result<std::monostate, temporal_rs::TemporalError> temporal_rs::Instant::to_ixdtf_string_with_provider_write(std::optional<temporal_rs::TimeZone> zone, temporal_rs::ToStringRoundingOptions options, const temporal_rs::Provider& p, W& writeable) const {
   diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
   auto result = temporal_rs::capi::temporal_rs_Instant_to_ixdtf_string_with_provider(this->AsFFI(),
-    zone ? zone->AsFFI() : nullptr,
+    zone.has_value() ? (temporal_rs::capi::TimeZone_option{ { zone.value().AsFFI() }, true }) : (temporal_rs::capi::TimeZone_option{ {}, false }),
     options.AsFFI(),
     p.AsFFI(),
     &write);
   return result.is_ok ? diplomat::result<std::monostate, temporal_rs::TemporalError>(diplomat::Ok<std::monostate>()) : diplomat::result<std::monostate, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::Instant::to_zoned_date_time_iso(const temporal_rs::TimeZone& zone) const {
+inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::Instant::to_zoned_date_time_iso(temporal_rs::TimeZone zone) const {
   auto result = temporal_rs::capi::temporal_rs_Instant_to_zoned_date_time_iso(this->AsFFI(),
     zone.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::ZonedDateTime>>(std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::Instant::to_zoned_date_time_iso_with_provider(const temporal_rs::TimeZone& zone, const temporal_rs::Provider& p) const {
+inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::Instant::to_zoned_date_time_iso_with_provider(temporal_rs::TimeZone zone, const temporal_rs::Provider& p) const {
   auto result = temporal_rs::capi::temporal_rs_Instant_to_zoned_date_time_iso_with_provider(this->AsFFI(),
     zone.AsFFI(),
     p.AsFFI());

--- a/temporal_capi/bindings/cpp/temporal_rs/PartialZonedDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PartialZonedDateTime.d.hpp
@@ -12,12 +12,12 @@
 #include "../diplomat_runtime.hpp"
 #include "PartialDate.d.hpp"
 #include "PartialTime.d.hpp"
+#include "TimeZone.d.hpp"
 
 namespace temporal_rs {
-namespace capi { struct TimeZone; }
-class TimeZone;
 struct PartialDate;
 struct PartialTime;
+struct TimeZone;
 }
 
 
@@ -27,7 +27,7 @@ namespace capi {
       temporal_rs::capi::PartialDate date;
       temporal_rs::capi::PartialTime time;
       diplomat::capi::OptionStringView offset;
-      const temporal_rs::capi::TimeZone* timezone;
+      temporal_rs::capi::TimeZone_option timezone;
     };
 
     typedef struct PartialZonedDateTime_option {union { PartialZonedDateTime ok; }; bool is_ok; } PartialZonedDateTime_option;
@@ -40,7 +40,7 @@ struct PartialZonedDateTime {
   temporal_rs::PartialDate date;
   temporal_rs::PartialTime time;
   std::optional<std::string_view> offset;
-  const temporal_rs::TimeZone* timezone;
+  std::optional<temporal_rs::TimeZone> timezone;
 
   inline temporal_rs::capi::PartialZonedDateTime AsFFI() const;
   inline static temporal_rs::PartialZonedDateTime FromFFI(temporal_rs::capi::PartialZonedDateTime c_struct);

--- a/temporal_capi/bindings/cpp/temporal_rs/PartialZonedDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PartialZonedDateTime.hpp
@@ -31,7 +31,7 @@ inline temporal_rs::capi::PartialZonedDateTime temporal_rs::PartialZonedDateTime
     /* .date = */ date.AsFFI(),
     /* .time = */ time.AsFFI(),
     /* .offset = */ offset.has_value() ? (diplomat::capi::OptionStringView{ { {offset.value().data(), offset.value().size()} }, true }) : (diplomat::capi::OptionStringView{ {}, false }),
-    /* .timezone = */ timezone ? timezone->AsFFI() : nullptr,
+    /* .timezone = */ timezone.has_value() ? (temporal_rs::capi::TimeZone_option{ { timezone.value().AsFFI() }, true }) : (temporal_rs::capi::TimeZone_option{ {}, false }),
   };
 }
 
@@ -40,7 +40,7 @@ inline temporal_rs::PartialZonedDateTime temporal_rs::PartialZonedDateTime::From
     /* .date = */ temporal_rs::PartialDate::FromFFI(c_struct.date),
     /* .time = */ temporal_rs::PartialTime::FromFFI(c_struct.time),
     /* .offset = */ c_struct.offset.is_ok ? std::optional(std::string_view(c_struct.offset.ok.data, c_struct.offset.ok.len)) : std::nullopt,
-    /* .timezone = */ temporal_rs::TimeZone::FromFFI(c_struct.timezone),
+    /* .timezone = */ c_struct.timezone.is_ok ? std::optional(temporal_rs::TimeZone::FromFFI(c_struct.timezone.ok)) : std::nullopt,
   };
 }
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
@@ -30,13 +30,12 @@ namespace capi { struct PlainYearMonth; }
 class PlainYearMonth;
 namespace capi { struct Provider; }
 class Provider;
-namespace capi { struct TimeZone; }
-class TimeZone;
 namespace capi { struct ZonedDateTime; }
 class ZonedDateTime;
 struct DifferenceSettings;
 struct PartialDate;
 struct TemporalError;
+struct TimeZone;
 class AnyCalendarKind;
 class ArithmeticOverflow;
 class DisplayCalendar;
@@ -63,9 +62,9 @@ public:
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_parsed(const temporal_rs::ParsedDate& parsed);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_epoch_milliseconds(int64_t ms, const temporal_rs::TimeZone& tz);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_epoch_milliseconds(int64_t ms, temporal_rs::TimeZone tz);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_epoch_milliseconds_with_provider(int64_t ms, const temporal_rs::TimeZone& tz, const temporal_rs::Provider& p);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> with(temporal_rs::PartialDate partial, std::optional<temporal_rs::ArithmeticOverflow> overflow) const;
 
@@ -131,9 +130,9 @@ public:
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError> to_plain_year_month() const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> to_zoned_date_time(const temporal_rs::TimeZone& time_zone, const temporal_rs::PlainTime* time) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> to_zoned_date_time(temporal_rs::TimeZone time_zone, const temporal_rs::PlainTime* time) const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> to_zoned_date_time_with_provider(const temporal_rs::TimeZone& time_zone, const temporal_rs::PlainTime* time, const temporal_rs::Provider& p) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> to_zoned_date_time_with_provider(temporal_rs::TimeZone time_zone, const temporal_rs::PlainTime* time, const temporal_rs::Provider& p) const;
 
   inline std::string to_ixdtf_string(temporal_rs::DisplayCalendar display_calendar) const;
   template<typename W>

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
@@ -50,10 +50,10 @@ namespace capi {
     temporal_rs_PlainDate_from_parsed_result temporal_rs_PlainDate_from_parsed(const temporal_rs::capi::ParsedDate* parsed);
 
     typedef struct temporal_rs_PlainDate_from_epoch_milliseconds_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_epoch_milliseconds_result;
-    temporal_rs_PlainDate_from_epoch_milliseconds_result temporal_rs_PlainDate_from_epoch_milliseconds(int64_t ms, const temporal_rs::capi::TimeZone* tz);
+    temporal_rs_PlainDate_from_epoch_milliseconds_result temporal_rs_PlainDate_from_epoch_milliseconds(int64_t ms, temporal_rs::capi::TimeZone tz);
 
     typedef struct temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result;
-    temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result temporal_rs_PlainDate_from_epoch_milliseconds_with_provider(int64_t ms, const temporal_rs::capi::TimeZone* tz, const temporal_rs::capi::Provider* p);
+    temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result temporal_rs_PlainDate_from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
 
     typedef struct temporal_rs_PlainDate_with_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_with_result;
     temporal_rs_PlainDate_with_result temporal_rs_PlainDate_with(const temporal_rs::capi::PlainDate* self, temporal_rs::capi::PartialDate partial, temporal_rs::capi::ArithmeticOverflow_option overflow);
@@ -129,10 +129,10 @@ namespace capi {
     temporal_rs_PlainDate_to_plain_year_month_result temporal_rs_PlainDate_to_plain_year_month(const temporal_rs::capi::PlainDate* self);
 
     typedef struct temporal_rs_PlainDate_to_zoned_date_time_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_to_zoned_date_time_result;
-    temporal_rs_PlainDate_to_zoned_date_time_result temporal_rs_PlainDate_to_zoned_date_time(const temporal_rs::capi::PlainDate* self, const temporal_rs::capi::TimeZone* time_zone, const temporal_rs::capi::PlainTime* time);
+    temporal_rs_PlainDate_to_zoned_date_time_result temporal_rs_PlainDate_to_zoned_date_time(const temporal_rs::capi::PlainDate* self, temporal_rs::capi::TimeZone time_zone, const temporal_rs::capi::PlainTime* time);
 
     typedef struct temporal_rs_PlainDate_to_zoned_date_time_with_provider_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_to_zoned_date_time_with_provider_result;
-    temporal_rs_PlainDate_to_zoned_date_time_with_provider_result temporal_rs_PlainDate_to_zoned_date_time_with_provider(const temporal_rs::capi::PlainDate* self, const temporal_rs::capi::TimeZone* time_zone, const temporal_rs::capi::PlainTime* time, const temporal_rs::capi::Provider* p);
+    temporal_rs_PlainDate_to_zoned_date_time_with_provider_result temporal_rs_PlainDate_to_zoned_date_time_with_provider(const temporal_rs::capi::PlainDate* self, temporal_rs::capi::TimeZone time_zone, const temporal_rs::capi::PlainTime* time, const temporal_rs::capi::Provider* p);
 
     void temporal_rs_PlainDate_to_ixdtf_string(const temporal_rs::capi::PlainDate* self, temporal_rs::capi::DisplayCalendar display_calendar, diplomat::capi::DiplomatWrite* write);
 
@@ -180,13 +180,13 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::Te
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::from_epoch_milliseconds(int64_t ms, const temporal_rs::TimeZone& tz) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::from_epoch_milliseconds(int64_t ms, temporal_rs::TimeZone tz) {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_from_epoch_milliseconds(ms,
     tz.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::from_epoch_milliseconds_with_provider(int64_t ms, const temporal_rs::TimeZone& tz, const temporal_rs::Provider& p) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p) {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_from_epoch_milliseconds_with_provider(ms,
     tz.AsFFI(),
     p.AsFFI());
@@ -375,14 +375,14 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_r
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainYearMonth>>(std::unique_ptr<temporal_rs::PlainYearMonth>(temporal_rs::PlainYearMonth::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDate::to_zoned_date_time(const temporal_rs::TimeZone& time_zone, const temporal_rs::PlainTime* time) const {
+inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDate::to_zoned_date_time(temporal_rs::TimeZone time_zone, const temporal_rs::PlainTime* time) const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_to_zoned_date_time(this->AsFFI(),
     time_zone.AsFFI(),
     time ? time->AsFFI() : nullptr);
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::ZonedDateTime>>(std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDate::to_zoned_date_time_with_provider(const temporal_rs::TimeZone& time_zone, const temporal_rs::PlainTime* time, const temporal_rs::Provider& p) const {
+inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDate::to_zoned_date_time_with_provider(temporal_rs::TimeZone time_zone, const temporal_rs::PlainTime* time, const temporal_rs::Provider& p) const {
   auto result = temporal_rs::capi::temporal_rs_PlainDate_to_zoned_date_time_with_provider(this->AsFFI(),
     time_zone.AsFFI(),
     time ? time->AsFFI() : nullptr,

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
@@ -26,14 +26,13 @@ namespace capi { struct PlainTime; }
 class PlainTime;
 namespace capi { struct Provider; }
 class Provider;
-namespace capi { struct TimeZone; }
-class TimeZone;
 namespace capi { struct ZonedDateTime; }
 class ZonedDateTime;
 struct DifferenceSettings;
 struct PartialDateTime;
 struct RoundingOptions;
 struct TemporalError;
+struct TimeZone;
 struct ToStringRoundingOptions;
 class AnyCalendarKind;
 class ArithmeticOverflow;
@@ -60,9 +59,9 @@ public:
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> from_parsed(const temporal_rs::ParsedDateTime& parsed);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> from_epoch_milliseconds(int64_t ms, const temporal_rs::TimeZone& tz);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> from_epoch_milliseconds(int64_t ms, temporal_rs::TimeZone tz);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> from_epoch_milliseconds_with_provider(int64_t ms, const temporal_rs::TimeZone& tz, const temporal_rs::Provider& p);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> with(temporal_rs::PartialDateTime partial, std::optional<temporal_rs::ArithmeticOverflow> overflow) const;
 
@@ -140,9 +139,9 @@ public:
 
   inline std::unique_ptr<temporal_rs::PlainTime> to_plain_time() const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> to_zoned_date_time(const temporal_rs::TimeZone& time_zone, temporal_rs::Disambiguation disambiguation) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> to_zoned_date_time(temporal_rs::TimeZone time_zone, temporal_rs::Disambiguation disambiguation) const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> to_zoned_date_time_with_provider(const temporal_rs::TimeZone& time_zone, temporal_rs::Disambiguation disambiguation, const temporal_rs::Provider& p) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> to_zoned_date_time_with_provider(temporal_rs::TimeZone time_zone, temporal_rs::Disambiguation disambiguation, const temporal_rs::Provider& p) const;
 
   inline diplomat::result<std::string, temporal_rs::TemporalError> to_ixdtf_string(temporal_rs::ToStringRoundingOptions options, temporal_rs::DisplayCalendar display_calendar) const;
   template<typename W>

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
@@ -48,10 +48,10 @@ namespace capi {
     temporal_rs_PlainDateTime_from_parsed_result temporal_rs_PlainDateTime_from_parsed(const temporal_rs::capi::ParsedDateTime* parsed);
 
     typedef struct temporal_rs_PlainDateTime_from_epoch_milliseconds_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_epoch_milliseconds_result;
-    temporal_rs_PlainDateTime_from_epoch_milliseconds_result temporal_rs_PlainDateTime_from_epoch_milliseconds(int64_t ms, const temporal_rs::capi::TimeZone* tz);
+    temporal_rs_PlainDateTime_from_epoch_milliseconds_result temporal_rs_PlainDateTime_from_epoch_milliseconds(int64_t ms, temporal_rs::capi::TimeZone tz);
 
     typedef struct temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider_result;
-    temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider_result temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider(int64_t ms, const temporal_rs::capi::TimeZone* tz, const temporal_rs::capi::Provider* p);
+    temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider_result temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
 
     typedef struct temporal_rs_PlainDateTime_with_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_with_result;
     temporal_rs_PlainDateTime_with_result temporal_rs_PlainDateTime_with(const temporal_rs::capi::PlainDateTime* self, temporal_rs::capi::PartialDateTime partial, temporal_rs::capi::ArithmeticOverflow_option overflow);
@@ -138,10 +138,10 @@ namespace capi {
     temporal_rs::capi::PlainTime* temporal_rs_PlainDateTime_to_plain_time(const temporal_rs::capi::PlainDateTime* self);
 
     typedef struct temporal_rs_PlainDateTime_to_zoned_date_time_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_to_zoned_date_time_result;
-    temporal_rs_PlainDateTime_to_zoned_date_time_result temporal_rs_PlainDateTime_to_zoned_date_time(const temporal_rs::capi::PlainDateTime* self, const temporal_rs::capi::TimeZone* time_zone, temporal_rs::capi::Disambiguation disambiguation);
+    temporal_rs_PlainDateTime_to_zoned_date_time_result temporal_rs_PlainDateTime_to_zoned_date_time(const temporal_rs::capi::PlainDateTime* self, temporal_rs::capi::TimeZone time_zone, temporal_rs::capi::Disambiguation disambiguation);
 
     typedef struct temporal_rs_PlainDateTime_to_zoned_date_time_with_provider_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_to_zoned_date_time_with_provider_result;
-    temporal_rs_PlainDateTime_to_zoned_date_time_with_provider_result temporal_rs_PlainDateTime_to_zoned_date_time_with_provider(const temporal_rs::capi::PlainDateTime* self, const temporal_rs::capi::TimeZone* time_zone, temporal_rs::capi::Disambiguation disambiguation, const temporal_rs::capi::Provider* p);
+    temporal_rs_PlainDateTime_to_zoned_date_time_with_provider_result temporal_rs_PlainDateTime_to_zoned_date_time_with_provider(const temporal_rs::capi::PlainDateTime* self, temporal_rs::capi::TimeZone time_zone, temporal_rs::capi::Disambiguation disambiguation, const temporal_rs::capi::Provider* p);
 
     typedef struct temporal_rs_PlainDateTime_to_ixdtf_string_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_to_ixdtf_string_result;
     temporal_rs_PlainDateTime_to_ixdtf_string_result temporal_rs_PlainDateTime_to_ixdtf_string(const temporal_rs::capi::PlainDateTime* self, temporal_rs::capi::ToStringRoundingOptions options, temporal_rs::capi::DisplayCalendar display_calendar, diplomat::capi::DiplomatWrite* write);
@@ -193,13 +193,13 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDateTime>>(std::unique_ptr<temporal_rs::PlainDateTime>(temporal_rs::PlainDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::from_epoch_milliseconds(int64_t ms, const temporal_rs::TimeZone& tz) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::from_epoch_milliseconds(int64_t ms, temporal_rs::TimeZone tz) {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_from_epoch_milliseconds(ms,
     tz.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDateTime>>(std::unique_ptr<temporal_rs::PlainDateTime>(temporal_rs::PlainDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::from_epoch_milliseconds_with_provider(int64_t ms, const temporal_rs::TimeZone& tz, const temporal_rs::Provider& p) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p) {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider(ms,
     tz.AsFFI(),
     p.AsFFI());
@@ -419,14 +419,14 @@ inline std::unique_ptr<temporal_rs::PlainTime> temporal_rs::PlainDateTime::to_pl
   return std::unique_ptr<temporal_rs::PlainTime>(temporal_rs::PlainTime::FromFFI(result));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::to_zoned_date_time(const temporal_rs::TimeZone& time_zone, temporal_rs::Disambiguation disambiguation) const {
+inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::to_zoned_date_time(temporal_rs::TimeZone time_zone, temporal_rs::Disambiguation disambiguation) const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_to_zoned_date_time(this->AsFFI(),
     time_zone.AsFFI(),
     disambiguation.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::ZonedDateTime>>(std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::to_zoned_date_time_with_provider(const temporal_rs::TimeZone& time_zone, temporal_rs::Disambiguation disambiguation, const temporal_rs::Provider& p) const {
+inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::to_zoned_date_time_with_provider(temporal_rs::TimeZone time_zone, temporal_rs::Disambiguation disambiguation, const temporal_rs::Provider& p) const {
   auto result = temporal_rs::capi::temporal_rs_PlainDateTime_to_zoned_date_time_with_provider(this->AsFFI(),
     time_zone.AsFFI(),
     disambiguation.AsFFI(),

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
@@ -22,10 +22,9 @@ namespace capi { struct PlainMonthDay; }
 class PlainMonthDay;
 namespace capi { struct Provider; }
 class Provider;
-namespace capi { struct TimeZone; }
-class TimeZone;
 struct PartialDate;
 struct TemporalError;
+struct TimeZone;
 class AnyCalendarKind;
 class ArithmeticOverflow;
 class DisplayCalendar;
@@ -66,9 +65,9 @@ public:
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> to_plain_date(std::optional<temporal_rs::PartialDate> year) const;
 
-  inline diplomat::result<int64_t, temporal_rs::TemporalError> epoch_ms_for(const temporal_rs::TimeZone& time_zone) const;
+  inline diplomat::result<int64_t, temporal_rs::TemporalError> epoch_ms_for(temporal_rs::TimeZone time_zone) const;
 
-  inline diplomat::result<int64_t, temporal_rs::TemporalError> epoch_ms_for_with_provider(const temporal_rs::TimeZone& time_zone, const temporal_rs::Provider& p) const;
+  inline diplomat::result<int64_t, temporal_rs::TemporalError> epoch_ms_for_with_provider(temporal_rs::TimeZone time_zone, const temporal_rs::Provider& p) const;
 
   inline std::string to_ixdtf_string(temporal_rs::DisplayCalendar display_calendar) const;
   template<typename W>

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
@@ -58,10 +58,10 @@ namespace capi {
     temporal_rs_PlainMonthDay_to_plain_date_result temporal_rs_PlainMonthDay_to_plain_date(const temporal_rs::capi::PlainMonthDay* self, temporal_rs::capi::PartialDate_option year);
 
     typedef struct temporal_rs_PlainMonthDay_epoch_ms_for_result {union {int64_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_epoch_ms_for_result;
-    temporal_rs_PlainMonthDay_epoch_ms_for_result temporal_rs_PlainMonthDay_epoch_ms_for(const temporal_rs::capi::PlainMonthDay* self, const temporal_rs::capi::TimeZone* time_zone);
+    temporal_rs_PlainMonthDay_epoch_ms_for_result temporal_rs_PlainMonthDay_epoch_ms_for(const temporal_rs::capi::PlainMonthDay* self, temporal_rs::capi::TimeZone time_zone);
 
     typedef struct temporal_rs_PlainMonthDay_epoch_ms_for_with_provider_result {union {int64_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainMonthDay_epoch_ms_for_with_provider_result;
-    temporal_rs_PlainMonthDay_epoch_ms_for_with_provider_result temporal_rs_PlainMonthDay_epoch_ms_for_with_provider(const temporal_rs::capi::PlainMonthDay* self, const temporal_rs::capi::TimeZone* time_zone, const temporal_rs::capi::Provider* p);
+    temporal_rs_PlainMonthDay_epoch_ms_for_with_provider_result temporal_rs_PlainMonthDay_epoch_ms_for_with_provider(const temporal_rs::capi::PlainMonthDay* self, temporal_rs::capi::TimeZone time_zone, const temporal_rs::capi::Provider* p);
 
     void temporal_rs_PlainMonthDay_to_ixdtf_string(const temporal_rs::capi::PlainMonthDay* self, temporal_rs::capi::DisplayCalendar display_calendar, diplomat::capi::DiplomatWrite* write);
 
@@ -146,13 +146,13 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::Te
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<int64_t, temporal_rs::TemporalError> temporal_rs::PlainMonthDay::epoch_ms_for(const temporal_rs::TimeZone& time_zone) const {
+inline diplomat::result<int64_t, temporal_rs::TemporalError> temporal_rs::PlainMonthDay::epoch_ms_for(temporal_rs::TimeZone time_zone) const {
   auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_epoch_ms_for(this->AsFFI(),
     time_zone.AsFFI());
   return result.is_ok ? diplomat::result<int64_t, temporal_rs::TemporalError>(diplomat::Ok<int64_t>(result.ok)) : diplomat::result<int64_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<int64_t, temporal_rs::TemporalError> temporal_rs::PlainMonthDay::epoch_ms_for_with_provider(const temporal_rs::TimeZone& time_zone, const temporal_rs::Provider& p) const {
+inline diplomat::result<int64_t, temporal_rs::TemporalError> temporal_rs::PlainMonthDay::epoch_ms_for_with_provider(temporal_rs::TimeZone time_zone, const temporal_rs::Provider& p) const {
   auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_epoch_ms_for_with_provider(this->AsFFI(),
     time_zone.AsFFI(),
     p.AsFFI());

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainTime.d.hpp
@@ -18,12 +18,11 @@ namespace capi { struct PlainTime; }
 class PlainTime;
 namespace capi { struct Provider; }
 class Provider;
-namespace capi { struct TimeZone; }
-class TimeZone;
 struct DifferenceSettings;
 struct PartialTime;
 struct RoundingOptions;
 struct TemporalError;
+struct TimeZone;
 struct ToStringRoundingOptions;
 class ArithmeticOverflow;
 }
@@ -45,9 +44,9 @@ public:
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> from_partial(temporal_rs::PartialTime partial, std::optional<temporal_rs::ArithmeticOverflow> overflow);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> from_epoch_milliseconds(int64_t ms, const temporal_rs::TimeZone& tz);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> from_epoch_milliseconds(int64_t ms, temporal_rs::TimeZone tz);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> from_epoch_milliseconds_with_provider(int64_t ms, const temporal_rs::TimeZone& tz, const temporal_rs::Provider& p);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> with(temporal_rs::PartialTime partial, std::optional<temporal_rs::ArithmeticOverflow> overflow) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainTime.hpp
@@ -37,10 +37,10 @@ namespace capi {
     temporal_rs_PlainTime_from_partial_result temporal_rs_PlainTime_from_partial(temporal_rs::capi::PartialTime partial, temporal_rs::capi::ArithmeticOverflow_option overflow);
 
     typedef struct temporal_rs_PlainTime_from_epoch_milliseconds_result {union {temporal_rs::capi::PlainTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_from_epoch_milliseconds_result;
-    temporal_rs_PlainTime_from_epoch_milliseconds_result temporal_rs_PlainTime_from_epoch_milliseconds(int64_t ms, const temporal_rs::capi::TimeZone* tz);
+    temporal_rs_PlainTime_from_epoch_milliseconds_result temporal_rs_PlainTime_from_epoch_milliseconds(int64_t ms, temporal_rs::capi::TimeZone tz);
 
     typedef struct temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result {union {temporal_rs::capi::PlainTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result;
-    temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result temporal_rs_PlainTime_from_epoch_milliseconds_with_provider(int64_t ms, const temporal_rs::capi::TimeZone* tz, const temporal_rs::capi::Provider* p);
+    temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result temporal_rs_PlainTime_from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
 
     typedef struct temporal_rs_PlainTime_with_result {union {temporal_rs::capi::PlainTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_with_result;
     temporal_rs_PlainTime_with_result temporal_rs_PlainTime_with(const temporal_rs::capi::PlainTime* self, temporal_rs::capi::PartialTime partial, temporal_rs::capi::ArithmeticOverflow_option overflow);
@@ -119,13 +119,13 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::Te
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainTime>>(std::unique_ptr<temporal_rs::PlainTime>(temporal_rs::PlainTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> temporal_rs::PlainTime::from_epoch_milliseconds(int64_t ms, const temporal_rs::TimeZone& tz) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> temporal_rs::PlainTime::from_epoch_milliseconds(int64_t ms, temporal_rs::TimeZone tz) {
   auto result = temporal_rs::capi::temporal_rs_PlainTime_from_epoch_milliseconds(ms,
     tz.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainTime>>(std::unique_ptr<temporal_rs::PlainTime>(temporal_rs::PlainTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> temporal_rs::PlainTime::from_epoch_milliseconds_with_provider(int64_t ms, const temporal_rs::TimeZone& tz, const temporal_rs::Provider& p) {
+inline diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> temporal_rs::PlainTime::from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p) {
   auto result = temporal_rs::capi::temporal_rs_PlainTime_from_epoch_milliseconds_with_provider(ms,
     tz.AsFFI(),
     p.AsFFI());

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.d.hpp
@@ -24,11 +24,10 @@ namespace capi { struct PlainYearMonth; }
 class PlainYearMonth;
 namespace capi { struct Provider; }
 class Provider;
-namespace capi { struct TimeZone; }
-class TimeZone;
 struct DifferenceSettings;
 struct PartialDate;
 struct TemporalError;
+struct TimeZone;
 class AnyCalendarKind;
 class ArithmeticOverflow;
 class DisplayCalendar;
@@ -95,9 +94,9 @@ public:
 
   inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> to_plain_date(std::optional<temporal_rs::PartialDate> day) const;
 
-  inline diplomat::result<int64_t, temporal_rs::TemporalError> epoch_ms_for(const temporal_rs::TimeZone& time_zone) const;
+  inline diplomat::result<int64_t, temporal_rs::TemporalError> epoch_ms_for(temporal_rs::TimeZone time_zone) const;
 
-  inline diplomat::result<int64_t, temporal_rs::TemporalError> epoch_ms_for_with_provider(const temporal_rs::TimeZone& time_zone, const temporal_rs::Provider& p) const;
+  inline diplomat::result<int64_t, temporal_rs::TemporalError> epoch_ms_for_with_provider(temporal_rs::TimeZone time_zone, const temporal_rs::Provider& p) const;
 
   inline std::string to_ixdtf_string(temporal_rs::DisplayCalendar display_calendar) const;
   template<typename W>

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.hpp
@@ -89,10 +89,10 @@ namespace capi {
     temporal_rs_PlainYearMonth_to_plain_date_result temporal_rs_PlainYearMonth_to_plain_date(const temporal_rs::capi::PlainYearMonth* self, temporal_rs::capi::PartialDate_option day);
 
     typedef struct temporal_rs_PlainYearMonth_epoch_ms_for_result {union {int64_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_epoch_ms_for_result;
-    temporal_rs_PlainYearMonth_epoch_ms_for_result temporal_rs_PlainYearMonth_epoch_ms_for(const temporal_rs::capi::PlainYearMonth* self, const temporal_rs::capi::TimeZone* time_zone);
+    temporal_rs_PlainYearMonth_epoch_ms_for_result temporal_rs_PlainYearMonth_epoch_ms_for(const temporal_rs::capi::PlainYearMonth* self, temporal_rs::capi::TimeZone time_zone);
 
     typedef struct temporal_rs_PlainYearMonth_epoch_ms_for_with_provider_result {union {int64_t ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainYearMonth_epoch_ms_for_with_provider_result;
-    temporal_rs_PlainYearMonth_epoch_ms_for_with_provider_result temporal_rs_PlainYearMonth_epoch_ms_for_with_provider(const temporal_rs::capi::PlainYearMonth* self, const temporal_rs::capi::TimeZone* time_zone, const temporal_rs::capi::Provider* p);
+    temporal_rs_PlainYearMonth_epoch_ms_for_with_provider_result temporal_rs_PlainYearMonth_epoch_ms_for_with_provider(const temporal_rs::capi::PlainYearMonth* self, temporal_rs::capi::TimeZone time_zone, const temporal_rs::capi::Provider* p);
 
     void temporal_rs_PlainYearMonth_to_ixdtf_string(const temporal_rs::capi::PlainYearMonth* self, temporal_rs::capi::DisplayCalendar display_calendar, diplomat::capi::DiplomatWrite* write);
 
@@ -255,13 +255,13 @@ inline diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::Te
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<int64_t, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::epoch_ms_for(const temporal_rs::TimeZone& time_zone) const {
+inline diplomat::result<int64_t, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::epoch_ms_for(temporal_rs::TimeZone time_zone) const {
   auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_epoch_ms_for(this->AsFFI(),
     time_zone.AsFFI());
   return result.is_ok ? diplomat::result<int64_t, temporal_rs::TemporalError>(diplomat::Ok<int64_t>(result.ok)) : diplomat::result<int64_t, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<int64_t, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::epoch_ms_for_with_provider(const temporal_rs::TimeZone& time_zone, const temporal_rs::Provider& p) const {
+inline diplomat::result<int64_t, temporal_rs::TemporalError> temporal_rs::PlainYearMonth::epoch_ms_for_with_provider(temporal_rs::TimeZone time_zone, const temporal_rs::Provider& p) const {
   auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_epoch_ms_for_with_provider(this->AsFFI(),
     time_zone.AsFFI(),
     p.AsFFI());

--- a/temporal_capi/bindings/cpp/temporal_rs/TimeZone.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/TimeZone.d.hpp
@@ -14,31 +14,46 @@
 namespace temporal_rs {
 namespace capi { struct Provider; }
 class Provider;
-namespace capi { struct TimeZone; }
-class TimeZone;
 struct TemporalError;
+struct TimeZone;
 }
 
 
 namespace temporal_rs {
 namespace capi {
-    struct TimeZone;
+    struct TimeZone {
+      int16_t offset_minutes;
+      size_t resolved_id;
+      size_t normalized_id;
+      bool is_iana_id;
+    };
+
+    typedef struct TimeZone_option {union { TimeZone ok; }; bool is_ok; } TimeZone_option;
 } // namespace capi
 } // namespace
 
+
 namespace temporal_rs {
-class TimeZone {
-public:
+/**
+ * A type representing a time zone over FFI.
+ *
+ * It is not recommended to directly manipulate the fields of this type.
+ */
+struct TimeZone {
+  int16_t offset_minutes;
+  size_t resolved_id;
+  size_t normalized_id;
+  bool is_iana_id;
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> try_from_identifier_str(std::string_view ident);
+  inline static diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> try_from_identifier_str(std::string_view ident);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> try_from_identifier_str_with_provider(std::string_view ident, const temporal_rs::Provider& p);
+  inline static diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> try_from_identifier_str_with_provider(std::string_view ident, const temporal_rs::Provider& p);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> try_from_offset_str(std::string_view ident);
+  inline static diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> try_from_offset_str(std::string_view ident);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> try_from_str(std::string_view ident);
+  inline static diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> try_from_str(std::string_view ident);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> try_from_str_with_provider(std::string_view ident, const temporal_rs::Provider& p);
+  inline static diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> try_from_str_with_provider(std::string_view ident, const temporal_rs::Provider& p);
 
   inline std::string identifier() const;
   template<typename W>
@@ -48,9 +63,9 @@ public:
   template<typename W>
   inline diplomat::result<std::monostate, temporal_rs::TemporalError> identifier_with_provider_write(const temporal_rs::Provider& p, W& writeable_output) const;
 
-  inline static std::unique_ptr<temporal_rs::TimeZone> utc();
+  inline static temporal_rs::TimeZone utc();
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> utc_with_provider(const temporal_rs::Provider& p);
+  inline static diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> utc_with_provider(const temporal_rs::Provider& p);
 
   /**
    * Create a TimeZone that represents +00:00
@@ -58,29 +73,17 @@ public:
    * This is the only way to infallibly make a TimeZone without compiled_data,
    * and can be used as a fallback.
    */
-  inline static std::unique_ptr<temporal_rs::TimeZone> zero();
-
-  inline std::unique_ptr<temporal_rs::TimeZone> clone() const;
+  inline static temporal_rs::TimeZone zero();
 
   /**
    * Get the primary time zone identifier corresponding to this time zone
    */
-  inline diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> primary_identifier() const;
+  inline diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> primary_identifier() const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> primary_identifier_with_provider(const temporal_rs::Provider& p) const;
+  inline diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> primary_identifier_with_provider(const temporal_rs::Provider& p) const;
 
-  inline const temporal_rs::capi::TimeZone* AsFFI() const;
-  inline temporal_rs::capi::TimeZone* AsFFI();
-  inline static const temporal_rs::TimeZone* FromFFI(const temporal_rs::capi::TimeZone* ptr);
-  inline static temporal_rs::TimeZone* FromFFI(temporal_rs::capi::TimeZone* ptr);
-  inline static void operator delete(void* ptr);
-private:
-  TimeZone() = delete;
-  TimeZone(const temporal_rs::TimeZone&) = delete;
-  TimeZone(temporal_rs::TimeZone&&) noexcept = delete;
-  TimeZone operator=(const temporal_rs::TimeZone&) = delete;
-  TimeZone operator=(temporal_rs::TimeZone&&) noexcept = delete;
-  static void operator delete[](void*, size_t) = delete;
+  inline temporal_rs::capi::TimeZone AsFFI() const;
+  inline static temporal_rs::TimeZone FromFFI(temporal_rs::capi::TimeZone c_struct);
 };
 
 } // namespace

--- a/temporal_capi/bindings/cpp/temporal_rs/TimeZone.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/TimeZone.hpp
@@ -20,72 +20,68 @@ namespace temporal_rs {
 namespace capi {
     extern "C" {
 
-    typedef struct temporal_rs_TimeZone_try_from_identifier_str_result {union {temporal_rs::capi::TimeZone* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_identifier_str_result;
+    typedef struct temporal_rs_TimeZone_try_from_identifier_str_result {union {temporal_rs::capi::TimeZone ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_identifier_str_result;
     temporal_rs_TimeZone_try_from_identifier_str_result temporal_rs_TimeZone_try_from_identifier_str(diplomat::capi::DiplomatStringView ident);
 
-    typedef struct temporal_rs_TimeZone_try_from_identifier_str_with_provider_result {union {temporal_rs::capi::TimeZone* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_identifier_str_with_provider_result;
+    typedef struct temporal_rs_TimeZone_try_from_identifier_str_with_provider_result {union {temporal_rs::capi::TimeZone ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_identifier_str_with_provider_result;
     temporal_rs_TimeZone_try_from_identifier_str_with_provider_result temporal_rs_TimeZone_try_from_identifier_str_with_provider(diplomat::capi::DiplomatStringView ident, const temporal_rs::capi::Provider* p);
 
-    typedef struct temporal_rs_TimeZone_try_from_offset_str_result {union {temporal_rs::capi::TimeZone* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_offset_str_result;
+    typedef struct temporal_rs_TimeZone_try_from_offset_str_result {union {temporal_rs::capi::TimeZone ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_offset_str_result;
     temporal_rs_TimeZone_try_from_offset_str_result temporal_rs_TimeZone_try_from_offset_str(diplomat::capi::DiplomatStringView ident);
 
-    typedef struct temporal_rs_TimeZone_try_from_str_result {union {temporal_rs::capi::TimeZone* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_str_result;
+    typedef struct temporal_rs_TimeZone_try_from_str_result {union {temporal_rs::capi::TimeZone ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_str_result;
     temporal_rs_TimeZone_try_from_str_result temporal_rs_TimeZone_try_from_str(diplomat::capi::DiplomatStringView ident);
 
-    typedef struct temporal_rs_TimeZone_try_from_str_with_provider_result {union {temporal_rs::capi::TimeZone* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_str_with_provider_result;
+    typedef struct temporal_rs_TimeZone_try_from_str_with_provider_result {union {temporal_rs::capi::TimeZone ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_try_from_str_with_provider_result;
     temporal_rs_TimeZone_try_from_str_with_provider_result temporal_rs_TimeZone_try_from_str_with_provider(diplomat::capi::DiplomatStringView ident, const temporal_rs::capi::Provider* p);
 
-    void temporal_rs_TimeZone_identifier(const temporal_rs::capi::TimeZone* self, diplomat::capi::DiplomatWrite* write);
+    void temporal_rs_TimeZone_identifier(temporal_rs::capi::TimeZone self, diplomat::capi::DiplomatWrite* write);
 
     typedef struct temporal_rs_TimeZone_identifier_with_provider_result {union { temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_identifier_with_provider_result;
-    temporal_rs_TimeZone_identifier_with_provider_result temporal_rs_TimeZone_identifier_with_provider(const temporal_rs::capi::TimeZone* self, const temporal_rs::capi::Provider* p, diplomat::capi::DiplomatWrite* write);
+    temporal_rs_TimeZone_identifier_with_provider_result temporal_rs_TimeZone_identifier_with_provider(temporal_rs::capi::TimeZone self, const temporal_rs::capi::Provider* p, diplomat::capi::DiplomatWrite* write);
 
-    temporal_rs::capi::TimeZone* temporal_rs_TimeZone_utc(void);
+    temporal_rs::capi::TimeZone temporal_rs_TimeZone_utc(void);
 
-    typedef struct temporal_rs_TimeZone_utc_with_provider_result {union {temporal_rs::capi::TimeZone* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_utc_with_provider_result;
+    typedef struct temporal_rs_TimeZone_utc_with_provider_result {union {temporal_rs::capi::TimeZone ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_utc_with_provider_result;
     temporal_rs_TimeZone_utc_with_provider_result temporal_rs_TimeZone_utc_with_provider(const temporal_rs::capi::Provider* p);
 
-    temporal_rs::capi::TimeZone* temporal_rs_TimeZone_zero(void);
+    temporal_rs::capi::TimeZone temporal_rs_TimeZone_zero(void);
 
-    temporal_rs::capi::TimeZone* temporal_rs_TimeZone_clone(const temporal_rs::capi::TimeZone* self);
+    typedef struct temporal_rs_TimeZone_primary_identifier_result {union {temporal_rs::capi::TimeZone ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_primary_identifier_result;
+    temporal_rs_TimeZone_primary_identifier_result temporal_rs_TimeZone_primary_identifier(temporal_rs::capi::TimeZone self);
 
-    typedef struct temporal_rs_TimeZone_primary_identifier_result {union {temporal_rs::capi::TimeZone* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_primary_identifier_result;
-    temporal_rs_TimeZone_primary_identifier_result temporal_rs_TimeZone_primary_identifier(const temporal_rs::capi::TimeZone* self);
-
-    typedef struct temporal_rs_TimeZone_primary_identifier_with_provider_result {union {temporal_rs::capi::TimeZone* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_primary_identifier_with_provider_result;
-    temporal_rs_TimeZone_primary_identifier_with_provider_result temporal_rs_TimeZone_primary_identifier_with_provider(const temporal_rs::capi::TimeZone* self, const temporal_rs::capi::Provider* p);
-
-    void temporal_rs_TimeZone_destroy(TimeZone* self);
+    typedef struct temporal_rs_TimeZone_primary_identifier_with_provider_result {union {temporal_rs::capi::TimeZone ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_TimeZone_primary_identifier_with_provider_result;
+    temporal_rs_TimeZone_primary_identifier_with_provider_result temporal_rs_TimeZone_primary_identifier_with_provider(temporal_rs::capi::TimeZone self, const temporal_rs::capi::Provider* p);
 
     } // extern "C"
 } // namespace capi
 } // namespace
 
-inline diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> temporal_rs::TimeZone::try_from_identifier_str(std::string_view ident) {
+inline diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> temporal_rs::TimeZone::try_from_identifier_str(std::string_view ident) {
   auto result = temporal_rs::capi::temporal_rs_TimeZone_try_from_identifier_str({ident.data(), ident.size()});
-  return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::TimeZone>>(std::unique_ptr<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Ok<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok))) : diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> temporal_rs::TimeZone::try_from_identifier_str_with_provider(std::string_view ident, const temporal_rs::Provider& p) {
+inline diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> temporal_rs::TimeZone::try_from_identifier_str_with_provider(std::string_view ident, const temporal_rs::Provider& p) {
   auto result = temporal_rs::capi::temporal_rs_TimeZone_try_from_identifier_str_with_provider({ident.data(), ident.size()},
     p.AsFFI());
-  return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::TimeZone>>(std::unique_ptr<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Ok<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok))) : diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> temporal_rs::TimeZone::try_from_offset_str(std::string_view ident) {
+inline diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> temporal_rs::TimeZone::try_from_offset_str(std::string_view ident) {
   auto result = temporal_rs::capi::temporal_rs_TimeZone_try_from_offset_str({ident.data(), ident.size()});
-  return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::TimeZone>>(std::unique_ptr<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Ok<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok))) : diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> temporal_rs::TimeZone::try_from_str(std::string_view ident) {
+inline diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> temporal_rs::TimeZone::try_from_str(std::string_view ident) {
   auto result = temporal_rs::capi::temporal_rs_TimeZone_try_from_str({ident.data(), ident.size()});
-  return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::TimeZone>>(std::unique_ptr<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Ok<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok))) : diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> temporal_rs::TimeZone::try_from_str_with_provider(std::string_view ident, const temporal_rs::Provider& p) {
+inline diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> temporal_rs::TimeZone::try_from_str_with_provider(std::string_view ident, const temporal_rs::Provider& p) {
   auto result = temporal_rs::capi::temporal_rs_TimeZone_try_from_str_with_provider({ident.data(), ident.size()},
     p.AsFFI());
-  return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::TimeZone>>(std::unique_ptr<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Ok<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok))) : diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
 inline std::string temporal_rs::TimeZone::identifier() const {
@@ -119,55 +115,49 @@ inline diplomat::result<std::monostate, temporal_rs::TemporalError> temporal_rs:
   return result.is_ok ? diplomat::result<std::monostate, temporal_rs::TemporalError>(diplomat::Ok<std::monostate>()) : diplomat::result<std::monostate, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline std::unique_ptr<temporal_rs::TimeZone> temporal_rs::TimeZone::utc() {
+inline temporal_rs::TimeZone temporal_rs::TimeZone::utc() {
   auto result = temporal_rs::capi::temporal_rs_TimeZone_utc();
-  return std::unique_ptr<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result));
+  return temporal_rs::TimeZone::FromFFI(result);
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> temporal_rs::TimeZone::utc_with_provider(const temporal_rs::Provider& p) {
+inline diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> temporal_rs::TimeZone::utc_with_provider(const temporal_rs::Provider& p) {
   auto result = temporal_rs::capi::temporal_rs_TimeZone_utc_with_provider(p.AsFFI());
-  return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::TimeZone>>(std::unique_ptr<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Ok<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok))) : diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline std::unique_ptr<temporal_rs::TimeZone> temporal_rs::TimeZone::zero() {
+inline temporal_rs::TimeZone temporal_rs::TimeZone::zero() {
   auto result = temporal_rs::capi::temporal_rs_TimeZone_zero();
-  return std::unique_ptr<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result));
+  return temporal_rs::TimeZone::FromFFI(result);
 }
 
-inline std::unique_ptr<temporal_rs::TimeZone> temporal_rs::TimeZone::clone() const {
-  auto result = temporal_rs::capi::temporal_rs_TimeZone_clone(this->AsFFI());
-  return std::unique_ptr<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result));
-}
-
-inline diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> temporal_rs::TimeZone::primary_identifier() const {
+inline diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> temporal_rs::TimeZone::primary_identifier() const {
   auto result = temporal_rs::capi::temporal_rs_TimeZone_primary_identifier(this->AsFFI());
-  return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::TimeZone>>(std::unique_ptr<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Ok<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok))) : diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError> temporal_rs::TimeZone::primary_identifier_with_provider(const temporal_rs::Provider& p) const {
+inline diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError> temporal_rs::TimeZone::primary_identifier_with_provider(const temporal_rs::Provider& p) const {
   auto result = temporal_rs::capi::temporal_rs_TimeZone_primary_identifier_with_provider(this->AsFFI(),
     p.AsFFI());
-  return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::TimeZone>>(std::unique_ptr<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::TimeZone>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+  return result.is_ok ? diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Ok<temporal_rs::TimeZone>(temporal_rs::TimeZone::FromFFI(result.ok))) : diplomat::result<temporal_rs::TimeZone, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline const temporal_rs::capi::TimeZone* temporal_rs::TimeZone::AsFFI() const {
-  return reinterpret_cast<const temporal_rs::capi::TimeZone*>(this);
+
+inline temporal_rs::capi::TimeZone temporal_rs::TimeZone::AsFFI() const {
+  return temporal_rs::capi::TimeZone {
+    /* .offset_minutes = */ offset_minutes,
+    /* .resolved_id = */ resolved_id,
+    /* .normalized_id = */ normalized_id,
+    /* .is_iana_id = */ is_iana_id,
+  };
 }
 
-inline temporal_rs::capi::TimeZone* temporal_rs::TimeZone::AsFFI() {
-  return reinterpret_cast<temporal_rs::capi::TimeZone*>(this);
-}
-
-inline const temporal_rs::TimeZone* temporal_rs::TimeZone::FromFFI(const temporal_rs::capi::TimeZone* ptr) {
-  return reinterpret_cast<const temporal_rs::TimeZone*>(ptr);
-}
-
-inline temporal_rs::TimeZone* temporal_rs::TimeZone::FromFFI(temporal_rs::capi::TimeZone* ptr) {
-  return reinterpret_cast<temporal_rs::TimeZone*>(ptr);
-}
-
-inline void temporal_rs::TimeZone::operator delete(void* ptr) {
-  temporal_rs::capi::temporal_rs_TimeZone_destroy(reinterpret_cast<temporal_rs::capi::TimeZone*>(ptr));
+inline temporal_rs::TimeZone temporal_rs::TimeZone::FromFFI(temporal_rs::capi::TimeZone c_struct) {
+  return temporal_rs::TimeZone {
+    /* .offset_minutes = */ c_struct.offset_minutes,
+    /* .resolved_id = */ c_struct.resolved_id,
+    /* .normalized_id = */ c_struct.normalized_id,
+    /* .is_iana_id = */ c_struct.is_iana_id,
+  };
 }
 
 

--- a/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.d.hpp
@@ -28,8 +28,6 @@ namespace capi { struct PlainTime; }
 class PlainTime;
 namespace capi { struct Provider; }
 class Provider;
-namespace capi { struct TimeZone; }
-class TimeZone;
 namespace capi { struct ZonedDateTime; }
 class ZonedDateTime;
 struct DifferenceSettings;
@@ -37,6 +35,7 @@ struct I128Nanoseconds;
 struct PartialZonedDateTime;
 struct RoundingOptions;
 struct TemporalError;
+struct TimeZone;
 struct ToStringRoundingOptions;
 class AnyCalendarKind;
 class ArithmeticOverflow;
@@ -59,9 +58,9 @@ namespace temporal_rs {
 class ZonedDateTime {
 public:
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> try_new(temporal_rs::I128Nanoseconds nanosecond, temporal_rs::AnyCalendarKind calendar, const temporal_rs::TimeZone& time_zone);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> try_new(temporal_rs::I128Nanoseconds nanosecond, temporal_rs::AnyCalendarKind calendar, temporal_rs::TimeZone time_zone);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> try_new_with_provider(temporal_rs::I128Nanoseconds nanosecond, temporal_rs::AnyCalendarKind calendar, const temporal_rs::TimeZone& time_zone, const temporal_rs::Provider& p);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> try_new_with_provider(temporal_rs::I128Nanoseconds nanosecond, temporal_rs::AnyCalendarKind calendar, temporal_rs::TimeZone time_zone, const temporal_rs::Provider& p);
 
   inline static diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> from_partial(temporal_rs::PartialZonedDateTime partial, std::optional<temporal_rs::ArithmeticOverflow> overflow, std::optional<temporal_rs::Disambiguation> disambiguation, std::optional<temporal_rs::OffsetDisambiguation> offset_option);
 
@@ -81,9 +80,9 @@ public:
 
   inline int64_t epoch_milliseconds() const;
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> from_epoch_milliseconds(int64_t ms, const temporal_rs::TimeZone& tz);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> from_epoch_milliseconds(int64_t ms, temporal_rs::TimeZone tz);
 
-  inline static diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> from_epoch_milliseconds_with_provider(int64_t ms, const temporal_rs::TimeZone& tz, const temporal_rs::Provider& p);
+  inline static diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
 
   inline temporal_rs::I128Nanoseconds epoch_nanoseconds() const;
 
@@ -95,11 +94,11 @@ public:
 
   inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> with_with_provider(temporal_rs::PartialZonedDateTime partial, std::optional<temporal_rs::Disambiguation> disambiguation, std::optional<temporal_rs::OffsetDisambiguation> offset_option, std::optional<temporal_rs::ArithmeticOverflow> overflow, const temporal_rs::Provider& p) const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> with_timezone(const temporal_rs::TimeZone& zone) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> with_timezone(temporal_rs::TimeZone zone) const;
 
-  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> with_timezone_with_provider(const temporal_rs::TimeZone& zone, const temporal_rs::Provider& p) const;
+  inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> with_timezone_with_provider(temporal_rs::TimeZone zone, const temporal_rs::Provider& p) const;
 
-  inline const temporal_rs::TimeZone& timezone() const;
+  inline temporal_rs::TimeZone timezone() const;
 
   inline int8_t compare_instant(const temporal_rs::ZonedDateTime& other) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.hpp
@@ -42,10 +42,10 @@ namespace capi {
     extern "C" {
 
     typedef struct temporal_rs_ZonedDateTime_try_new_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_try_new_result;
-    temporal_rs_ZonedDateTime_try_new_result temporal_rs_ZonedDateTime_try_new(temporal_rs::capi::I128Nanoseconds nanosecond, temporal_rs::capi::AnyCalendarKind calendar, const temporal_rs::capi::TimeZone* time_zone);
+    temporal_rs_ZonedDateTime_try_new_result temporal_rs_ZonedDateTime_try_new(temporal_rs::capi::I128Nanoseconds nanosecond, temporal_rs::capi::AnyCalendarKind calendar, temporal_rs::capi::TimeZone time_zone);
 
     typedef struct temporal_rs_ZonedDateTime_try_new_with_provider_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_try_new_with_provider_result;
-    temporal_rs_ZonedDateTime_try_new_with_provider_result temporal_rs_ZonedDateTime_try_new_with_provider(temporal_rs::capi::I128Nanoseconds nanosecond, temporal_rs::capi::AnyCalendarKind calendar, const temporal_rs::capi::TimeZone* time_zone, const temporal_rs::capi::Provider* p);
+    temporal_rs_ZonedDateTime_try_new_with_provider_result temporal_rs_ZonedDateTime_try_new_with_provider(temporal_rs::capi::I128Nanoseconds nanosecond, temporal_rs::capi::AnyCalendarKind calendar, temporal_rs::capi::TimeZone time_zone, const temporal_rs::capi::Provider* p);
 
     typedef struct temporal_rs_ZonedDateTime_from_partial_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_from_partial_result;
     temporal_rs_ZonedDateTime_from_partial_result temporal_rs_ZonedDateTime_from_partial(temporal_rs::capi::PartialZonedDateTime partial, temporal_rs::capi::ArithmeticOverflow_option overflow, temporal_rs::capi::Disambiguation_option disambiguation, temporal_rs::capi::OffsetDisambiguation_option offset_option);
@@ -74,10 +74,10 @@ namespace capi {
     int64_t temporal_rs_ZonedDateTime_epoch_milliseconds(const temporal_rs::capi::ZonedDateTime* self);
 
     typedef struct temporal_rs_ZonedDateTime_from_epoch_milliseconds_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_from_epoch_milliseconds_result;
-    temporal_rs_ZonedDateTime_from_epoch_milliseconds_result temporal_rs_ZonedDateTime_from_epoch_milliseconds(int64_t ms, const temporal_rs::capi::TimeZone* tz);
+    temporal_rs_ZonedDateTime_from_epoch_milliseconds_result temporal_rs_ZonedDateTime_from_epoch_milliseconds(int64_t ms, temporal_rs::capi::TimeZone tz);
 
     typedef struct temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result;
-    temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider(int64_t ms, const temporal_rs::capi::TimeZone* tz, const temporal_rs::capi::Provider* p);
+    temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
 
     temporal_rs::capi::I128Nanoseconds temporal_rs_ZonedDateTime_epoch_nanoseconds(const temporal_rs::capi::ZonedDateTime* self);
 
@@ -92,12 +92,12 @@ namespace capi {
     temporal_rs_ZonedDateTime_with_with_provider_result temporal_rs_ZonedDateTime_with_with_provider(const temporal_rs::capi::ZonedDateTime* self, temporal_rs::capi::PartialZonedDateTime partial, temporal_rs::capi::Disambiguation_option disambiguation, temporal_rs::capi::OffsetDisambiguation_option offset_option, temporal_rs::capi::ArithmeticOverflow_option overflow, const temporal_rs::capi::Provider* p);
 
     typedef struct temporal_rs_ZonedDateTime_with_timezone_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_with_timezone_result;
-    temporal_rs_ZonedDateTime_with_timezone_result temporal_rs_ZonedDateTime_with_timezone(const temporal_rs::capi::ZonedDateTime* self, const temporal_rs::capi::TimeZone* zone);
+    temporal_rs_ZonedDateTime_with_timezone_result temporal_rs_ZonedDateTime_with_timezone(const temporal_rs::capi::ZonedDateTime* self, temporal_rs::capi::TimeZone zone);
 
     typedef struct temporal_rs_ZonedDateTime_with_timezone_with_provider_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_with_timezone_with_provider_result;
-    temporal_rs_ZonedDateTime_with_timezone_with_provider_result temporal_rs_ZonedDateTime_with_timezone_with_provider(const temporal_rs::capi::ZonedDateTime* self, const temporal_rs::capi::TimeZone* zone, const temporal_rs::capi::Provider* p);
+    temporal_rs_ZonedDateTime_with_timezone_with_provider_result temporal_rs_ZonedDateTime_with_timezone_with_provider(const temporal_rs::capi::ZonedDateTime* self, temporal_rs::capi::TimeZone zone, const temporal_rs::capi::Provider* p);
 
-    const temporal_rs::capi::TimeZone* temporal_rs_ZonedDateTime_timezone(const temporal_rs::capi::ZonedDateTime* self);
+    temporal_rs::capi::TimeZone temporal_rs_ZonedDateTime_timezone(const temporal_rs::capi::ZonedDateTime* self);
 
     int8_t temporal_rs_ZonedDateTime_compare_instant(const temporal_rs::capi::ZonedDateTime* self, const temporal_rs::capi::ZonedDateTime* other);
 
@@ -232,14 +232,14 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::try_new(temporal_rs::I128Nanoseconds nanosecond, temporal_rs::AnyCalendarKind calendar, const temporal_rs::TimeZone& time_zone) {
+inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::try_new(temporal_rs::I128Nanoseconds nanosecond, temporal_rs::AnyCalendarKind calendar, temporal_rs::TimeZone time_zone) {
   auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_try_new(nanosecond.AsFFI(),
     calendar.AsFFI(),
     time_zone.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::ZonedDateTime>>(std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::try_new_with_provider(temporal_rs::I128Nanoseconds nanosecond, temporal_rs::AnyCalendarKind calendar, const temporal_rs::TimeZone& time_zone, const temporal_rs::Provider& p) {
+inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::try_new_with_provider(temporal_rs::I128Nanoseconds nanosecond, temporal_rs::AnyCalendarKind calendar, temporal_rs::TimeZone time_zone, const temporal_rs::Provider& p) {
   auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_try_new_with_provider(nanosecond.AsFFI(),
     calendar.AsFFI(),
     time_zone.AsFFI(),
@@ -314,13 +314,13 @@ inline int64_t temporal_rs::ZonedDateTime::epoch_milliseconds() const {
   return result;
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::from_epoch_milliseconds(int64_t ms, const temporal_rs::TimeZone& tz) {
+inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::from_epoch_milliseconds(int64_t ms, temporal_rs::TimeZone tz) {
   auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_from_epoch_milliseconds(ms,
     tz.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::ZonedDateTime>>(std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::from_epoch_milliseconds_with_provider(int64_t ms, const temporal_rs::TimeZone& tz, const temporal_rs::Provider& p) {
+inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p) {
   auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider(ms,
     tz.AsFFI(),
     p.AsFFI());
@@ -361,22 +361,22 @@ inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::ZonedDateTime>>(std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::with_timezone(const temporal_rs::TimeZone& zone) const {
+inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::with_timezone(temporal_rs::TimeZone zone) const {
   auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_with_timezone(this->AsFFI(),
     zone.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::ZonedDateTime>>(std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::with_timezone_with_provider(const temporal_rs::TimeZone& zone, const temporal_rs::Provider& p) const {
+inline diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::with_timezone_with_provider(temporal_rs::TimeZone zone, const temporal_rs::Provider& p) const {
   auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_with_timezone_with_provider(this->AsFFI(),
     zone.AsFFI(),
     p.AsFFI());
   return result.is_ok ? diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Ok<std::unique_ptr<temporal_rs::ZonedDateTime>>(std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline const temporal_rs::TimeZone& temporal_rs::ZonedDateTime::timezone() const {
+inline temporal_rs::TimeZone temporal_rs::ZonedDateTime::timezone() const {
   auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_timezone(this->AsFFI());
-  return *temporal_rs::TimeZone::FromFFI(result);
+  return temporal_rs::TimeZone::FromFFI(result);
 }
 
 inline int8_t temporal_rs::ZonedDateTime::compare_instant(const temporal_rs::ZonedDateTime& other) const {

--- a/temporal_capi/src/instant.rs
+++ b/temporal_capi/src/instant.rs
@@ -128,7 +128,7 @@ pub mod ffi {
         #[cfg(feature = "compiled_data")]
         pub fn to_ixdtf_string_with_compiled_data(
             &self,
-            zone: Option<&TimeZone>,
+            zone: Option<TimeZone>,
             options: ToStringRoundingOptions,
             write: &mut DiplomatWrite,
         ) -> Result<(), TemporalError> {
@@ -136,7 +136,7 @@ pub mod ffi {
         }
         pub fn to_ixdtf_string_with_provider<'p>(
             &self,
-            zone: Option<&TimeZone>,
+            zone: Option<TimeZone>,
             options: ToStringRoundingOptions,
             p: &Provider<'p>,
             write: &mut DiplomatWrite,
@@ -144,7 +144,7 @@ pub mod ffi {
             use writeable::Writeable;
             with_provider!(p, |p| {
                 let writeable = self.0.to_ixdtf_writeable_with_provider(
-                    zone.map(|x| &x.0),
+                    zone.map(Into::into),
                     options.into(),
                     p,
                 )?;
@@ -158,18 +158,18 @@ pub mod ffi {
         #[cfg(feature = "compiled_data")]
         pub fn to_zoned_date_time_iso(
             &self,
-            zone: &TimeZone,
+            zone: TimeZone,
         ) -> Result<Box<ZonedDateTime>, TemporalError> {
             self.to_zoned_date_time_iso_with_provider(zone, &Provider::compiled())
         }
         pub fn to_zoned_date_time_iso_with_provider<'p>(
             &self,
-            zone: &TimeZone,
+            zone: TimeZone,
             p: &Provider<'p>,
         ) -> Result<Box<ZonedDateTime>, TemporalError> {
             with_provider!(p, |p| self
                 .0
-                .to_zoned_date_time_iso_with_provider(zone.0, p))
+                .to_zoned_date_time_iso_with_provider(zone.into(), p))
             .map(|c| Box::new(ZonedDateTime(c)))
             .map_err(Into::into)
         }

--- a/temporal_capi/src/plain_date.rs
+++ b/temporal_capi/src/plain_date.rs
@@ -152,18 +152,15 @@ pub mod ffi {
         }
 
         #[cfg(feature = "compiled_data")]
-        pub fn from_epoch_milliseconds(
-            ms: i64,
-            tz: &crate::time_zone::ffi::TimeZone,
-        ) -> Result<Box<Self>, TemporalError> {
+        pub fn from_epoch_milliseconds(ms: i64, tz: TimeZone) -> Result<Box<Self>, TemporalError> {
             Self::from_epoch_milliseconds_with_provider(ms, tz, &Provider::compiled())
         }
         pub fn from_epoch_milliseconds_with_provider<'p>(
             ms: i64,
-            tz: &crate::time_zone::ffi::TimeZone,
+            tz: TimeZone,
             p: &Provider<'p>,
         ) -> Result<Box<Self>, TemporalError> {
-            let zdt = crate::zoned_date_time::zdt_from_epoch_ms_with_provider(ms, &tz.0, p)?;
+            let zdt = crate::zoned_date_time::zdt_from_epoch_ms_with_provider(ms, tz.into(), p)?;
             Ok(Box::new(Self(zdt.to_plain_date())))
         }
         pub fn with(
@@ -334,19 +331,19 @@ pub mod ffi {
         #[cfg(feature = "compiled_data")]
         pub fn to_zoned_date_time(
             &self,
-            time_zone: &TimeZone,
+            time_zone: TimeZone,
             time: Option<&PlainTime>,
         ) -> Result<Box<ZonedDateTime>, TemporalError> {
             self.to_zoned_date_time_with_provider(time_zone, time, &Provider::compiled())
         }
         pub fn to_zoned_date_time_with_provider<'p>(
             &self,
-            time_zone: &TimeZone,
+            time_zone: TimeZone,
             time: Option<&PlainTime>,
             p: &Provider<'p>,
         ) -> Result<Box<ZonedDateTime>, TemporalError> {
             with_provider!(p, |p| self.0.to_zoned_date_time_with_provider(
-                time_zone.0,
+                time_zone.into(),
                 time.map(|x| x.0),
                 p
             ))

--- a/temporal_capi/src/plain_date_time.rs
+++ b/temporal_capi/src/plain_date_time.rs
@@ -125,18 +125,15 @@ pub mod ffi {
         }
 
         #[cfg(feature = "compiled_data")]
-        pub fn from_epoch_milliseconds(
-            ms: i64,
-            tz: &crate::time_zone::ffi::TimeZone,
-        ) -> Result<Box<Self>, TemporalError> {
+        pub fn from_epoch_milliseconds(ms: i64, tz: TimeZone) -> Result<Box<Self>, TemporalError> {
             Self::from_epoch_milliseconds_with_provider(ms, tz, &Provider::compiled())
         }
         pub fn from_epoch_milliseconds_with_provider<'p>(
             ms: i64,
-            tz: &crate::time_zone::ffi::TimeZone,
+            tz: TimeZone,
             p: &Provider<'p>,
         ) -> Result<Box<Self>, TemporalError> {
-            let zdt = crate::zoned_date_time::zdt_from_epoch_ms_with_provider(ms, &tz.0, p)?;
+            let zdt = crate::zoned_date_time::zdt_from_epoch_ms_with_provider(ms, tz.into(), p)?;
             Ok(Box::new(Self(zdt.to_plain_date_time())))
         }
         pub fn with(
@@ -322,7 +319,7 @@ pub mod ffi {
         #[cfg(feature = "compiled_data")]
         pub fn to_zoned_date_time(
             &self,
-            time_zone: &TimeZone,
+            time_zone: TimeZone,
             disambiguation: Disambiguation,
         ) -> Result<Box<ZonedDateTime>, TemporalError> {
             self.to_zoned_date_time_with_provider(time_zone, disambiguation, &Provider::compiled())
@@ -330,12 +327,12 @@ pub mod ffi {
 
         pub fn to_zoned_date_time_with_provider<'p>(
             &self,
-            time_zone: &TimeZone,
+            time_zone: TimeZone,
             disambiguation: Disambiguation,
             p: &Provider<'p>,
         ) -> Result<Box<ZonedDateTime>, TemporalError> {
             with_provider!(p, |p| self.0.to_zoned_date_time_with_provider(
-                time_zone.0,
+                time_zone.into(),
                 disambiguation.into(),
                 p
             ))

--- a/temporal_capi/src/plain_month_day.rs
+++ b/temporal_capi/src/plain_month_day.rs
@@ -8,6 +8,7 @@ pub mod ffi {
 
     use crate::options::ffi::{ArithmeticOverflow, DisplayCalendar};
     use crate::plain_date::ffi::{PartialDate, PlainDate};
+    use crate::time_zone::ffi::TimeZone;
 
     use crate::provider::ffi::Provider;
     use alloc::string::String;
@@ -108,21 +109,18 @@ pub mod ffi {
         }
 
         #[cfg(feature = "compiled_data")]
-        pub fn epoch_ms_for(
-            &self,
-            time_zone: &crate::time_zone::ffi::TimeZone,
-        ) -> Result<i64, TemporalError> {
+        pub fn epoch_ms_for(&self, time_zone: TimeZone) -> Result<i64, TemporalError> {
             self.epoch_ms_for_with_provider(time_zone, &Provider::compiled())
         }
 
         pub fn epoch_ms_for_with_provider<'p>(
             &self,
-            time_zone: &crate::time_zone::ffi::TimeZone,
+            time_zone: TimeZone,
             p: &Provider<'p>,
         ) -> Result<i64, TemporalError> {
             let ns = with_provider!(p, |p| self
                 .0
-                .epoch_ns_for_with_provider(&time_zone.0, p)
+                .epoch_ns_for_with_provider(time_zone.into(), p)
                 .map_err(TemporalError::from))?;
 
             let ns_i128 = ns.as_i128();

--- a/temporal_capi/src/plain_time.rs
+++ b/temporal_capi/src/plain_time.rs
@@ -80,7 +80,7 @@ pub mod ffi {
             tz: TimeZone,
             p: &Provider<'p>,
         ) -> Result<Box<Self>, TemporalError> {
-            let zdt = crate::zoned_date_time::zdt_from_epoch_ms_with_provider(ms, tz.0, p)?;
+            let zdt = crate::zoned_date_time::zdt_from_epoch_ms_with_provider(ms, tz.into(), p)?;
             Ok(Box::new(Self(zdt.to_plain_time())))
         }
 

--- a/temporal_capi/src/plain_time.rs
+++ b/temporal_capi/src/plain_time.rs
@@ -10,6 +10,7 @@ pub mod ffi {
         ArithmeticOverflow, DifferenceSettings, RoundingOptions, ToStringRoundingOptions,
     };
     use crate::provider::ffi::Provider;
+    use crate::time_zone::ffi::TimeZone;
     use alloc::string::String;
     use core::str::FromStr;
     use diplomat_runtime::{DiplomatOption, DiplomatWrite};
@@ -71,18 +72,15 @@ pub mod ffi {
         }
 
         #[cfg(feature = "compiled_data")]
-        pub fn from_epoch_milliseconds(
-            ms: i64,
-            tz: &crate::time_zone::ffi::TimeZone,
-        ) -> Result<Box<Self>, TemporalError> {
+        pub fn from_epoch_milliseconds(ms: i64, tz: TimeZone) -> Result<Box<Self>, TemporalError> {
             Self::from_epoch_milliseconds_with_provider(ms, tz, &Provider::compiled())
         }
         pub fn from_epoch_milliseconds_with_provider<'p>(
             ms: i64,
-            tz: &crate::time_zone::ffi::TimeZone,
+            tz: TimeZone,
             p: &Provider<'p>,
         ) -> Result<Box<Self>, TemporalError> {
-            let zdt = crate::zoned_date_time::zdt_from_epoch_ms_with_provider(ms, &tz.0, p)?;
+            let zdt = crate::zoned_date_time::zdt_from_epoch_ms_with_provider(ms, tz.0, p)?;
             Ok(Box::new(Self(zdt.to_plain_time())))
         }
 

--- a/temporal_capi/src/plain_year_month.rs
+++ b/temporal_capi/src/plain_year_month.rs
@@ -6,6 +6,7 @@ pub mod ffi {
     use crate::duration::ffi::Duration;
     use crate::error::ffi::TemporalError;
     use crate::provider::ffi::Provider;
+    use crate::time_zone::ffi::TimeZone;
     use alloc::boxed::Box;
 
     use crate::options::ffi::{ArithmeticOverflow, DifferenceSettings, DisplayCalendar};
@@ -180,19 +181,18 @@ pub mod ffi {
         }
 
         #[cfg(feature = "compiled_data")]
-        pub fn epoch_ms_for(
-            &self,
-            time_zone: &crate::time_zone::ffi::TimeZone,
-        ) -> Result<i64, TemporalError> {
+        pub fn epoch_ms_for(&self, time_zone: TimeZone) -> Result<i64, TemporalError> {
             self.epoch_ms_for_with_provider(time_zone, &Provider::compiled())
         }
         pub fn epoch_ms_for_with_provider<'p>(
             &self,
-            time_zone: &crate::time_zone::ffi::TimeZone,
+            time_zone: TimeZone,
             p: &Provider<'p>,
         ) -> Result<i64, TemporalError> {
-            let ns = with_provider!(p, |p| self.0.epoch_ns_for_with_provider(&time_zone.0, p))
-                .map_err(TemporalError::from)?;
+            let ns = with_provider!(p, |p| self
+                .0
+                .epoch_ns_for_with_provider(time_zone.into(), p))
+            .map_err(TemporalError::from)?;
 
             let ns_i128 = ns.as_i128();
             let ms = ns_i128 / 1_000_000;

--- a/temporal_capi/src/time_zone.rs
+++ b/temporal_capi/src/time_zone.rs
@@ -112,3 +112,9 @@ pub mod ffi {
         }
     }
 }
+
+impl From<ffi::TimeZone> for temporal_rs::TimeZone {
+    fn from(other: ffi::TimeZone) -> Self {
+        unimplemented!()
+    }
+}

--- a/temporal_capi/src/time_zone.rs
+++ b/temporal_capi/src/time_zone.rs
@@ -1,70 +1,85 @@
+use temporal_rs::provider::TimeZoneId;
+use temporal_rs::UtcOffset;
+use timezone_provider::provider::{NormalizedId, ResolvedId};
+
 #[diplomat::bridge]
 #[diplomat::abi_rename = "temporal_rs_{0}"]
 #[diplomat::attr(auto, namespace = "temporal_rs")]
 pub mod ffi {
     use crate::error::ffi::TemporalError;
     use crate::provider::ffi::Provider;
-    use alloc::boxed::Box;
     use core::fmt::Write;
     use diplomat_runtime::DiplomatWrite;
 
-    #[diplomat::opaque]
-    #[diplomat::transparent_convert]
-    pub struct TimeZone(pub temporal_rs::TimeZone);
+    /// A type representing a time zone over FFI.
+    ///
+    /// It is not recommended to directly manipulate the fields of this type.
+    #[derive(Copy, Clone)]
+    pub struct TimeZone {
+        /// The UTC offset in minutes (is_iana_id = false)
+        pub offset_minutes: i16,
+        /// An id which can be used with the resolver (is_iana_id = true)
+        pub resolved_id: usize,
+        /// An id which can be used with the normalizer (is_iana_id = true)
+        pub normalized_id: usize,
+        /// Whether this is an IANA id or an offset
+        pub is_iana_id: bool,
+    }
 
     impl TimeZone {
         #[cfg(feature = "compiled_data")]
-        pub fn try_from_identifier_str(ident: &DiplomatStr) -> Result<Box<Self>, TemporalError> {
+        pub fn try_from_identifier_str(ident: &DiplomatStr) -> Result<Self, TemporalError> {
             Self::try_from_identifier_str_with_provider(ident, &Provider::compiled())
         }
         pub fn try_from_identifier_str_with_provider<'p>(
             ident: &DiplomatStr,
             p: &Provider<'p>,
-        ) -> Result<Box<Self>, TemporalError> {
+        ) -> Result<Self, TemporalError> {
             let Ok(ident) = core::str::from_utf8(ident) else {
                 return Err(temporal_rs::TemporalError::range().into());
             };
             with_provider!(p, |p| {
                 temporal_rs::TimeZone::try_from_identifier_str_with_provider(ident, p)
             })
-            .map(|x| Box::new(TimeZone(x)))
+            .map(Into::into)
             .map_err(Into::into)
         }
-        pub fn try_from_offset_str(ident: &DiplomatStr) -> Result<Box<Self>, TemporalError> {
+        pub fn try_from_offset_str(ident: &DiplomatStr) -> Result<Self, TemporalError> {
             temporal_rs::UtcOffset::from_utf8(ident)
-                .map(|x| Box::new(TimeZone(temporal_rs::TimeZone::UtcOffset(x))))
+                .map(|x| temporal_rs::TimeZone::UtcOffset(x).into())
                 .map_err(Into::into)
         }
         #[cfg(feature = "compiled_data")]
-        pub fn try_from_str(ident: &DiplomatStr) -> Result<Box<Self>, TemporalError> {
+        pub fn try_from_str(ident: &DiplomatStr) -> Result<Self, TemporalError> {
             Self::try_from_str_with_provider(ident, &Provider::compiled())
         }
         pub fn try_from_str_with_provider<'p>(
             ident: &DiplomatStr,
             p: &Provider<'p>,
-        ) -> Result<Box<Self>, TemporalError> {
+        ) -> Result<Self, TemporalError> {
             let Ok(ident) = core::str::from_utf8(ident) else {
                 return Err(temporal_rs::TemporalError::range().into());
             };
             with_provider!(p, |p| temporal_rs::TimeZone::try_from_str_with_provider(
                 ident, p
             ))
-            .map(|x| Box::new(TimeZone(x)))
+            .map(Into::into)
             .map_err(Into::into)
         }
 
         #[cfg(feature = "compiled_data")]
-        pub fn identifier(&self, write: &mut DiplomatWrite) {
+        pub fn identifier(self, write: &mut DiplomatWrite) {
             let _ = self.identifier_with_provider(&Provider::compiled(), write);
         }
 
         pub fn identifier_with_provider<'p>(
-            &self,
+            self,
             p: &Provider<'p>,
             write: &mut DiplomatWrite,
         ) -> Result<(), TemporalError> {
             // TODO ideally this would use Writeable instead of allocating
-            let s = with_provider!(p, |p| self.0.identifier_with_provider(p)).unwrap_or_default();
+            let s =
+                with_provider!(p, |p| self.tz().identifier_with_provider(p)).unwrap_or_default();
 
             // This can only fail in cases where the DiplomatWriteable is capped, we
             // don't care about that.
@@ -73,48 +88,70 @@ pub mod ffi {
         }
 
         #[cfg(feature = "compiled_data")]
-        pub fn utc() -> Box<Self> {
-            // TODO merge signature with below
-            Box::new(Self(temporal_rs::TimeZone::utc()))
+        pub fn utc() -> Self {
+            temporal_rs::TimeZone::utc().into()
         }
 
-        pub fn utc_with_provider<'p>(p: &Provider<'p>) -> Result<Box<Self>, TemporalError> {
-            Ok(Box::new(Self(with_provider!(p, |p| {
-                temporal_rs::TimeZone::utc_with_provider(p)
-            }))))
+        pub fn utc_with_provider<'p>(p: &Provider<'p>) -> Result<Self, TemporalError> {
+            Ok(with_provider!(p, |p| { temporal_rs::TimeZone::utc_with_provider(p) }).into())
         }
 
         /// Create a TimeZone that represents +00:00
         ///
         /// This is the only way to infallibly make a TimeZone without compiled_data,
         /// and can be used as a fallback.
-        pub fn zero() -> Box<Self> {
-            Box::new(Self(temporal_rs::TimeZone::UtcOffset(Default::default())))
-        }
-
-        #[allow(clippy::should_implement_trait)]
-        pub fn clone(&self) -> Box<TimeZone> {
-            Box::new(TimeZone(self.0))
+        pub fn zero() -> Self {
+            temporal_rs::TimeZone::UtcOffset(Default::default()).into()
         }
 
         /// Get the primary time zone identifier corresponding to this time zone
         #[cfg(feature = "compiled_data")]
-        pub fn primary_identifier(&self) -> Result<Box<Self>, TemporalError> {
+        pub fn primary_identifier(self) -> Result<Self, TemporalError> {
             self.primary_identifier_with_provider(&Provider::compiled())
         }
         pub fn primary_identifier_with_provider<'p>(
-            &self,
+            self,
             p: &Provider<'p>,
-        ) -> Result<Box<Self>, TemporalError> {
-            with_provider!(p, |p| self.0.primary_identifier_with_provider(p))
-                .map(|x| Box::new(TimeZone(x)))
+        ) -> Result<Self, TemporalError> {
+            with_provider!(p, |p| self.tz().primary_identifier_with_provider(p))
+                .map(Into::into)
                 .map_err(Into::into)
+        }
+
+        pub(crate) fn tz(self) -> temporal_rs::TimeZone {
+            self.into()
         }
     }
 }
 
 impl From<ffi::TimeZone> for temporal_rs::TimeZone {
     fn from(other: ffi::TimeZone) -> Self {
-        unimplemented!()
+        if other.is_iana_id {
+            Self::IanaIdentifier(TimeZoneId {
+                normalized: NormalizedId(other.normalized_id),
+                resolved: ResolvedId(other.resolved_id),
+            })
+        } else {
+            Self::UtcOffset(UtcOffset::from_minutes(other.offset_minutes))
+        }
+    }
+}
+
+impl From<temporal_rs::TimeZone> for ffi::TimeZone {
+    fn from(other: temporal_rs::TimeZone) -> Self {
+        match other {
+            temporal_rs::TimeZone::UtcOffset(offset) => Self {
+                offset_minutes: offset.minutes(),
+                is_iana_id: false,
+                normalized_id: 0,
+                resolved_id: 0,
+            },
+            temporal_rs::TimeZone::IanaIdentifier(id) => Self {
+                normalized_id: id.normalized.0,
+                resolved_id: id.resolved.0,
+                is_iana_id: true,
+                offset_minutes: 0,
+            },
+        }
     }
 }

--- a/temporal_capi/src/zoned_date_time.rs
+++ b/temporal_capi/src/zoned_date_time.rs
@@ -38,7 +38,7 @@ pub mod ffi {
         pub date: PartialDate<'a>,
         pub time: PartialTime,
         pub offset: DiplomatOption<DiplomatStrSlice<'a>>,
-        pub timezone: Option<&'a TimeZone>,
+        pub timezone: DiplomatOption<TimeZone>,
     }
 
     pub struct RelativeTo<'a> {
@@ -366,8 +366,8 @@ pub mod ffi {
                 .map_err(Into::into)
         }
 
-        pub fn timezone<'a>(&'a self) -> &'a TimeZone {
-            TimeZone::transparent_convert(self.0.time_zone())
+        pub fn timezone(&self) -> TimeZone {
+            TimeZone::from(*self.0.time_zone())
         }
 
         pub fn compare_instant(&self, other: &Self) -> core::cmp::Ordering {
@@ -725,7 +725,7 @@ pub(crate) fn zdt_from_epoch_ms_with_provider<'p>(
 impl TryFrom<ffi::PartialZonedDateTime<'_>> for temporal_rs::partial::PartialZonedDateTime {
     type Error = TemporalError;
     fn try_from(other: ffi::PartialZonedDateTime<'_>) -> Result<Self, TemporalError> {
-        let timezone = other.timezone.map(|x| x.0);
+        let timezone = other.timezone.clone().into_option().map(|x| x.tz());
         let calendar = temporal_rs::Calendar::new(other.date.calendar.into());
         Ok(Self {
             fields: other.try_into()?,

--- a/temporal_capi/src/zoned_date_time.rs
+++ b/temporal_capi/src/zoned_date_time.rs
@@ -145,19 +145,19 @@ pub mod ffi {
         pub fn try_new(
             nanosecond: I128Nanoseconds,
             calendar: AnyCalendarKind,
-            time_zone: &TimeZone,
+            time_zone: TimeZone,
         ) -> Result<Box<Self>, TemporalError> {
             Self::try_new_with_provider(nanosecond, calendar, time_zone, &Provider::compiled())
         }
         pub fn try_new_with_provider<'p>(
             nanosecond: I128Nanoseconds,
             calendar: AnyCalendarKind,
-            time_zone: &TimeZone,
+            time_zone: TimeZone,
             p: &Provider<'p>,
         ) -> Result<Box<Self>, TemporalError> {
             with_provider!(p, |p| temporal_rs::ZonedDateTime::try_new_with_provider(
                 nanosecond.into(),
-                time_zone.0,
+                time_zone.into(),
                 temporal_rs::Calendar::new(calendar.into()),
                 p
             ))
@@ -294,15 +294,15 @@ pub mod ffi {
         }
 
         #[cfg(feature = "compiled_data")]
-        pub fn from_epoch_milliseconds(ms: i64, tz: &TimeZone) -> Result<Box<Self>, TemporalError> {
+        pub fn from_epoch_milliseconds(ms: i64, tz: TimeZone) -> Result<Box<Self>, TemporalError> {
             Self::from_epoch_milliseconds_with_provider(ms, tz, &Provider::compiled())
         }
         pub fn from_epoch_milliseconds_with_provider<'p>(
             ms: i64,
-            tz: &TimeZone,
+            tz: TimeZone,
             p: &Provider<'p>,
         ) -> Result<Box<Self>, TemporalError> {
-            super::zdt_from_epoch_ms_with_provider(ms, &tz.0, p).map(|c| Box::new(Self(c)))
+            super::zdt_from_epoch_ms_with_provider(ms, tz.into(), p).map(|c| Box::new(Self(c)))
         }
 
         pub fn epoch_nanoseconds(&self) -> I128Nanoseconds {
@@ -353,15 +353,15 @@ pub mod ffi {
         }
 
         #[cfg(feature = "compiled_data")]
-        pub fn with_timezone(&self, zone: &TimeZone) -> Result<Box<Self>, TemporalError> {
+        pub fn with_timezone(&self, zone: TimeZone) -> Result<Box<Self>, TemporalError> {
             self.with_timezone_with_provider(zone, &Provider::compiled())
         }
         pub fn with_timezone_with_provider<'p>(
             &self,
-            zone: &TimeZone,
+            zone: TimeZone,
             p: &Provider<'p>,
         ) -> Result<Box<Self>, TemporalError> {
-            with_provider!(p, |p| self.0.with_time_zone_with_provider(zone.0, p))
+            with_provider!(p, |p| self.0.with_time_zone_with_provider(zone.into(), p))
                 .map(|x| Box::new(ZonedDateTime(x)))
                 .map_err(Into::into)
         }
@@ -713,12 +713,12 @@ pub mod ffi {
 
 pub(crate) fn zdt_from_epoch_ms_with_provider<'p>(
     ms: i64,
-    time_zone: &temporal_rs::TimeZone,
+    time_zone: temporal_rs::TimeZone,
     p: &Provider<'p>,
 ) -> Result<temporal_rs::ZonedDateTime, TemporalError> {
     let instant = temporal_rs::Instant::from_epoch_milliseconds(ms)?;
     with_provider!(p, |p| instant
-        .to_zoned_date_time_iso_with_provider(*time_zone, p))
+        .to_zoned_date_time_iso_with_provider(time_zone, p))
     .map_err(Into::into)
 }
 


### PR DESCRIPTION
This also moves a lot of internal stuff to taking TimeZone instead of &TimeZone. I think that's fine but I can revert if requested.