### PR TITLE
Fix returned duration sign for non-ISO date arithmetic

### DIFF
--- a/src/builtins/core/calendar.rs
+++ b/src/builtins/core/calendar.rs
@@ -514,12 +514,16 @@ impl Calendar {
             .days
             .try_into()
             .map_err(|_| TemporalError::range().with_enum(ErrorMessage::DurationNotValid))?;
-        let duration = DateDuration::new(
+        let mut duration = DateDuration::new(
             added.years.into(),
             added.months.into(),
             added.weeks.into(),
             days,
         )?;
+
+        if added.is_negative {
+            duration = duration.negated();
+        }
         Ok(Duration::from(duration))
     }
 

--- a/src/builtins/core/plain_date_time.rs
+++ b/src/builtins/core/plain_date_time.rs
@@ -1310,6 +1310,24 @@ mod tests {
     }
 
     #[test]
+    fn dt_since_conflicting_signs() {
+        // From intl402/Temporal/PlainDateTime/prototype/since/wrapping-at-end-of-month-gregorian
+        // Tests that date arithmetic with conflicting signs works
+        let a = PlainDateTime::try_new(2023, 3, 1, 2, 0, 0, 0, 0, 0, Calendar::GREGORIAN).unwrap();
+        let b = PlainDateTime::try_new(2023, 1, 1, 3, 0, 0, 0, 0, 0, Calendar::GREGORIAN).unwrap();
+
+        let settings = DifferenceSettings {
+            largest_unit: Some(Unit::Year),
+            ..Default::default()
+        };
+        let result = a.since(&b, settings).unwrap();
+
+        assert_eq!(result.months(), 1);
+        assert_eq!(result.days(), 30);
+        assert_eq!(result.hours(), 23);
+    }
+
+    #[test]
     fn dt_round_basic() {
         let assert_datetime =
             |dt: PlainDateTime, expected: (i32, u8, u8, u8, u8, u8, u16, u16, u16)| {


### PR DESCRIPTION
```
  'intl402/Temporal/PlainDateTime/prototype/since/wrapping-at-end-of-month-gregorian': [FAIL],
  'intl402/Temporal/PlainDateTime/prototype/until/wrapping-at-end-of-month-gregorian': [FAIL],
```

Surprised this didn't break more things.

Fixes #617