### PR TITLE
Release 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## What's Changed in v0.2.6
+* Allow more flexible diplomat-runtime versions by @Manishearth in [#740](https://github.com/boa-dev/temporal/pull/740)
+
+**Full Changelog**: https://github.com/boa-dev/temporal/compare/v0.2.5...v0.2.6
+
 ## What's Changed in v0.2.5
 * Update to Diplomat 0.16 by @Manishearth in [#738](https://github.com/boa-dev/temporal/pull/738)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bakeddata"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "databake",
  "prettyplease",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "depcheck"
-version = "0.2.5"
+version = "0.2.6"
 
 [[package]]
 name = "diplomat"
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-gen"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "diplomat-tool",
 ]
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "temporal_capi"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "temporal_rs"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "calendrical_calculations",
  "core_maths",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "timezone_provider"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "combine",
  "databake",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "tzif-inspect"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "jiff-tzdb",
  "temporal_rs",
@@ -1324,7 +1324,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zoneinfo-test-gen"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.2.5"
+version = "0.2.6"
 rust-version = "1.86.0"
 authors = ["boa-dev"]
 license = "MIT OR Apache-2.0"
@@ -29,8 +29,8 @@ exclude = [
 
 [workspace.dependencies]
 # Self
-temporal_rs = { version = "0.2.5", path = ".", default-features = false }
-timezone_provider = { version = "0.2.5", path = "./provider", default-features = false }
+temporal_rs = { version = "0.2.6", path = ".", default-features = false }
+timezone_provider = { version = "0.2.6", path = "./provider", default-features = false }
 zoneinfo_rs = { version = "0.1.0", path = "./zoneinfo", default-features = false }
 
 # Dependencies


### PR DESCRIPTION
Pulls in one important dep change.

Doing a full release since the 0.2.6 number will be "used up" anyway if we do a patch release to just temporal_capi. Won't be a problem post-1.0.