### PR TITLE
Allow more flexible diplomat-runtime versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "diplomat-runtime"
-version = "0.16.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae517853d9f82b2d144393b1c32c34c46c2e361de2b6c44a8fdfce23beb211cd"
+checksum = "25b2f28ba90d2ffa95a531ea479769d4a6b2f5f187cd76ab5fd3bdcd64b3603e"
 
 [[package]]
 name = "diplomat-tool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ ixdtf = "0.6.4"
 
 # Diplomat
 diplomat-tool = { version = "0.16.0", default-features = false }
-diplomat-runtime = { version = "0.16.0", default-features = false }
+diplomat-runtime = { version = ">= 0.15.2, < 0.17.0", default-features = false }
 diplomat = { version = "0.16.0", default-features = false }
 
 


### PR DESCRIPTION
We're hoping to not have diplomat-runtime update every release (
https://github.com/rust-diplomat/diplomat/issues/958). 

To prepare for that, i'm adding a range dep here


It would be nice to get a patch release of temporal_capi. Otherwise I can just make a new release.