### PR TITLE
Update to Diplomat 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -94,7 +105,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -133,7 +144,7 @@ dependencies = [
  "prettyplease",
  "rustc-hash",
  "serde_json",
- "syn",
+ "syn 2.0.118",
  "timezone_provider",
  "zerovec",
 ]
@@ -146,12 +157,6 @@ checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bitflags"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
@@ -221,7 +226,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -289,7 +294,7 @@ checksum = "6834770958c7b84223607e49758ec0dde273c4df915e734aad50f62968a4c134"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -299,14 +304,14 @@ version = "0.2.4"
 
 [[package]]
 name = "diplomat"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7935649d00000f5c5d735448ad3dc07b9738160727017914cf42138b8e8e6611"
+checksum = "26fdfa02eb9a2e1ff82a375524be1ce9fd50ae63787f5737da6951b25d21e857"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -318,46 +323,44 @@ dependencies = [
 
 [[package]]
 name = "diplomat-runtime"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "640d5943a101226437e9ad4ef2b4181d0ff053a86e77cc18ae73e8c729766ac3"
+checksum = "ae517853d9f82b2d144393b1c32c34c46c2e361de2b6c44a8fdfce23beb211cd"
 
 [[package]]
 name = "diplomat-tool"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a742eeda95cd614873b815c4577519b07b737e2dceaf65f47d983bbdaabc5d7"
+checksum = "f5d41389acae2e2471446d77523afd91afdbeff407a4b703b7b628df825c0bb9"
 dependencies = [
  "askama",
  "clap",
  "colored",
  "diplomat_core",
- "displaydoc",
  "heck",
  "indenter",
  "itertools",
- "pulldown-cmark",
  "quote",
  "serde",
- "syn",
+ "syn 3.0.3",
  "syn-inline-mod",
  "toml",
 ]
 
 [[package]]
 name = "diplomat_core"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf41b94101a4bce993febaf0098092b0bb31deaf0ecaf6e0a2562465f61b383"
+checksum = "f4ede23809e2fcc555d8b2e10ffa7a1c31331ebca8e5477f4f2b48ab8a0a9a6b"
 dependencies = [
- "displaydoc",
+ "annotate-snippets",
  "either",
  "proc-macro2",
  "quote",
  "serde",
  "smallvec",
  "strck",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -368,7 +371,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -388,15 +391,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "hashbrown"
@@ -645,9 +639,9 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-traits"
@@ -693,36 +687,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
-dependencies = [
- "bitflags",
- "getopts",
- "memchr",
- "pulldown-cmark-escape",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark-escape"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"
@@ -782,7 +757,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -852,13 +827,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn-inline-mod"
-version = "0.6.0"
+name = "syn"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa6dca1fdb7b2ed46dd534a326725419d4fb10f23d8c85a8b2860e5eb25d0f9"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
- "syn",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn-inline-mod"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d5cd09c54d02e69217d362ee45b62821932cb16778a4513a722364ba4cb098"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -869,7 +855,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1000,12 +986,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,9 +993,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8_iter"
@@ -1051,7 +1031,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -1073,7 +1053,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1118,7 +1098,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1129,7 +1109,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1272,7 +1252,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -1293,7 +1273,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -1333,7 +1313,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,9 @@ zoneinfo64 = "0.3.0"
 ixdtf = "0.6.4"
 
 # Diplomat
-diplomat-tool = { version = "0.15.0", default-features = false }
-diplomat-runtime = { version = "0.15.0", default-features = false }
-diplomat = { version = "0.15.0", default-features = false }
+diplomat-tool = { version = "0.16.0", default-features = false }
+diplomat-runtime = { version = "0.16.0", default-features = false }
+diplomat = { version = "0.16.0", default-features = false }
 
 
 [package]

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.d.hpp
@@ -79,7 +79,7 @@ public:
 
   inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError> from_utf16(std::u16string_view s);
 
-  inline const temporal_rs::Calendar& calendar() const;
+  inline const temporal_rs::Calendar& calendar() const DIPLOMAT_LIFETIME_BOUND;
 
   inline bool is_valid() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDate.hpp
@@ -239,7 +239,7 @@ inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, te
     return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::PlainDate>>(std::unique_ptr<temporal_rs::PlainDate>(temporal_rs::PlainDate::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainDate>, temporal_rs::TemporalError>(temporal_rs::diplomat::Err<temporal_rs::TemporalError>(temporal_rs::TemporalError::FromFFI(result.err)));
 }
 
-inline const temporal_rs::Calendar& temporal_rs::PlainDate::calendar() const {
+inline const temporal_rs::Calendar& temporal_rs::PlainDate::calendar() const DIPLOMAT_LIFETIME_BOUND {
     auto result = temporal_rs::capi::temporal_rs_PlainDate_calendar(this->AsFFI());
     return *temporal_rs::Calendar::FromFFI(result);
 }

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.d.hpp
@@ -90,7 +90,7 @@ public:
 
   inline uint16_t nanosecond() const;
 
-  inline const temporal_rs::Calendar& calendar() const;
+  inline const temporal_rs::Calendar& calendar() const DIPLOMAT_LIFETIME_BOUND;
 
   inline int32_t year() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainDateTime.hpp
@@ -288,7 +288,7 @@ inline uint16_t temporal_rs::PlainDateTime::nanosecond() const {
     return result;
 }
 
-inline const temporal_rs::Calendar& temporal_rs::PlainDateTime::calendar() const {
+inline const temporal_rs::Calendar& temporal_rs::PlainDateTime::calendar() const DIPLOMAT_LIFETIME_BOUND {
     auto result = temporal_rs::capi::temporal_rs_PlainDateTime_calendar(this->AsFFI());
     return *temporal_rs::Calendar::FromFFI(result);
 }

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.d.hpp
@@ -57,7 +57,7 @@ public:
 
   inline uint8_t day() const;
 
-  inline const temporal_rs::Calendar& calendar() const;
+  inline const temporal_rs::Calendar& calendar() const DIPLOMAT_LIFETIME_BOUND;
 
   inline uint8_t month() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainMonthDay.hpp
@@ -128,7 +128,7 @@ inline uint8_t temporal_rs::PlainMonthDay::day() const {
     return result;
 }
 
-inline const temporal_rs::Calendar& temporal_rs::PlainMonthDay::calendar() const {
+inline const temporal_rs::Calendar& temporal_rs::PlainMonthDay::calendar() const DIPLOMAT_LIFETIME_BOUND {
     auto result = temporal_rs::capi::temporal_rs_PlainMonthDay_calendar(this->AsFFI());
     return *temporal_rs::Calendar::FromFFI(result);
 }

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.d.hpp
@@ -80,7 +80,7 @@ public:
 
   inline uint8_t reference_day() const;
 
-  inline const temporal_rs::Calendar& calendar() const;
+  inline const temporal_rs::Calendar& calendar() const DIPLOMAT_LIFETIME_BOUND;
 
   inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::PlainYearMonth>, temporal_rs::TemporalError> add(const temporal_rs::Duration& duration, temporal_rs::ArithmeticOverflow overflow) const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/PlainYearMonth.hpp
@@ -214,7 +214,7 @@ inline uint8_t temporal_rs::PlainYearMonth::reference_day() const {
     return result;
 }
 
-inline const temporal_rs::Calendar& temporal_rs::PlainYearMonth::calendar() const {
+inline const temporal_rs::Calendar& temporal_rs::PlainYearMonth::calendar() const DIPLOMAT_LIFETIME_BOUND {
     auto result = temporal_rs::capi::temporal_rs_PlainYearMonth_calendar(this->AsFFI());
     return *temporal_rs::Calendar::FromFFI(result);
 }

--- a/temporal_capi/bindings/cpp/temporal_rs/Provider.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Provider.d.hpp
@@ -35,7 +35,7 @@ public:
    *
    * This failing to construct is not a Temporal error, so it just returns ()
    */
-  inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::Provider>, std::monostate> new_zoneinfo64(temporal_rs::diplomat::span<const uint32_t> data);
+  inline static temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::Provider>, std::monostate> new_zoneinfo64(temporal_rs::diplomat::span<const uint32_t> data DIPLOMAT_LIFETIME_BOUND);
 
   inline static std::unique_ptr<temporal_rs::Provider> new_compiled();
 

--- a/temporal_capi/bindings/cpp/temporal_rs/Provider.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/Provider.hpp
@@ -31,7 +31,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::Provider>, std::monostate> temporal_rs::Provider::new_zoneinfo64(temporal_rs::diplomat::span<const uint32_t> data) {
+inline temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::Provider>, std::monostate> temporal_rs::Provider::new_zoneinfo64(temporal_rs::diplomat::span<const uint32_t> data DIPLOMAT_LIFETIME_BOUND) {
     auto result = temporal_rs::capi::temporal_rs_Provider_new_zoneinfo64({data.data(), data.size()});
     return result.is_ok ? temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::Provider>, std::monostate>(temporal_rs::diplomat::Ok<std::unique_ptr<temporal_rs::Provider>>(std::unique_ptr<temporal_rs::Provider>(temporal_rs::Provider::FromFFI(result.ok)))) : temporal_rs::diplomat::result<std::unique_ptr<temporal_rs::Provider>, std::monostate>(temporal_rs::diplomat::Err<std::monostate>());
 }

--- a/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.d.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.d.hpp
@@ -178,7 +178,7 @@ public:
 
   inline uint16_t nanosecond() const;
 
-  inline const temporal_rs::Calendar& calendar() const;
+  inline const temporal_rs::Calendar& calendar() const DIPLOMAT_LIFETIME_BOUND;
 
   inline int32_t year() const;
 

--- a/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/ZonedDateTime.hpp
@@ -652,7 +652,7 @@ inline uint16_t temporal_rs::ZonedDateTime::nanosecond() const {
     return result;
 }
 
-inline const temporal_rs::Calendar& temporal_rs::ZonedDateTime::calendar() const {
+inline const temporal_rs::Calendar& temporal_rs::ZonedDateTime::calendar() const DIPLOMAT_LIFETIME_BOUND {
     auto result = temporal_rs::capi::temporal_rs_ZonedDateTime_calendar(this->AsFFI());
     return *temporal_rs::Calendar::FromFFI(result);
 }

--- a/temporal_capi/bindings/cpp/temporal_rs/diplomat_runtime.hpp
+++ b/temporal_capi/bindings/cpp/temporal_rs/diplomat_runtime.hpp
@@ -18,6 +18,20 @@
 #include <array>
 #endif
 
+#ifndef DIPLOMAT_LIFETIME_BOUND
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(msvc::lifetimebound)
+#define DIPLOMAT_LIFETIME_BOUND [[msvc::lifetimebound]]
+#elif __has_cpp_attribute(clang::lifetimebound)
+#define DIPLOMAT_LIFETIME_BOUND [[clang::lifetimebound]]
+#endif
+#endif
+#endif
+
+#ifndef DIPLOMAT_LIFETIME_BOUND
+#define DIPLOMAT_LIFETIME_BOUND
+#endif
+
 namespace temporal_rs {
 namespace diplomat {
 
@@ -88,12 +102,16 @@ extern "C" inline void _flush(capi::DiplomatWrite* w) {
   string->resize(w->len);
 }
 
-extern "C" inline bool _grow(capi::DiplomatWrite* w, uintptr_t requested) {
+extern "C" inline bool _grow_impl(capi::DiplomatWrite* w, uintptr_t requested) {
   std::string* string = reinterpret_cast<std::string*>(w->context);
   string->resize(requested);
   w->cap = string->length();
   w->buf = &(*string)[0];
   return true;
+}
+
+extern "C" inline bool _grow(capi::DiplomatWrite* w, size_t requested) {
+  return _grow_impl(w, static_cast<uintptr_t>(requested));
 }
 
 inline capi::DiplomatWrite WriteFromString(std::string& string) {
@@ -356,6 +374,11 @@ struct as_ffi<T, std::void_t<decltype(std::declval<std::remove_pointer_t<T>>().A
   using type = decltype(std::declval<std::remove_pointer_t<T>>().AsFFI());
 };
 
+template <typename T>
+struct as_ffi<std::unique_ptr<T>> {
+  using type = decltype(std::declval<T>().AsFFI());
+};
+
 template<typename T>
 using as_ffi_t = typename as_ffi<T>::type;
 
@@ -377,7 +400,11 @@ struct diplomat_c_span_convert {
     using type = diplomat::capi::Diplomat##name##ViewMut; \
   }; \
 
+#if !defined(__sun) || !defined(_CHAR_IS_SIGNED)
+// int8_t and char are the same type on Solaris. Guard this definition to avoid
+// conflicts.
 MAKE_SLICE_CONVERTERS(I8, int8_t)
+#endif
 MAKE_SLICE_CONVERTERS(U8, uint8_t)
 MAKE_SLICE_CONVERTERS(I16, int16_t)
 MAKE_SLICE_CONVERTERS(U16, uint16_t)
@@ -394,6 +421,34 @@ MAKE_SLICE_CONVERTERS(String16, char16_t)
 
 template<typename T>
 using diplomat_c_span_convert_t = typename diplomat_c_span_convert<T>::type;
+
+template<typename T>
+struct is_unique_ptr {
+  static constexpr bool value = false;
+  using type = T;
+};
+
+template<typename T>
+struct is_unique_ptr<std::unique_ptr<T>> {
+  static constexpr bool value = true;
+  using type = T;
+};
+
+template<typename T>
+constexpr bool is_unique_ptr_v = is_unique_ptr<T>::value;
+
+template<typename T>
+struct is_optional {
+  static constexpr bool value = false;
+};
+
+template<typename T>
+struct is_optional<std::optional<T>> {
+  static constexpr bool value = true;
+};
+
+template<typename T>
+constexpr bool is_optional_v = is_optional<T>::value;
 
 /// Replace the argument types from the std::function with the argument types for th function pointer
 template<typename T>
@@ -414,6 +469,8 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
       } else if constexpr (!std::is_same_v<T, as_ffi_t<T>>) {
         if constexpr (std::is_lvalue_reference_v<T>) {
           return *std::remove_reference_t<T>::FromFFI(val);
+        } else if constexpr (is_unique_ptr_v<T>) {
+          return T(is_unique_ptr<T>::type::FromFFI(val));
         }
         else {
           return T::FromFFI(val);
@@ -446,6 +503,23 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
         return (*reinterpret_cast<const function_t *>(cb))(replace<Args>(args)...);
     }
 
+    template<typename TOut, typename T>
+    static TOut replace_optional_ret(std::optional<T> optional) {
+      constexpr bool has_ok = !std::is_same_v<T, std::monostate>;
+
+      bool is_ok = optional.has_value();
+
+      TOut out;
+      out.is_ok = is_ok;
+
+      if constexpr(has_ok) {
+        if (is_ok) {
+          out.ok = replace_ret<T>(optional.value());
+        }
+      }
+      return out;
+    }
+
     template<typename T, typename E, typename TOut>
     static TOut c_run_callback_result(const void *cb, replace_fn_t<Args>... args) {
       result<T, E> res = c_run_callback(cb, args...);
@@ -460,13 +534,21 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
 
       if constexpr (has_ok) {
         if (is_ok) {
-          out.ok = replace_ret<T>(std::get<Ok<T>>(res.val).inner);
+          if constexpr (is_optional_v<T>) {
+            out.ok = replace_optional_ret<decltype(out.ok)>(std::get<Ok<T>>(res.val).inner);
+          } else {
+            out.ok = replace_ret<T>(std::get<Ok<T>>(res.val).inner);
+          }
         }
       }
 
       if constexpr(has_err) {
         if (!is_ok) {
-          out.err = replace_ret<E>(std::get<Err<E>>(res.val).inner);
+          if constexpr(is_optional_v<T>) {
+            out.err = replace_optional_ret<decltype(out.err)>(std::get<Err<E>>(res.val).inner);
+          } else {
+            out.err = replace_ret<E>(std::get<Err<E>>(res.val).inner);
+          }
         }
       }
 
@@ -476,21 +558,9 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
     // For DiplomatOption<>
     template<typename T, typename TOut>
     static TOut c_run_callback_diplomat_option(const void *cb, replace_fn_t<Args>... args) {
-      constexpr bool has_ok = !std::is_same_v<T, std::monostate>;
-
       std::optional<T> ret = c_run_callback(cb, args...);
 
-      bool is_ok = ret.has_value();
-
-      TOut out;
-      out.is_ok = is_ok;
-
-      if constexpr(has_ok) {
-        if (is_ok) {
-          out.ok = replace_ret<T>(ret.value());
-        }
-      }
-      return out;
+      return replace_optional_ret<TOut>(ret);
     }
 
     // All we need to do is just convert one pointer to another, while keeping the arguments the same:
@@ -498,7 +568,11 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
     static T c_run_callback_diplomat_opaque(const void* cb, replace_fn_t<Args>... args) {
       Ret out = c_run_callback(cb, args...);
 
-      return out->AsFFI();
+      if constexpr(std::is_pointer_v<Ret>) {
+        return out->AsFFI();
+      } else {
+        return out.AsFFI();
+      }
     }
 
     static void c_delete(const void *cb) {


### PR DESCRIPTION
Main thing this adds is clang lifetime annotations.

We should do a release when ICU4X does one.