### PR TITLE
fix: allow passing `&dyn TimeZoneProvider` in arguments

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,7 @@ A `TimeZoneProvider` API on a core builtin will look like the below.
 
 ```rust
 impl ZonedDateTime {
-    pub fn day_with_provider(&self, provider: &impl TimeZoneProvider) -> TemporalResult<u8> {
+    pub fn day_with_provider(&self, provider: &(impl TimeZoneProvider + ?Sized)) -> TemporalResult<u8> {
         // Code goes here.
     }
 }

--- a/provider/src/tzif.rs
+++ b/provider/src/tzif.rs
@@ -1917,7 +1917,7 @@ mod tests {
             id: &str,
             before_offset: i64,
             after_offset: i64,
-            provider: &impl TimeZoneProvider,
+            provider: &(impl TimeZoneProvider + ?Sized),
         ) {
             let id = provider.get(id.as_bytes()).unwrap();
             let before_possible = provider

--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -830,7 +830,7 @@ impl Duration {
         &self,
         other: &Duration,
         relative_to: Option<RelativeTo>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Ordering> {
         if self == other {
             return Ok(Ordering::Equal);
@@ -1054,7 +1054,7 @@ impl Duration {
         &self,
         options: RoundingOptions,
         relative_to: Option<RelativeTo>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         // NOTE(HalidOdat): Steps 1-12 are handled before calling the function.
         //
@@ -1286,7 +1286,7 @@ impl Duration {
         &self,
         unit: Unit,
         relative_to: Option<RelativeTo>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
         // Review question what is the return type of duration.prototye.total?
     ) -> TemporalResult<FiniteF64> {
         match relative_to {

--- a/src/builtins/core/duration/normalized.rs
+++ b/src/builtins/core/duration/normalized.rs
@@ -372,7 +372,7 @@ impl InternalDurationRecord {
         sign: Sign,
         dest_epoch_ns: i128,
         dt: &PlainDateTime,
-        time_zone: Option<(&TimeZone, &impl TimeZoneProvider)>, // ???
+        time_zone: Option<(&TimeZone, &(impl TimeZoneProvider + ?Sized))>, // ???
         options: ResolvedRoundingOptions,
     ) -> TemporalResult<NudgeRecord> {
         // NOTE: r2 may never be used...need to test.
@@ -660,7 +660,7 @@ impl InternalDurationRecord {
         dt: &PlainDateTime,
         time_zone: &TimeZone,
         options: ResolvedRoundingOptions,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<NudgeRecord> {
         let d = self.date();
         // 1.Let start be ? CalendarDateAdd(calendar, isoDateTime.[[ISODate]], duration.[[Date]], constrain).
@@ -822,7 +822,7 @@ impl InternalDurationRecord {
         sign: Sign,
         nudged_epoch_ns: i128,
         iso_date_time: &IsoDateTime,
-        time_zone: Option<(&TimeZone, &impl TimeZoneProvider)>,
+        time_zone: Option<(&TimeZone, &(impl TimeZoneProvider + ?Sized))>,
         calendar: &Calendar,
         largest_unit: Unit,
         smallest_unit: Unit,
@@ -956,7 +956,7 @@ impl InternalDurationRecord {
         &self,
         dest_epoch_ns: i128,
         dt: &PlainDateTime,
-        time_zone: Option<(&TimeZone, &impl TimeZoneProvider)>,
+        time_zone: Option<(&TimeZone, &(impl TimeZoneProvider + ?Sized))>,
         options: ResolvedRoundingOptions,
     ) -> TemporalResult<InternalDurationRecord> {
         let duration = *self;
@@ -1014,7 +1014,7 @@ impl InternalDurationRecord {
         &self,
         dest_epoch_ns: i128,
         dt: &PlainDateTime,
-        time_zone: Option<(&TimeZone, &impl TimeZoneProvider)>,
+        time_zone: Option<(&TimeZone, &(impl TimeZoneProvider + ?Sized))>,
         unit: Unit,
     ) -> TemporalResult<FiniteF64> {
         // 1. If IsCalendarUnit(unit) is true, or timeZone is not unset and unit is day, then

--- a/src/builtins/core/instant.rs
+++ b/src/builtins/core/instant.rs
@@ -395,7 +395,7 @@ impl Instant {
     pub fn to_zoned_date_time_iso_with_provider(
         &self,
         time_zone: TimeZone,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<ZonedDateTime> {
         ZonedDateTime::new_unchecked_with_provider(*self, time_zone, Calendar::ISO, provider)
     }
@@ -409,7 +409,7 @@ impl Instant {
         &self,
         timezone: Option<TimeZone>,
         options: ToStringRoundingOptions,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<String> {
         self.to_ixdtf_writeable_with_provider(timezone, options, provider)
             .map(|x| x.write_to_string().into())
@@ -420,7 +420,7 @@ impl Instant {
         &self,
         timezone: Option<TimeZone>,
         options: ToStringRoundingOptions,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<impl Writeable + '_> {
         let resolved_options = options.resolve()?;
         let round = self.round_instant(ResolvedRoundingOptions::from_to_string_options(

--- a/src/builtins/core/now.rs
+++ b/src/builtins/core/now.rs
@@ -24,7 +24,7 @@ impl<H: HostHooks> Now<H> {
     pub(crate) fn system_datetime_with_provider(
         self,
         time_zone: Option<TimeZone>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<IsoDateTime> {
         let system_nanoseconds = self.host_hooks.get_system_epoch_nanoseconds()?;
         let time_zone = time_zone.unwrap_or(self.host_hooks.get_system_time_zone(provider)?);
@@ -34,7 +34,7 @@ impl<H: HostHooks> Now<H> {
     /// Converts the current [`Now`] into a [`TimeZone`].
     pub fn time_zone_with_provider(
         self,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<TimeZone> {
         self.host_hooks.get_system_time_zone(provider)
     }
@@ -50,7 +50,7 @@ impl<H: HostHooks> Now<H> {
     pub fn zoned_date_time_iso_with_provider(
         self,
         time_zone: Option<TimeZone>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<ZonedDateTime> {
         let system_nanoseconds = self.host_hooks.get_system_epoch_nanoseconds()?;
         let time_zone = time_zone.unwrap_or(self.host_hooks.get_system_time_zone(provider)?);
@@ -67,7 +67,7 @@ impl<H: HostHooks> Now<H> {
     pub fn plain_date_time_iso_with_provider(
         self,
         time_zone: Option<TimeZone>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<PlainDateTime> {
         let iso = self.system_datetime_with_provider(time_zone, provider)?;
         Ok(PlainDateTime::new_unchecked(iso, Calendar::ISO))
@@ -80,7 +80,7 @@ impl<H: HostHooks> Now<H> {
     pub fn plain_date_iso_with_provider(
         self,
         time_zone: Option<TimeZone>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<PlainDate> {
         let iso = self.system_datetime_with_provider(time_zone, provider)?;
         Ok(PlainDate::new_unchecked(iso.date, Calendar::ISO))
@@ -93,7 +93,7 @@ impl<H: HostHooks> Now<H> {
     pub fn plain_time_with_provider(
         self,
         time_zone: Option<TimeZone>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<PlainTime> {
         let iso = self.system_datetime_with_provider(time_zone, provider)?;
         Ok(PlainTime::new_unchecked(iso.time))
@@ -148,7 +148,10 @@ mod tests {
         }
 
         impl HostTimeZone for TestHooks {
-            fn get_host_time_zone(&self, _: &impl TimeZoneProvider) -> TemporalResult<TimeZone> {
+            fn get_host_time_zone(
+                &self,
+                _: &(impl TimeZoneProvider + ?Sized),
+            ) -> TemporalResult<TimeZone> {
                 Ok(self.time_zone)
             }
         }

--- a/src/builtins/core/plain_date.rs
+++ b/src/builtins/core/plain_date.rs
@@ -660,7 +660,7 @@ impl PlainDate {
         &self,
         time_zone: TimeZone,
         plain_time: Option<PlainTime>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<ZonedDateTime> {
         // NOTE (nekevss): Steps 1-4 are engine specific
         let epoch_ns = if let Some(time) = plain_time {

--- a/src/builtins/core/plain_date_time.rs
+++ b/src/builtins/core/plain_date_time.rs
@@ -892,7 +892,7 @@ impl PlainDateTime {
         &self,
         time_zone: TimeZone,
         disambiguation: Disambiguation,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<ZonedDateTime> {
         // 6. Let epochNs be ? GetEpochNanosecondsFor(timeZone, dateTime.[[ISODateTime]], disambiguation).
         let epoch_ns = time_zone.get_epoch_nanoseconds_for(self.iso, disambiguation, provider)?;

--- a/src/builtins/core/plain_month_day.rs
+++ b/src/builtins/core/plain_month_day.rs
@@ -353,7 +353,7 @@ impl PlainMonthDay {
     pub fn epoch_ns_for_with_provider(
         &self,
         time_zone: TimeZone,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<EpochNanoseconds> {
         // 2. Let isoDateTime be CombineISODateAndTimeRecord(temporalYearMonth.[[ISODate]], NoonTimeRecord()).
         let iso = IsoDateTime::new(self.iso, IsoTime::noon())?;

--- a/src/builtins/core/plain_year_month.rs
+++ b/src/builtins/core/plain_year_month.rs
@@ -615,7 +615,7 @@ impl PlainYearMonth {
     pub fn epoch_ns_for_with_provider(
         &self,
         time_zone: TimeZone,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<EpochNanoseconds> {
         // 2. Let isoDateTime be CombineISODateAndTimeRecord(temporalYearMonth.[[ISODate]], NoonTimeRecord()).
         let iso = IsoDateTime::new(self.iso, IsoTime::noon())?;

--- a/src/builtins/core/time_zone.rs
+++ b/src/builtins/core/time_zone.rs
@@ -172,7 +172,7 @@ impl TimeZone {
     #[inline]
     pub(crate) fn from_time_zone_record(
         record: TimeZoneRecord<Utf8>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         let timezone = match record {
             TimeZoneRecord::Name(name) => TimeZone::IanaIdentifier(provider.get(name)?),
@@ -190,7 +190,7 @@ impl TimeZone {
     /// Parses a `TimeZone` from a provided `&str`.
     pub fn try_from_identifier_str_with_provider(
         identifier: &str,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         parse_identifier(identifier).map(|tz| match tz {
             TimeZoneRecord::Name(name) => Ok(TimeZone::IanaIdentifier(provider.get(name)?)),
@@ -210,7 +210,7 @@ impl TimeZone {
     /// This is the equivalent to [`ParseTemporalTimeZoneString`](https://tc39.es/proposal-temporal/#sec-temporal-parsetemporaltimezonestring)
     pub fn try_from_str_with_provider(
         src: &str,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         if let Ok(timezone) = Self::try_from_identifier_str_with_provider(src, provider) {
             return Ok(timezone);
@@ -227,7 +227,7 @@ impl TimeZone {
     /// Returns the current `TimeZoneSlot`'s identifier.
     pub fn identifier_with_provider(
         &self,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<String> {
         Ok(match self {
             TimeZone::IanaIdentifier(s) => provider.identifier(*s)?.into(),
@@ -244,7 +244,7 @@ impl TimeZone {
     /// Get the primary identifier for this timezone
     pub fn primary_identifier_with_provider(
         &self,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         Ok(match self {
             TimeZone::IanaIdentifier(s) => TimeZone::IanaIdentifier(provider.canonicalized(*s)?),
@@ -262,7 +262,7 @@ impl TimeZone {
     pub(crate) fn time_zone_equals_with_provider(
         &self,
         other: &Self,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<bool> {
         Ok(match (self, other) {
             (TimeZone::IanaIdentifier(one), TimeZone::IanaIdentifier(two)) => {
@@ -282,7 +282,7 @@ impl TimeZone {
     }
 
     /// Get the primary identifier for this timezone
-    pub fn utc_with_provider(provider: &impl TimeZoneProvider) -> Self {
+    pub fn utc_with_provider(provider: &(impl TimeZoneProvider + ?Sized)) -> Self {
         Self::IanaIdentifier(provider.get(b"UTC").unwrap_or_default())
     }
 }
@@ -303,7 +303,7 @@ impl TimeZone {
     pub(crate) fn get_iso_datetime_for(
         &self,
         instant: &Instant,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<IsoDateTime> {
         // 1. Let offsetNanoseconds be GetOffsetNanosecondsFor(timeZone, epochNs).
         let nanos = self.get_offset_nanos_for(instant.as_i128(), provider)?;
@@ -321,7 +321,7 @@ impl TimeZone {
     pub(crate) fn get_offset_nanos_for(
         &self,
         utc_epoch: i128,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<i128> {
         // 1. Let parseResult be ! ParseTimeZoneIdentifier(timeZone).
         match self {
@@ -340,7 +340,7 @@ impl TimeZone {
     pub(crate) fn get_utc_offset_for(
         &self,
         utc_epoch: i128,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<UtcOffset> {
         let offset = self.get_offset_nanos_for(utc_epoch, provider)?;
         let offset = i64::try_from(offset).ok().temporal_unwrap()?;
@@ -351,7 +351,7 @@ impl TimeZone {
         &self,
         local_iso: IsoDateTime,
         disambiguation: Disambiguation,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<EpochNanosecondsAndOffset> {
         // 1. Let possibleEpochNs be ? GetPossibleEpochNanoseconds(timeZone, isoDateTime).
         let possible_nanos = self.get_possible_epoch_ns_for(local_iso, provider)?;
@@ -363,7 +363,7 @@ impl TimeZone {
     pub(crate) fn get_possible_epoch_ns_for(
         &self,
         local_iso: IsoDateTime,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<CandidateEpochNanoseconds> {
         // 1.Let parseResult be ! ParseTimeZoneIdentifier(timeZone).
         let possible_nanoseconds = match self {
@@ -442,7 +442,7 @@ impl TimeZone {
         nanos: CandidateEpochNanoseconds,
         iso: IsoDateTime,
         disambiguation: Disambiguation,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<EpochNanosecondsAndOffset> {
         // 1. Let n be possibleEpochNs's length.
         let valid_bounds = match nanos {
@@ -556,7 +556,7 @@ impl TimeZone {
     pub(crate) fn get_start_of_day(
         &self,
         iso_date: &IsoDate,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<EpochNanosecondsAndOffset> {
         // 1. Let isoDateTime be CombineISODateAndTimeRecord(isoDate, MidnightTimeRecord()).
         let iso = IsoDateTime::new_unchecked(*iso_date, IsoTime::default());

--- a/src/builtins/core/zoned_date_time.rs
+++ b/src/builtins/core/zoned_date_time.rs
@@ -283,7 +283,7 @@ impl ZonedDateTime {
         instant: Instant,
         time_zone: TimeZone,
         calendar: Calendar,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         let offset = time_zone
             .get_utc_offset_for(instant.epoch_nanoseconds().0, provider)
@@ -307,7 +307,7 @@ impl ZonedDateTime {
         &self,
         duration: InternalDurationRecord,
         overflow: Overflow,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Instant> {
         // 1. If DateDurationSign(duration.[[Date]]) = 0, then
         if duration.date().sign() == Sign::Zero {
@@ -349,7 +349,7 @@ impl ZonedDateTime {
         &self,
         duration: &Duration,
         overflow: Overflow,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         // 1. Let duration be ? ToTemporalDuration(temporalDurationLike).
         // 2. If operation is subtract, set duration to CreateNegatedTemporalDuration(duration).
@@ -375,7 +375,7 @@ impl ZonedDateTime {
         &self,
         other: &Instant,
         resolved_options: ResolvedRoundingOptions,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<InternalDurationRecord> {
         // 1. If UnitCategory(largestUnit) is time, then
         if resolved_options.largest_unit.is_time_unit() {
@@ -406,7 +406,7 @@ impl ZonedDateTime {
         &self,
         other: &Instant,
         unit: Unit,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<FiniteF64> {
         // 1. If UnitCategory(unit) is time, then
         if unit.is_time_unit() {
@@ -436,7 +436,7 @@ impl ZonedDateTime {
         &self,
         other: &Instant,
         largest_unit: Unit,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<InternalDurationRecord> {
         // 1. If ns1 = ns2, return CombineDateAndTimeDuration(ZeroDateDuration(), 0).
         if self.epoch_nanoseconds() == other.epoch_nanoseconds() {
@@ -517,7 +517,7 @@ impl ZonedDateTime {
         op: DifferenceOperation,
         other: &Self,
         options: DifferenceSettings,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Duration> {
         // NOTE: for order of operations, this should be asserted prior to this point
         // by any engine implementors, but asserting out of caution.
@@ -590,7 +590,7 @@ impl ZonedDateTime {
         nanos: i128,
         time_zone: TimeZone,
         calendar: Calendar,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         let instant = Instant::try_new(nanos)?;
         Self::new_unchecked_with_provider(instant, time_zone, calendar, provider)
@@ -618,7 +618,7 @@ impl ZonedDateTime {
     pub fn try_new_iso_with_provider(
         nanos: i128,
         time_zone: TimeZone,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         let instant = Instant::try_new(nanos)?;
         Self::new_unchecked_with_provider(instant, time_zone, Calendar::ISO, provider)
@@ -630,7 +630,7 @@ impl ZonedDateTime {
         instant: Instant,
         time_zone: TimeZone,
         calendar: Calendar,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         Self::new_unchecked_with_provider(instant, time_zone, calendar, provider)
     }
@@ -640,7 +640,7 @@ impl ZonedDateTime {
     pub fn try_new_iso_from_instant_with_provider(
         instant: Instant,
         time_zone: TimeZone,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         Self::new_unchecked_with_provider(instant, time_zone, Calendar::ISO, provider)
     }
@@ -666,7 +666,7 @@ impl ZonedDateTime {
         overflow: Option<Overflow>,
         disambiguation: Option<Disambiguation>,
         offset_option: Option<OffsetDisambiguation>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         let overflow = overflow.unwrap_or(Overflow::Constrain);
         let disambiguation = disambiguation.unwrap_or(Disambiguation::Compatible);
@@ -729,7 +729,7 @@ impl ZonedDateTime {
         disambiguation: Option<Disambiguation>,
         offset_option: Option<OffsetDisambiguation>,
         overflow: Option<Overflow>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         let overflow = overflow.unwrap_or_default();
         let disambiguation = disambiguation.unwrap_or_default();
@@ -785,7 +785,7 @@ impl ZonedDateTime {
     pub fn with_time_zone_with_provider(
         &self,
         time_zone: TimeZone,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         Self::try_new_with_provider(
             self.epoch_nanoseconds().as_i128(),
@@ -830,7 +830,7 @@ impl ZonedDateTime {
     pub fn get_time_zone_transition_with_provider(
         &self,
         direction: TransitionDirection,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Option<Self>> {
         // 8. If IsOffsetTimeZoneIdentifier(timeZone) is true, return null.
         let TimeZone::IanaIdentifier(identifier) = self.time_zone else {
@@ -872,7 +872,7 @@ impl ZonedDateTime {
 
     pub fn hours_in_day_with_provider(
         &self,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<f64> {
         // 1-3. Is engine specific steps
         // 4. Let isoDateTime be GetISODateTimeFor(timeZone, zonedDateTime.[[EpochNanoseconds]]).
@@ -1095,7 +1095,7 @@ impl ZonedDateTime {
     pub fn with_plain_time_and_provider(
         &self,
         time: Option<PlainTime>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         let iso = self.get_iso_datetime();
         let epoch_ns = if let Some(time) = time {
@@ -1121,7 +1121,7 @@ impl ZonedDateTime {
         &self,
         duration: &Duration,
         overflow: Option<Overflow>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         self.add_internal(duration, overflow.unwrap_or(Overflow::Constrain), provider)
     }
@@ -1131,7 +1131,7 @@ impl ZonedDateTime {
         &self,
         duration: &Duration,
         overflow: Option<Overflow>,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         self.add_internal(
             &duration.negated(),
@@ -1144,7 +1144,7 @@ impl ZonedDateTime {
     pub fn equals_with_provider(
         &self,
         other: &Self,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<bool> {
         // 4. If zonedDateTime.[[EpochNanoseconds]] ≠ other.[[EpochNanoseconds]], return false.
         if self.instant != other.instant {
@@ -1167,7 +1167,7 @@ impl ZonedDateTime {
         &self,
         other: &Self,
         options: DifferenceSettings,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Duration> {
         self.diff_internal_with_provider(DifferenceOperation::Since, other, options, provider)
     }
@@ -1177,7 +1177,7 @@ impl ZonedDateTime {
         &self,
         other: &Self,
         options: DifferenceSettings,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Duration> {
         self.diff_internal_with_provider(DifferenceOperation::Until, other, options, provider)
     }
@@ -1186,7 +1186,7 @@ impl ZonedDateTime {
     /// for the current `ZonedDateTime`.
     pub fn start_of_day_with_provider(
         &self,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         let iso = self.get_iso_datetime();
         let epoch_nanos = self.time_zone.get_start_of_day(&iso.date, provider)?;
@@ -1219,7 +1219,7 @@ impl ZonedDateTime {
     /// Creates a default formatted IXDTF (RFC 9557) date/time string for the provided `ZonedDateTime`.
     pub fn to_string_with_provider(
         &self,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<String> {
         self.to_ixdtf_string_with_provider(
             DisplayOffset::Auto,
@@ -1234,7 +1234,7 @@ impl ZonedDateTime {
     pub fn round_with_provider(
         &self,
         options: RoundingOptions,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         // 1. Let zonedDateTime be the this value.
         // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
@@ -1362,7 +1362,7 @@ impl ZonedDateTime {
         display_timezone: DisplayTimeZone,
         display_calendar: DisplayCalendar,
         options: ToStringRoundingOptions,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<String> {
         let resolved_options = options.resolve()?;
         let result =
@@ -1395,7 +1395,7 @@ impl ZonedDateTime {
         source: &[u8],
         disambiguation: Disambiguation,
         offset_option: OffsetDisambiguation,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         let parsed = ParsedZonedDateTime::from_utf8_with_provider(source, provider)?;
 
@@ -1406,7 +1406,7 @@ impl ZonedDateTime {
         parsed: ParsedZonedDateTime,
         disambiguation: Disambiguation,
         offset_option: OffsetDisambiguation,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         let date = IsoDate::new_with_overflow(
             parsed.date.record.year,
@@ -1453,7 +1453,7 @@ pub(crate) fn interpret_isodatetime_offset(
     disambiguation: Disambiguation,
     offset_option: OffsetDisambiguation,
     match_minutes: bool,
-    provider: &impl TimeZoneProvider,
+    provider: &(impl TimeZoneProvider + ?Sized),
 ) -> TemporalResult<EpochNanosecondsAndOffset> {
     // 1.  If time is start-of-day, then
     let Some(time) = time else {

--- a/src/builtins/core/zoned_date_time/tests.rs
+++ b/src/builtins/core/zoned_date_time/tests.rs
@@ -488,7 +488,7 @@ fn basic_zdt_add() {
 
 fn parse_zdt_with_reject(
     s: &str,
-    provider: &impl TimeZoneProvider,
+    provider: &(impl TimeZoneProvider + ?Sized),
 ) -> TemporalResult<ZonedDateTime> {
     ZonedDateTime::from_utf8_with_provider(
         s.as_bytes(),
@@ -500,7 +500,7 @@ fn parse_zdt_with_reject(
 
 fn parse_zdt_with_compatible(
     s: &str,
-    provider: &impl TimeZoneProvider,
+    provider: &(impl TimeZoneProvider + ?Sized),
 ) -> TemporalResult<ZonedDateTime> {
     ZonedDateTime::from_utf8_with_provider(
         s.as_bytes(),
@@ -599,7 +599,10 @@ fn test_pacific_niue() {
     })
 }
 
-fn total_seconds_for_one_day(s: &str, provider: &impl TimeZoneProvider) -> TemporalResult<f64> {
+fn total_seconds_for_one_day(
+    s: &str,
+    provider: &(impl TimeZoneProvider + ?Sized),
+) -> TemporalResult<f64> {
     Ok(Duration::new(0, 0, 0, 1, 0, 0, 0, 0, 0, 0)
         .unwrap()
         .total_with_provider(
@@ -645,7 +648,7 @@ fn assert_tr(
     zdt: &ZonedDateTime,
     direction: TransitionDirection,
     s: &str,
-    provider: &impl TimeZoneProvider,
+    provider: &(impl TimeZoneProvider + ?Sized),
 ) {
     assert_eq!(
         zdt.get_time_zone_transition_with_provider(direction, provider)

--- a/src/host.rs
+++ b/src/host.rs
@@ -13,7 +13,10 @@ pub trait HostClock {
 
 /// The `HostTimeZone` trait defines the host's time zone.
 pub trait HostTimeZone {
-    fn get_host_time_zone(&self, provider: &impl TimeZoneProvider) -> TemporalResult<TimeZone>;
+    fn get_host_time_zone(
+        &self,
+        provider: &(impl TimeZoneProvider + ?Sized),
+    ) -> TemporalResult<TimeZone>;
 }
 
 /// `HostHooks` marks whether a trait implements the required host hooks with some
@@ -23,7 +26,10 @@ pub trait HostHooks: HostClock + HostTimeZone {
         self.get_host_epoch_nanoseconds()
     }
 
-    fn get_system_time_zone(&self, provider: &impl TimeZoneProvider) -> TemporalResult<TimeZone> {
+    fn get_system_time_zone(
+        &self,
+        provider: &(impl TimeZoneProvider + ?Sized),
+    ) -> TemporalResult<TimeZone> {
         self.get_host_time_zone(provider)
     }
 }
@@ -54,7 +60,7 @@ impl HostClock for EmptyHostSystem {
 }
 
 impl HostTimeZone for EmptyHostSystem {
-    fn get_host_time_zone(&self, _: &impl TimeZoneProvider) -> TemporalResult<TimeZone> {
+    fn get_host_time_zone(&self, _: &(impl TimeZoneProvider + ?Sized)) -> TemporalResult<TimeZone> {
         Ok(TimeZone::from(UtcOffset::default()))
     }
 }

--- a/src/options/relative_to.rs
+++ b/src/options/relative_to.rs
@@ -38,7 +38,7 @@ impl RelativeTo {
     /// is invalid, then an error is returned.
     pub fn try_from_str_with_provider(
         source: &str,
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         // b. Let result be ? ParseISODateTime(value, « TemporalDateTimeString[+Zoned], TemporalDateTimeString[~Zoned] »).
         let bytes = source.as_bytes();

--- a/src/parsed_intermediates.rs
+++ b/src/parsed_intermediates.rs
@@ -132,7 +132,7 @@ impl ParsedZonedDateTime {
     /// Converts a UTF-8 encoded string into a `ParsedZonedDateTime`.
     pub fn from_utf8_with_provider(
         source: &[u8],
-        provider: &impl TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
         // Steps from the parse bits of of ToZonedDateTime
 

--- a/src/parsers/time_zone.rs
+++ b/src/parsers/time_zone.rs
@@ -12,7 +12,7 @@ use super::{parse_ixdtf, ParseVariant};
 #[inline]
 pub(crate) fn parse_allowed_timezone_formats(
     s: &str,
-    provider: &impl TimeZoneProvider,
+    provider: &(impl TimeZoneProvider + ?Sized),
 ) -> Option<TimeZone> {
     let (offset, annotation) = if let Ok((offset, annotation)) =
         parse_ixdtf(s.as_bytes(), ParseVariant::DateTime).map(|r| (r.offset, r.tz))

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -7,7 +7,6 @@ use crate::TemporalResult;
 use crate::unix_time::EpochNanoseconds;
 use crate::TemporalError;
 use crate::TimeZone;
-#[cfg(feature = "sys")]
 use timezone_provider::provider::TimeZoneProvider;
 use web_time::{SystemTime, UNIX_EPOCH};
 
@@ -22,10 +21,8 @@ use web_time::{SystemTime, UNIX_EPOCH};
 //
 
 /// The Temporal object for accessing current system time
-#[cfg(feature = "sys")]
 pub struct Temporal;
 
-#[cfg(feature = "sys")]
 impl Temporal {
     /// Get a `Now` object for the default host system.
     pub fn now() -> Now<DefaultHostSystem> {
@@ -36,39 +33,35 @@ impl Temporal {
 /// A default host system implementation
 ///
 /// This implementation is backed by [`SystemTime`] and [`iana_time_zone`]
-#[cfg(feature = "sys")]
 pub struct DefaultHostSystem;
 
-#[cfg(feature = "sys")]
 impl HostHooks for DefaultHostSystem {}
 
-#[cfg(feature = "sys")]
 impl HostClock for DefaultHostSystem {
     fn get_host_epoch_nanoseconds(&self) -> TemporalResult<EpochNanoseconds> {
         get_system_nanoseconds()
     }
 }
 
-#[cfg(feature = "sys")]
 impl HostTimeZone for DefaultHostSystem {
     fn get_host_time_zone(
         &self,
-        provider: &impl timezone_provider::provider::TimeZoneProvider,
+        provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<TimeZone> {
         get_system_timezone(provider)
     }
 }
 
-#[cfg(feature = "sys")]
 #[inline]
-pub(crate) fn get_system_timezone(provider: &impl TimeZoneProvider) -> TemporalResult<TimeZone> {
+pub(crate) fn get_system_timezone(
+    provider: &(impl TimeZoneProvider + ?Sized),
+) -> TemporalResult<TimeZone> {
     iana_time_zone::get_timezone()
         .map(|s| TimeZone::try_from_identifier_str_with_provider(&s, provider))
         .map_err(|_| TemporalError::general("Error fetching system time"))?
 }
 
 /// Returns the system time in nanoseconds.
-#[cfg(feature = "sys")]
 pub(crate) fn get_system_nanoseconds() -> TemporalResult<EpochNanoseconds> {
     use crate::unix_time::EpochNanoseconds;
 


### PR DESCRIPTION
Tested the crate using `cargo semver-checks` and everything looks good, so we could release this change in a 0.1.1 version if we want to.