### PR TITLE
Fix a small typo in errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -302,7 +302,7 @@ pub fn ixdtf_error_to_static_string(error: ParseError) -> &'static str {
 
         ParseError::InvalidDayRange => "Parsed day value not in a valid range.",
 
-        ParseError::DateYear => "Invalid chracter while parsing year value.",
+        ParseError::DateYear => "Invalid character while parsing year value.",
 
         ParseError::DateExtendedYear => "Invalid character while parsing extended year value.",
 


### PR DESCRIPTION
Looks like `chracter` was probably meant to be `character`. Tests still pass after this. I didn't see any other guidelines I should follow in `CONTRIBUTING.md`, but let me know if there's any other validation I should do.