### PR TITLE
Fix ZonedDateTime::with bug when empty fields is provided

### DIFF
--- a/src/builtins/core/plain_date.rs
+++ b/src/builtins/core/plain_date.rs
@@ -1,5 +1,6 @@
 //! This module implements `PlainDate` and any directly related algorithms.
 
+use crate::error::ErrorMessage;
 use crate::parsed_intermediates::ParsedDate;
 use crate::{
     builtins::{
@@ -437,7 +438,7 @@ impl PlainDate {
     /// Creates a `PlainDate` with values from a [`PartialDate`].
     pub fn with(&self, fields: CalendarFields, overflow: Option<Overflow>) -> TemporalResult<Self> {
         if fields.is_empty() {
-            return Err(TemporalError::r#type().with_message("CalendarFields must have a field."));
+            return Err(TemporalError::r#type().with_enum(ErrorMessage::EmptyFieldsIsInvalid));
         }
         // 6. Let fieldsResult be ? PrepareCalendarFieldsAndFieldNames(calendarRec, temporalDate, « "day", "month", "monthCode", "year" »).
         // 7. Let partialDate be ? PrepareTemporalFields(temporalDateLike, fieldsResult.[[FieldNames]], partial).

--- a/src/builtins/core/plain_date_time.rs
+++ b/src/builtins/core/plain_date_time.rs
@@ -4,6 +4,7 @@ use super::{
     duration::normalized::InternalDurationRecord, Duration, PartialTime, PlainDate, PlainTime,
     ZonedDateTime,
 };
+use crate::error::ErrorMessage;
 use crate::parsed_intermediates::ParsedDateTime;
 use crate::{
     builtins::{
@@ -643,9 +644,7 @@ impl PlainDateTime {
     #[inline]
     pub fn with(&self, fields: DateTimeFields, overflow: Option<Overflow>) -> TemporalResult<Self> {
         if fields.is_empty() {
-            return Err(
-                TemporalError::r#type().with_message("A PartialDateTime must have a valid field.")
-            );
+            return Err(TemporalError::r#type().with_enum(ErrorMessage::EmptyFieldsIsInvalid));
         }
         let overflow = overflow.unwrap_or(Overflow::Constrain);
 

--- a/src/builtins/core/plain_month_day.rs
+++ b/src/builtins/core/plain_month_day.rs
@@ -5,6 +5,7 @@ use core::str::FromStr;
 
 use crate::{
     builtins::calendar::CalendarFields,
+    error::ErrorMessage,
     iso::{IsoDate, IsoDateTime, IsoTime},
     options::{Disambiguation, DisplayCalendar, Overflow},
     parsed_intermediates::ParsedDate,
@@ -265,7 +266,7 @@ impl PlainMonthDay {
         //
         // NOTE:  We assert that partial is not empty per step 6
         if fields.is_empty() {
-            return Err(TemporalError::r#type().with_message("partial object must have a field."));
+            return Err(TemporalError::r#type().with_enum(ErrorMessage::EmptyFieldsIsInvalid));
         }
 
         // NOTE: We only need to set month / month_code and day, per spec.

--- a/src/builtins/core/plain_time.rs
+++ b/src/builtins/core/plain_time.rs
@@ -5,6 +5,7 @@ use crate::{
         core::{DateDuration, Duration},
         duration::normalized::InternalDurationRecord,
     },
+    error::ErrorMessage,
     iso::IsoTime,
     options::{
         DifferenceOperation, DifferenceSettings, Overflow, ResolvedRoundingOptions,
@@ -437,7 +438,7 @@ impl PlainTime {
     pub fn with(&self, partial: PartialTime, overflow: Option<Overflow>) -> TemporalResult<Self> {
         // NOTE: 4.5.12 ToTemporalTimeRecord requires one field to be set.
         if partial.is_empty() {
-            return Err(TemporalError::r#type().with_message("PartialTime cannot be empty."));
+            return Err(TemporalError::r#type().with_enum(ErrorMessage::EmptyFieldsIsInvalid));
         }
 
         let iso = self

--- a/src/builtins/core/plain_year_month.rs
+++ b/src/builtins/core/plain_year_month.rs
@@ -7,6 +7,7 @@ use tinystr::TinyAsciiStr;
 
 use crate::{
     builtins::calendar::{CalendarFields, YearMonthCalendarFields},
+    error::ErrorMessage,
     iso::{year_month_within_limits, IsoDate, IsoDateTime, IsoTime},
     options::{
         DifferenceOperation, DifferenceSettings, Disambiguation, DisplayCalendar, Overflow,
@@ -549,9 +550,7 @@ impl PlainYearMonth {
         // 5. Let fields be ISODateToFields(calendar, yearMonth.[[ISODate]], year-month).
         // 6. Let partialYearMonth be ? PrepareCalendarFields(calendar, temporalYearMonthLike, « year, month, month-code », « », partial).
         if fields.is_empty() {
-            return Err(
-                TemporalError::r#type().with_message("plainYearMonth fields cannot be empty")
-            );
+            return Err(TemporalError::r#type().with_enum(ErrorMessage::EmptyFieldsIsInvalid));
         }
         // 7. Set fields to CalendarMergeFields(calendar, fields, partialYearMonth).
         // 8. Let resolvedOptions be ? GetOptionsObject(options).

--- a/src/builtins/core/zoned_date_time.rs
+++ b/src/builtins/core/zoned_date_time.rs
@@ -744,6 +744,9 @@ impl ZonedDateTime {
         overflow: Option<Overflow>,
         provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<Self> {
+        if fields.is_empty() {
+            return Err(TemporalError::r#type().with_enum(ErrorMessage::EmptyFieldsIsInvalid));
+        }
         let overflow = overflow.unwrap_or_default();
         let disambiguation = disambiguation.unwrap_or_default();
         let offset_option = offset_option.unwrap_or(OffsetDisambiguation::Reject);

--- a/src/error.rs
+++ b/src/error.rs
@@ -212,6 +212,7 @@ pub(crate) enum ErrorMessage {
     // Field mismatches
     CalendarMismatch,
     TzMismatch,
+    EmptyFieldsIsInvalid,
 
     // Parsing
     ParserNeedsDate,
@@ -263,6 +264,7 @@ impl ErrorMessage {
                 "Calendar must be the same for operations involving two calendared types."
             }
             Self::TzMismatch => "Timezones must be the same if unit is a day unit.",
+            Self::EmptyFieldsIsInvalid => "fields cannot be empty",
 
             Self::ParserNeedsDate => "Could not find a valid DateRecord node during parsing.",
             Self::FractionalTimeMoreThanNineDigits => "Fractional time exceeds nine digits.",


### PR DESCRIPTION
This PR rejects empty fields being provided to `ZonedDateTime::with_with_provider`.

It also adds an `ErrorMessage` value for empty fields.