### PR TITLE
Add TryFrom for PartialDuration to Duration

### DIFF
--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -139,6 +139,7 @@ impl PartialDuration {
     }
 }
 
+
 /// The native Rust implementation of `Temporal.Duration`.
 ///
 /// Represents a span of time such as "2 hours and 30 minutes" or "3 years, 2 months".
@@ -330,6 +331,13 @@ impl core::fmt::Display for Duration {
             "Duration must return a valid string with default options."
         );
         f.write_str(&string.map_err(|_| Default::default())?)
+    }
+}
+
+impl TryFrom<PartialDuration> for Duration {
+    type Error = TemporalError;
+    fn try_from(partial: PartialDuration) -> Result<Self, Self::Error> {
+        Duration::from_partial_duration(partial)
     }
 }
 

--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -139,7 +139,6 @@ impl PartialDuration {
     }
 }
 
-
 /// The native Rust implementation of `Temporal.Duration`.
 ///
 /// Represents a span of time such as "2 hours and 30 minutes" or "3 years, 2 months".


### PR DESCRIPTION
This PR adds a `TryFrom` implemenation for converting a PartialDuration to Duration.

The core reasoning is to simplify the case where someone would want to add a single day in Rust.

```rust
use temporal_rs::{Temporal, PlainDate, partial::PartialDuration};

let today = Temporal::now().plain_date_iso(None).unwrap();
let one_day = PartialDuration::empty().with_days(1);
// Before: 
// let tomorrow = today.add(Duration::from_partial_duration(one_day).unwrap()).unwrap()
// After:
let tomorrow = today.add(one_day.try_into().unwrap()).unwrap();
```