### PR TITLE
Add feature to force float64-representable durations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,10 @@ tzdb = [
     "timezone_provider/tzif",
 ]
 std = []
+# https://github.com/boa-dev/temporal/issues/613
+# ECMA-conformant implementations must store durations as float64-representable numbers
+# Rust users probably should not enable this, unless they wish to match the quirks of JavaScript
+float64_representable_durations = []
 
 [package.metadata.cargo-all-features]
 denylist = ["default"]

--- a/src/builtins/core/duration.rs
+++ b/src/builtins/core/duration.rs
@@ -389,8 +389,21 @@ impl Duration {
             hours,
             minutes,
             seconds,
+
+            // https://github.com/boa-dev/temporal/issues/613
+            // With float64_representable_durations enabled, force all smaller units
+            // to be in the float64-representable range.
+            #[cfg(feature = "float64_representable_durations")]
+            milliseconds: milliseconds as f64 as u64,
+            #[cfg(feature = "float64_representable_durations")]
+            microseconds: microseconds as f64 as u128,
+            #[cfg(feature = "float64_representable_durations")]
+            nanoseconds: nanoseconds as f64 as u128,
+            #[cfg(not(feature = "float64_representable_durations"))]
             milliseconds,
+            #[cfg(not(feature = "float64_representable_durations"))]
             microseconds,
+            #[cfg(not(feature = "float64_representable_durations"))]
             nanoseconds,
         }
     }


### PR DESCRIPTION
Fixes https://github.com/boa-dev/temporal/issues/613