### PR TITLE
Implement std::error::Error for TemporalError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -135,7 +135,7 @@ impl TemporalError {
     }
 }
 
-impl std::error::Error for TemporalError {}
+impl core::error::Error for TemporalError {}
 
 impl fmt::Display for TemporalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Currently, `TemporalError` does not implement `std::error::Error`, which makes `TemporalResult` incompatible with ecosystem crates for error conversions, such as `anyhow`.

The fix is a simple one-line addition to implement the error trait, since `TemporalError` already implements `Display` and `Debug`.