### PR TITLE
Remove HijriSimulatedMecca / islamic-rgsa

### DIFF
--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -90,8 +90,6 @@ impl Calendar {
     pub const HIJRI_TABULAR_THURSDAY: Self = Self::new(AnyCalendarKind::HijriTabularTypeIIThursday);
     /// The Hijri Umm al-Qura calendar
     pub const HIJRI_UMM_AL_QURA: Self = Self::new(AnyCalendarKind::HijriUmmAlQura);
-    /// The Hijri simulated calendar
-    pub const HIJRI_SIMULATED: Self = Self::new(AnyCalendarKind::HijriSimulatedMecca);
     /// The ISO 8601 calendar
     pub const ISO: Self = Self::new(AnyCalendarKind::Iso);
     /// The Japanese calendar
@@ -135,7 +133,8 @@ impl Calendar {
                 }
             }
             AnyCalendarKind::HijriSimulatedMecca => {
-                const { &AnyCalendar::HijriSimulated(Hijri::new_simulated_mecca()) }
+                // This calendar is currently unsupported by Temporal
+                &AnyCalendar::Iso(Iso)
             }
             AnyCalendarKind::HijriTabularTypeIIThursday => {
                 const {

--- a/src/builtins/core/plain_month_day.rs
+++ b/src/builtins/core/plain_month_day.rs
@@ -528,34 +528,30 @@ mod tests {
 
     #[test]
     /// This test is for calendars where we don't wish to hardcode dates; but we do wish to know
-    /// that monthcodes can be constructed without issue
-    fn automated_reference_year() {
+    /// that monthcodes can be constructed without issue (currently only UAQ)
+    fn automated_uaq_reference_year() {
         let reference_iso = IsoDate::new_unchecked(1972, 12, 31);
-        for cal in [
-            AnyCalendarKind::HijriSimulatedMecca,
-            AnyCalendarKind::HijriUmmAlQura,
-        ] {
-            let calendar = Calendar::new(cal);
-            for month in 1..=12 {
-                for day in [29, 30] {
-                    let month_code = crate::builtins::calendar::month_to_month_code(month).unwrap();
 
-                    let calendar_fields = CalendarFields {
-                        month_code: Some(month_code),
-                        day: Some(day),
-                        ..Default::default()
-                    };
+        let calendar = Calendar::new(AnyCalendarKind::HijriUmmAlQura);
+        for month in 1..=12 {
+            for day in [29, 30] {
+                let month_code = crate::builtins::calendar::month_to_month_code(month).unwrap();
 
-                    let md = calendar
-                        .month_day_from_fields(calendar_fields, Overflow::Reject)
-                        .unwrap();
+                let calendar_fields = CalendarFields {
+                    month_code: Some(month_code),
+                    day: Some(day),
+                    ..Default::default()
+                };
 
-                    assert!(
-                        md.iso <= reference_iso,
-                        "Reference ISO for {month}-{day} must be before 1972-12-31, found, {:?}",
-                        md.iso,
-                    );
-                }
+                let md = calendar
+                    .month_day_from_fields(calendar_fields, Overflow::Reject)
+                    .unwrap();
+
+                assert!(
+                    md.iso <= reference_iso,
+                    "Reference ISO for {month}-{day} must be before 1972-12-31, found, {:?}",
+                    md.iso,
+                );
             }
         }
     }

--- a/src/parsed_intermediates.rs
+++ b/src/parsed_intermediates.rs
@@ -24,6 +24,9 @@ use ixdtf::records::UtcOffsetRecordOrZ;
 fn extract_kind(calendar: Option<&[u8]>) -> TemporalResult<AnyCalendarKind> {
     Ok(calendar
         .map(Calendar::try_kind_from_utf8)
+        // Note that this will successfully parse AnyCalendarKind::HijriSimulatedMecca
+        // However, Calendar::new will immediately turn it into an ISO calendar,
+        // so we don't need to do anything here.
         .transpose()?
         .unwrap_or(AnyCalendarKind::Iso))
 }

--- a/temporal_capi/bindings/c/AnyCalendarKind.d.h
+++ b/temporal_capi/bindings/c/AnyCalendarKind.d.h
@@ -22,14 +22,13 @@ typedef enum AnyCalendarKind {
   AnyCalendarKind_Hebrew = 7,
   AnyCalendarKind_Indian = 8,
   AnyCalendarKind_HijriTabularTypeIIFriday = 9,
-  AnyCalendarKind_HijriSimulatedMecca = 10,
-  AnyCalendarKind_HijriTabularTypeIIThursday = 11,
-  AnyCalendarKind_HijriUmmAlQura = 12,
-  AnyCalendarKind_Iso = 13,
-  AnyCalendarKind_Japanese = 14,
-  AnyCalendarKind_JapaneseExtended = 15,
-  AnyCalendarKind_Persian = 16,
-  AnyCalendarKind_Roc = 17,
+  AnyCalendarKind_HijriTabularTypeIIThursday = 10,
+  AnyCalendarKind_HijriUmmAlQura = 11,
+  AnyCalendarKind_Iso = 12,
+  AnyCalendarKind_Japanese = 13,
+  AnyCalendarKind_JapaneseExtended = 14,
+  AnyCalendarKind_Persian = 15,
+  AnyCalendarKind_Roc = 16,
 } AnyCalendarKind;
 
 typedef struct AnyCalendarKind_option {union { AnyCalendarKind ok; }; bool is_ok; } AnyCalendarKind_option;

--- a/temporal_capi/bindings/cpp/temporal_rs/AnyCalendarKind.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/AnyCalendarKind.d.hpp
@@ -29,14 +29,13 @@ namespace capi {
       AnyCalendarKind_Hebrew = 7,
       AnyCalendarKind_Indian = 8,
       AnyCalendarKind_HijriTabularTypeIIFriday = 9,
-      AnyCalendarKind_HijriSimulatedMecca = 10,
-      AnyCalendarKind_HijriTabularTypeIIThursday = 11,
-      AnyCalendarKind_HijriUmmAlQura = 12,
-      AnyCalendarKind_Iso = 13,
-      AnyCalendarKind_Japanese = 14,
-      AnyCalendarKind_JapaneseExtended = 15,
-      AnyCalendarKind_Persian = 16,
-      AnyCalendarKind_Roc = 17,
+      AnyCalendarKind_HijriTabularTypeIIThursday = 10,
+      AnyCalendarKind_HijriUmmAlQura = 11,
+      AnyCalendarKind_Iso = 12,
+      AnyCalendarKind_Japanese = 13,
+      AnyCalendarKind_JapaneseExtended = 14,
+      AnyCalendarKind_Persian = 15,
+      AnyCalendarKind_Roc = 16,
     };
 
     typedef struct AnyCalendarKind_option {union { AnyCalendarKind ok; }; bool is_ok; } AnyCalendarKind_option;
@@ -57,14 +56,13 @@ public:
         Hebrew = 7,
         Indian = 8,
         HijriTabularTypeIIFriday = 9,
-        HijriSimulatedMecca = 10,
-        HijriTabularTypeIIThursday = 11,
-        HijriUmmAlQura = 12,
-        Iso = 13,
-        Japanese = 14,
-        JapaneseExtended = 15,
-        Persian = 16,
-        Roc = 17,
+        HijriTabularTypeIIThursday = 10,
+        HijriUmmAlQura = 11,
+        Iso = 12,
+        Japanese = 13,
+        JapaneseExtended = 14,
+        Persian = 15,
+        Roc = 16,
     };
 
     AnyCalendarKind(): value(Value::Buddhist) {}

--- a/temporal_capi/bindings/cpp/temporal_rs/AnyCalendarKind.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/AnyCalendarKind.hpp
@@ -44,7 +44,6 @@ inline temporal_rs::AnyCalendarKind temporal_rs::AnyCalendarKind::FromFFI(tempor
         case temporal_rs::capi::AnyCalendarKind_Hebrew:
         case temporal_rs::capi::AnyCalendarKind_Indian:
         case temporal_rs::capi::AnyCalendarKind_HijriTabularTypeIIFriday:
-        case temporal_rs::capi::AnyCalendarKind_HijriSimulatedMecca:
         case temporal_rs::capi::AnyCalendarKind_HijriTabularTypeIIThursday:
         case temporal_rs::capi::AnyCalendarKind_HijriUmmAlQura:
         case temporal_rs::capi::AnyCalendarKind_Iso:

--- a/temporal_capi/src/calendar.rs
+++ b/temporal_capi/src/calendar.rs
@@ -18,7 +18,6 @@ pub mod ffi {
         Hebrew,
         Indian,
         HijriTabularTypeIIFriday,
-        HijriSimulatedMecca,
         HijriTabularTypeIIThursday,
         HijriUmmAlQura,
         Iso,
@@ -33,6 +32,8 @@ pub mod ffi {
             let value = icu_locale::extensions::unicode::Value::try_from_utf8(s).ok()?;
             let algorithm = CalendarAlgorithm::try_from(&value).ok()?;
             match icu_calendar::AnyCalendarKind::try_from(algorithm) {
+                // islamic-rgsa / simulated-mecca is supported by ICU4X but not Temporal
+                Ok(icu_calendar::AnyCalendarKind::HijriSimulatedMecca) => None,
                 Ok(c) => Some(c.into()),
                 Err(()) if algorithm == CalendarAlgorithm::Hijri(None) => {
                     Some(Self::HijriTabularTypeIIFriday)


### PR DESCRIPTION
The spec doesn't have it anymore.

We use AnyCalendarKind parsing code so we still parse it, we just turn it into Iso.

I don't quite know the best way to handle this for temporal_rs: Calendar::new is infallible, but it's mostly internally used in parsing, and we accept AnyCalendarKinds in our public API.

I think in the long run we should switch to `try_new` and in the IXDTF parsing case have a fallback to Iso.