### PR TITLE
Fix serialization of durations with zero seconds and nonzero subseconds

### DIFF
--- a/src/builtins/core/duration/tests.rs
+++ b/src/builtins/core/duration/tests.rs
@@ -73,6 +73,12 @@ fn duration_to_string_auto_precision() {
         .as_temporal_string(ToStringRoundingOptions::default())
         .unwrap();
     assert_eq!(&result, "P1Y2M3W4DT5H6M7.98765S");
+
+    let duration = Duration::new(0, 0, 0, 2, 0, 0, 0, 0, 0, 1).unwrap();
+    let result = duration
+        .as_temporal_string(ToStringRoundingOptions::default())
+        .unwrap();
+    assert_eq!(&result, "P2DT0.000000001S");
 }
 
 #[test]

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -594,6 +594,7 @@ impl Writeable for FormattableDuration {
                     let unit_below_minute = self.date.is_none() && hours == 0 && minutes == 0;
 
                     let write_second = seconds != 0
+                        || ns != 0
                         || unit_below_minute
                         || matches!(self.precision, Precision::Digit(_));
 
@@ -899,10 +900,26 @@ pub fn parse_allowed_calendar_formats(s: &[u8]) -> Option<&[u8]> {
 
 #[cfg(test)]
 mod tests {
-    use super::{FormattableDate, FormattableOffset};
-    use crate::parsers::{FormattableTime, Precision};
+    use super::{FormattableDate, FormattableDuration, FormattableOffset};
+    use crate::parsers::{FormattableTime, FormattableTimeDuration, Precision};
     use alloc::format;
     use writeable::assert_writeable_eq;
+
+    #[test]
+    fn duration() {
+        let duration = FormattableDuration {
+            sign: crate::Sign::Positive,
+            date: Some(super::FormattableDateDuration {
+                years: 1,
+                months: 0,
+                weeks: 0,
+                days: 0,
+            }),
+            time: Some(FormattableTimeDuration::Seconds(0, 0, 0, Some(1))),
+            precision: Precision::Auto,
+        };
+        assert_writeable_eq!(duration, "P1YT0.000000001S");
+    }
 
     #[test]
     fn offset_string() {


### PR DESCRIPTION
Previously, if a duration had nonzero minutes or higher, zero seconds, and nonzero subseconds, the subseconds would not be printed.

See test262 tests at https://github.com/tc39/test262/pull/4620. Also adds simple inline tests for this case.