### PR TITLE
Add missing from_epoch_nanoseconds() FFI

### DIFF
--- a/temporal_capi/bindings/c/PlainDate.h
+++ b/temporal_capi/bindings/c/PlainDate.h
@@ -13,6 +13,7 @@
 #include "DifferenceSettings.d.h"
 #include "DisplayCalendar.d.h"
 #include "Duration.d.h"
+#include "I128Nanoseconds.d.h"
 #include "ParsedDate.d.h"
 #include "PartialDate.d.h"
 #include "PlainDateTime.d.h"
@@ -51,6 +52,12 @@ temporal_rs_PlainDate_from_epoch_milliseconds_result temporal_rs_PlainDate_from_
 
 typedef struct temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result;
 temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result temporal_rs_PlainDate_from_epoch_milliseconds_with_provider(int64_t ms, TimeZone tz, const Provider* p);
+
+typedef struct temporal_rs_PlainDate_from_epoch_nanoseconds_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_epoch_nanoseconds_result;
+temporal_rs_PlainDate_from_epoch_nanoseconds_result temporal_rs_PlainDate_from_epoch_nanoseconds(I128Nanoseconds ns, TimeZone tz);
+
+typedef struct temporal_rs_PlainDate_from_epoch_nanoseconds_with_provider_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_epoch_nanoseconds_with_provider_result;
+temporal_rs_PlainDate_from_epoch_nanoseconds_with_provider_result temporal_rs_PlainDate_from_epoch_nanoseconds_with_provider(I128Nanoseconds ns, TimeZone tz, const Provider* p);
 
 typedef struct temporal_rs_PlainDate_with_result {union {PlainDate* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_with_result;
 temporal_rs_PlainDate_with_result temporal_rs_PlainDate_with(const PlainDate* self, PartialDate partial, ArithmeticOverflow_option overflow);

--- a/temporal_capi/bindings/c/PlainDateTime.h
+++ b/temporal_capi/bindings/c/PlainDateTime.h
@@ -52,7 +52,7 @@ typedef struct temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider_r
 temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider_result temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider(int64_t ms, TimeZone tz, const Provider* p);
 
 typedef struct temporal_rs_PlainDateTime_from_epoch_nanoseconds_result {union {PlainDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_epoch_nanoseconds_result;
-temporal_rs_PlainDateTime_from_epoch_nanoseconds_result temporal_rs_PlainDateTime_from_epoch_nanoseconds(I128Nanoseconds ns, TimeZone tz, const Provider* p);
+temporal_rs_PlainDateTime_from_epoch_nanoseconds_result temporal_rs_PlainDateTime_from_epoch_nanoseconds(I128Nanoseconds ns, TimeZone tz);
 
 typedef struct temporal_rs_PlainDateTime_from_epoch_nanoseconds_with_provider_result {union {PlainDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_epoch_nanoseconds_with_provider_result;
 temporal_rs_PlainDateTime_from_epoch_nanoseconds_with_provider_result temporal_rs_PlainDateTime_from_epoch_nanoseconds_with_provider(I128Nanoseconds ns, TimeZone tz, const Provider* p);

--- a/temporal_capi/bindings/c/PlainTime.h
+++ b/temporal_capi/bindings/c/PlainTime.h
@@ -10,6 +10,7 @@
 #include "ArithmeticOverflow.d.h"
 #include "DifferenceSettings.d.h"
 #include "Duration.d.h"
+#include "I128Nanoseconds.d.h"
 #include "PartialTime.d.h"
 #include "Provider.d.h"
 #include "RoundingOptions.d.h"
@@ -38,6 +39,12 @@ temporal_rs_PlainTime_from_epoch_milliseconds_result temporal_rs_PlainTime_from_
 
 typedef struct temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result {union {PlainTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result;
 temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result temporal_rs_PlainTime_from_epoch_milliseconds_with_provider(int64_t ms, TimeZone tz, const Provider* p);
+
+typedef struct temporal_rs_PlainTime_from_epoch_nanoseconds_result {union {PlainTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_from_epoch_nanoseconds_result;
+temporal_rs_PlainTime_from_epoch_nanoseconds_result temporal_rs_PlainTime_from_epoch_nanoseconds(I128Nanoseconds ns, TimeZone tz);
+
+typedef struct temporal_rs_PlainTime_from_epoch_nanoseconds_with_provider_result {union {PlainTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_from_epoch_nanoseconds_with_provider_result;
+temporal_rs_PlainTime_from_epoch_nanoseconds_with_provider_result temporal_rs_PlainTime_from_epoch_nanoseconds_with_provider(I128Nanoseconds ns, TimeZone tz, const Provider* p);
 
 typedef struct temporal_rs_PlainTime_with_result {union {PlainTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_with_result;
 temporal_rs_PlainTime_with_result temporal_rs_PlainTime_with(const PlainTime* self, PartialTime partial, ArithmeticOverflow_option overflow);

--- a/temporal_capi/bindings/c/ZonedDateTime.h
+++ b/temporal_capi/bindings/c/ZonedDateTime.h
@@ -76,6 +76,12 @@ temporal_rs_ZonedDateTime_from_epoch_milliseconds_result temporal_rs_ZonedDateTi
 typedef struct temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result;
 temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider(int64_t ms, TimeZone tz, const Provider* p);
 
+typedef struct temporal_rs_ZonedDateTime_from_epoch_nanoseconds_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_from_epoch_nanoseconds_result;
+temporal_rs_ZonedDateTime_from_epoch_nanoseconds_result temporal_rs_ZonedDateTime_from_epoch_nanoseconds(I128Nanoseconds ns, TimeZone tz);
+
+typedef struct temporal_rs_ZonedDateTime_from_epoch_nanoseconds_with_provider_result {union {ZonedDateTime* ok; TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_from_epoch_nanoseconds_with_provider_result;
+temporal_rs_ZonedDateTime_from_epoch_nanoseconds_with_provider_result temporal_rs_ZonedDateTime_from_epoch_nanoseconds_with_provider(I128Nanoseconds ns, TimeZone tz, const Provider* p);
+
 I128Nanoseconds temporal_rs_ZonedDateTime_epoch_nanoseconds(const ZonedDateTime* self);
 
 int64_t temporal_rs_ZonedDateTime_offset_nanoseconds(const ZonedDateTime* self);

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
@@ -32,6 +32,7 @@ class Provider;
 namespace capi { struct ZonedDateTime; }
 class ZonedDateTime;
 struct DifferenceSettings;
+struct I128Nanoseconds;
 struct PartialDate;
 struct TemporalError;
 struct TimeZone;
@@ -65,6 +66,10 @@ public:
   inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_epoch_milliseconds(int64_t ms, temporal_rs::TimeZone tz);
 
   inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
+
+  inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_epoch_nanoseconds(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz);
+
+  inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_epoch_nanoseconds_with_provider(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
 
   inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> with(temporal_rs::PartialDate partial, std::optional<temporal_rs::ArithmeticOverflow> overflow) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
@@ -17,6 +17,7 @@
 #include "DifferenceSettings.hpp"
 #include "DisplayCalendar.hpp"
 #include "Duration.hpp"
+#include "I128Nanoseconds.hpp"
 #include "ParsedDate.hpp"
 #include "PartialDate.hpp"
 #include "PlainDateTime.hpp"
@@ -54,6 +55,12 @@ namespace capi {
 
     typedef struct temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result;
     temporal_rs_PlainDate_from_epoch_milliseconds_with_provider_result temporal_rs_PlainDate_from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
+
+    typedef struct temporal_rs_PlainDate_from_epoch_nanoseconds_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_epoch_nanoseconds_result;
+    temporal_rs_PlainDate_from_epoch_nanoseconds_result temporal_rs_PlainDate_from_epoch_nanoseconds(temporal_rs::capi::I128Nanoseconds ns, temporal_rs::capi::TimeZone tz);
+
+    typedef struct temporal_rs_PlainDate_from_epoch_nanoseconds_with_provider_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_from_epoch_nanoseconds_with_provider_result;
+    temporal_rs_PlainDate_from_epoch_nanoseconds_with_provider_result temporal_rs_PlainDate_from_epoch_nanoseconds_with_provider(temporal_rs::capi::I128Nanoseconds ns, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
 
     typedef struct temporal_rs_PlainDate_with_result {union {temporal_rs::capi::PlainDate* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDate_with_result;
     temporal_rs_PlainDate_with_result temporal_rs_PlainDate_with(const temporal_rs::capi::PlainDate* self, temporal_rs::capi::PartialDate partial, temporal_rs::capi::ArithmeticOverflow_option overflow);
@@ -188,6 +195,19 @@ inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, te
 
 inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p) {
     auto result = temporal_rs::capi::temporal_rs_PlainDate_from_epoch_milliseconds_with_provider(ms,
+        tz.AsFFI(),
+        p.AsFFI());
+    return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(temporal_rs::diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+}
+
+inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::from_epoch_nanoseconds(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz) {
+    auto result = temporal_rs::capi::temporal_rs_PlainDate_from_epoch_nanoseconds(ns.AsFFI(),
+        tz.AsFFI());
+    return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(temporal_rs::diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+}
+
+inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> temporal_rs::PlainDate::from_epoch_nanoseconds_with_provider(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz, const temporal_rs::Provider& p) {
+    auto result = temporal_rs::capi::temporal_rs_PlainDate_from_epoch_nanoseconds_with_provider(ns.AsFFI(),
         tz.AsFFI(),
         p.AsFFI());
     return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(temporal_rs::diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
@@ -64,7 +64,7 @@ public:
 
   inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
 
-  inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> from_epoch_nanoseconds(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
+  inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> from_epoch_nanoseconds(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz);
 
   inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> from_epoch_nanoseconds_with_provider(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
@@ -55,7 +55,7 @@ namespace capi {
     temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider_result temporal_rs_PlainDateTime_from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
 
     typedef struct temporal_rs_PlainDateTime_from_epoch_nanoseconds_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_epoch_nanoseconds_result;
-    temporal_rs_PlainDateTime_from_epoch_nanoseconds_result temporal_rs_PlainDateTime_from_epoch_nanoseconds(temporal_rs::capi::I128Nanoseconds ns, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
+    temporal_rs_PlainDateTime_from_epoch_nanoseconds_result temporal_rs_PlainDateTime_from_epoch_nanoseconds(temporal_rs::capi::I128Nanoseconds ns, temporal_rs::capi::TimeZone tz);
 
     typedef struct temporal_rs_PlainDateTime_from_epoch_nanoseconds_with_provider_result {union {temporal_rs::capi::PlainDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainDateTime_from_epoch_nanoseconds_with_provider_result;
     temporal_rs_PlainDateTime_from_epoch_nanoseconds_with_provider_result temporal_rs_PlainDateTime_from_epoch_nanoseconds_with_provider(temporal_rs::capi::I128Nanoseconds ns, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
@@ -213,10 +213,9 @@ inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>
     return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::PlainDateTime>>(std::unique_ptr<temporal_rs::PlainDateTime>(temporal_rs::PlainDateTime::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::from_epoch_nanoseconds(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz, const temporal_rs::Provider& p) {
+inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError> temporal_rs::PlainDateTime::from_epoch_nanoseconds(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz) {
     auto result = temporal_rs::capi::temporal_rs_PlainDateTime_from_epoch_nanoseconds(ns.AsFFI(),
-        tz.AsFFI(),
-        p.AsFFI());
+        tz.AsFFI());
     return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::PlainDateTime>>(std::unique_ptr<temporal_rs::PlainDateTime>(temporal_rs::PlainDateTime::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDateTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainTime.d.hpp
@@ -18,6 +18,7 @@ class PlainTime;
 namespace capi { struct Provider; }
 class Provider;
 struct DifferenceSettings;
+struct I128Nanoseconds;
 struct PartialTime;
 struct RoundingOptions;
 struct TemporalError;
@@ -47,6 +48,10 @@ public:
   inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> from_epoch_milliseconds(int64_t ms, temporal_rs::TimeZone tz);
 
   inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
+
+  inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> from_epoch_nanoseconds(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz);
+
+  inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> from_epoch_nanoseconds_with_provider(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
 
   inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> with(temporal_rs::PartialTime partial, std::optional<temporal_rs::ArithmeticOverflow> overflow) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainTime.hpp
@@ -14,6 +14,7 @@
 #include "ArithmeticOverflow.hpp"
 #include "DifferenceSettings.hpp"
 #include "Duration.hpp"
+#include "I128Nanoseconds.hpp"
 #include "PartialTime.hpp"
 #include "Provider.hpp"
 #include "RoundingOptions.hpp"
@@ -41,6 +42,12 @@ namespace capi {
 
     typedef struct temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result {union {temporal_rs::capi::PlainTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result;
     temporal_rs_PlainTime_from_epoch_milliseconds_with_provider_result temporal_rs_PlainTime_from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
+
+    typedef struct temporal_rs_PlainTime_from_epoch_nanoseconds_result {union {temporal_rs::capi::PlainTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_from_epoch_nanoseconds_result;
+    temporal_rs_PlainTime_from_epoch_nanoseconds_result temporal_rs_PlainTime_from_epoch_nanoseconds(temporal_rs::capi::I128Nanoseconds ns, temporal_rs::capi::TimeZone tz);
+
+    typedef struct temporal_rs_PlainTime_from_epoch_nanoseconds_with_provider_result {union {temporal_rs::capi::PlainTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_from_epoch_nanoseconds_with_provider_result;
+    temporal_rs_PlainTime_from_epoch_nanoseconds_with_provider_result temporal_rs_PlainTime_from_epoch_nanoseconds_with_provider(temporal_rs::capi::I128Nanoseconds ns, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
 
     typedef struct temporal_rs_PlainTime_with_result {union {temporal_rs::capi::PlainTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_PlainTime_with_result;
     temporal_rs_PlainTime_with_result temporal_rs_PlainTime_with(const temporal_rs::capi::PlainTime* self, temporal_rs::capi::PartialTime partial, temporal_rs::capi::ArithmeticOverflow_option overflow);
@@ -127,6 +134,19 @@ inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, te
 
 inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> temporal_rs::PlainTime::from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p) {
     auto result = temporal_rs::capi::temporal_rs_PlainTime_from_epoch_milliseconds_with_provider(ms,
+        tz.AsFFI(),
+        p.AsFFI());
+    return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::PlainTime>>(std::unique_ptr<temporal_rs::PlainTime>(temporal_rs::PlainTime::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+}
+
+inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> temporal_rs::PlainTime::from_epoch_nanoseconds(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz) {
+    auto result = temporal_rs::capi::temporal_rs_PlainTime_from_epoch_nanoseconds(ns.AsFFI(),
+        tz.AsFFI());
+    return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::PlainTime>>(std::unique_ptr<temporal_rs::PlainTime>(temporal_rs::PlainTime::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+}
+
+inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError> temporal_rs::PlainTime::from_epoch_nanoseconds_with_provider(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz, const temporal_rs::Provider& p) {
+    auto result = temporal_rs::capi::temporal_rs_PlainTime_from_epoch_nanoseconds_with_provider(ns.AsFFI(),
         tz.AsFFI(),
         p.AsFFI());
     return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::PlainTime>>(std::unique_ptr<temporal_rs::PlainTime>(temporal_rs::PlainTime::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));

--- a/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.d.hpp
@@ -84,6 +84,10 @@ public:
 
   inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
 
+  inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> from_epoch_nanoseconds(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz);
+
+  inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> from_epoch_nanoseconds_with_provider(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz, const temporal_rs::Provider& p);
+
   inline temporal_rs::I128Nanoseconds epoch_nanoseconds() const;
 
   inline int64_t offset_nanoseconds() const;

--- a/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.hpp
@@ -79,6 +79,12 @@ namespace capi {
     typedef struct temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result;
     temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider_result temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
 
+    typedef struct temporal_rs_ZonedDateTime_from_epoch_nanoseconds_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_from_epoch_nanoseconds_result;
+    temporal_rs_ZonedDateTime_from_epoch_nanoseconds_result temporal_rs_ZonedDateTime_from_epoch_nanoseconds(temporal_rs::capi::I128Nanoseconds ns, temporal_rs::capi::TimeZone tz);
+
+    typedef struct temporal_rs_ZonedDateTime_from_epoch_nanoseconds_with_provider_result {union {temporal_rs::capi::ZonedDateTime* ok; temporal_rs::capi::TemporalError err;}; bool is_ok;} temporal_rs_ZonedDateTime_from_epoch_nanoseconds_with_provider_result;
+    temporal_rs_ZonedDateTime_from_epoch_nanoseconds_with_provider_result temporal_rs_ZonedDateTime_from_epoch_nanoseconds_with_provider(temporal_rs::capi::I128Nanoseconds ns, temporal_rs::capi::TimeZone tz, const temporal_rs::capi::Provider* p);
+
     temporal_rs::capi::I128Nanoseconds temporal_rs_ZonedDateTime_epoch_nanoseconds(const temporal_rs::capi::ZonedDateTime* self);
 
     int64_t temporal_rs_ZonedDateTime_offset_nanoseconds(const temporal_rs::capi::ZonedDateTime* self);
@@ -322,6 +328,19 @@ inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>
 
 inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::from_epoch_milliseconds_with_provider(int64_t ms, temporal_rs::TimeZone tz, const temporal_rs::Provider& p) {
     auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_from_epoch_milliseconds_with_provider(ms,
+        tz.AsFFI(),
+        p.AsFFI());
+    return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::ZonedDateTime>>(std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+}
+
+inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::from_epoch_nanoseconds(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz) {
+    auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_from_epoch_nanoseconds(ns.AsFFI(),
+        tz.AsFFI());
+    return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::ZonedDateTime>>(std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
+}
+
+inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError> temporal_rs::ZonedDateTime::from_epoch_nanoseconds_with_provider(temporal_rs::I128Nanoseconds ns, temporal_rs::TimeZone tz, const temporal_rs::Provider& p) {
+    auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_from_epoch_nanoseconds_with_provider(ns.AsFFI(),
         tz.AsFFI(),
         p.AsFFI());
     return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::ZonedDateTime>>(std::unique_ptr<temporal_rs::ZonedDateTime>(temporal_rs::ZonedDateTime::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::ZonedDateTime>, temporal_rs::TemporalError>(temporal_rs::diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));

--- a/temporal_capi/src/plain_date.rs
+++ b/temporal_capi/src/plain_date.rs
@@ -8,6 +8,7 @@ pub mod ffi {
     use crate::calendar::ffi::{AnyCalendarKind, Calendar};
     use crate::duration::ffi::Duration;
     use crate::error::ffi::TemporalError;
+    use crate::instant::ffi::I128Nanoseconds;
     use crate::options::ffi::{ArithmeticOverflow, DifferenceSettings, DisplayCalendar};
     use crate::plain_date_time::ffi::PlainDateTime;
     use crate::plain_month_day::ffi::PlainMonthDay;
@@ -162,6 +163,23 @@ pub mod ffi {
             let zdt = crate::zoned_date_time::zdt_from_epoch_ms_with_provider(ms, tz.into(), p)?;
             Ok(Box::new(Self(zdt.to_plain_date())))
         }
+
+        #[cfg(feature = "compiled_data")]
+        pub fn from_epoch_nanoseconds(
+            ns: I128Nanoseconds,
+            tz: TimeZone,
+        ) -> Result<Box<Self>, TemporalError> {
+            Self::from_epoch_nanoseconds_with_provider(ns, tz, &Provider::compiled())
+        }
+        pub fn from_epoch_nanoseconds_with_provider<'p>(
+            ns: I128Nanoseconds,
+            tz: TimeZone,
+            p: &Provider<'p>,
+        ) -> Result<Box<Self>, TemporalError> {
+            let zdt = crate::zoned_date_time::zdt_from_epoch_ns_with_provider(ns, tz.into(), p)?;
+            Ok(Box::new(Self(zdt.to_plain_date())))
+        }
+
         pub fn with(
             &self,
             partial: PartialDate,

--- a/temporal_capi/src/plain_date_time.rs
+++ b/temporal_capi/src/plain_date_time.rs
@@ -137,10 +137,9 @@ pub mod ffi {
             Ok(Box::new(Self(zdt.to_plain_date_time())))
         }
         #[cfg(feature = "compiled_data")]
-        pub fn from_epoch_nanoseconds<'p>(
+        pub fn from_epoch_nanoseconds(
             ns: I128Nanoseconds,
             tz: TimeZone,
-            p: &Provider<'p>,
         ) -> Result<Box<Self>, TemporalError> {
             Self::from_epoch_nanoseconds_with_provider(ns, tz, &Provider::compiled())
         }

--- a/temporal_capi/src/plain_time.rs
+++ b/temporal_capi/src/plain_time.rs
@@ -5,6 +5,7 @@ pub mod ffi {
 
     use crate::duration::ffi::Duration;
     use crate::error::ffi::TemporalError;
+    use crate::instant::ffi::I128Nanoseconds;
     use crate::options::ffi::{
         ArithmeticOverflow, DifferenceSettings, RoundingOptions, ToStringRoundingOptions,
     };
@@ -80,6 +81,22 @@ pub mod ffi {
             p: &Provider<'p>,
         ) -> Result<Box<Self>, TemporalError> {
             let zdt = crate::zoned_date_time::zdt_from_epoch_ms_with_provider(ms, tz.into(), p)?;
+            Ok(Box::new(Self(zdt.to_plain_time())))
+        }
+
+        #[cfg(feature = "compiled_data")]
+        pub fn from_epoch_nanoseconds(
+            ns: I128Nanoseconds,
+            tz: TimeZone,
+        ) -> Result<Box<Self>, TemporalError> {
+            Self::from_epoch_nanoseconds_with_provider(ns, tz, &Provider::compiled())
+        }
+        pub fn from_epoch_nanoseconds_with_provider<'p>(
+            ns: I128Nanoseconds,
+            tz: TimeZone,
+            p: &Provider<'p>,
+        ) -> Result<Box<Self>, TemporalError> {
+            let zdt = crate::zoned_date_time::zdt_from_epoch_ns_with_provider(ns, tz.into(), p)?;
             Ok(Box::new(Self(zdt.to_plain_time())))
         }
 

--- a/temporal_capi/src/zoned_date_time.rs
+++ b/temporal_capi/src/zoned_date_time.rs
@@ -305,6 +305,22 @@ pub mod ffi {
             super::zdt_from_epoch_ms_with_provider(ms, tz.into(), p).map(|c| Box::new(Self(c)))
         }
 
+        #[cfg(feature = "compiled_data")]
+        pub fn from_epoch_nanoseconds(
+            ns: I128Nanoseconds,
+            tz: TimeZone,
+        ) -> Result<Box<Self>, TemporalError> {
+            Self::from_epoch_nanoseconds_with_provider(ns, tz, &Provider::compiled())
+        }
+        pub fn from_epoch_nanoseconds_with_provider<'p>(
+            ns: I128Nanoseconds,
+            tz: TimeZone,
+            p: &Provider<'p>,
+        ) -> Result<Box<Self>, TemporalError> {
+            let zdt = crate::zoned_date_time::zdt_from_epoch_ns_with_provider(ns, tz.into(), p)?;
+            Ok(Box::new(Self(zdt)))
+        }
+
         pub fn epoch_nanoseconds(&self) -> I128Nanoseconds {
             self.0.epoch_nanoseconds().as_i128().into()
         }


### PR DESCRIPTION
The intention of #579 was full feature parity for `from_epoch_nanoseconds()` with `from_epoch_milliseconds()`, so #583 was not sufficient. It also mistakenly gave the compiled data variant a provider parameter.